### PR TITLE
Add color palette picker with 12 themes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { PalettePicker } from "@/components/palette-picker";
 import { CartSheet } from "@/components/cart-sheet";
 import Home from "@/pages/home";
 import Gallery from "@/pages/gallery";
@@ -50,6 +51,7 @@ function App() {
                   <SidebarTrigger data-testid="button-sidebar-toggle" />
                   <div className="flex items-center gap-2">
                     <CartSheet />
+                    <PalettePicker />
                     <ThemeToggle />
                   </div>
                 </header>

--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -292,7 +292,7 @@ function Minimap({ artistRooms, placements, hallLeft, hallRight, hallwayLen, pla
         })}
         <g transform={`translate(${ox + playerPosition.x * mapScale}, ${oz + playerPosition.z * mapScale})`}>
           <g transform={`rotate(${-playerPosition.rotation * 180 / Math.PI})`}>
-            <polygon points="0,-4 3,3 0,1.5 -3,3" fill="#F97316" stroke="#fff" strokeWidth={0.8} />
+            <polygon points="0,-4 3,3 0,1.5 -3,3" fill="hsl(var(--primary))" stroke="#fff" strokeWidth={0.8} />
           </g>
         </g>
       </svg>

--- a/client/src/components/maze-gallery-3d.tsx
+++ b/client/src/components/maze-gallery-3d.tsx
@@ -1100,7 +1100,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
               <g transform={`rotate(${(-playerPosition.rotation * 180 / Math.PI)})`}>
                 <polygon 
                   points={`0,${-5*scale} ${3*scale},${3*scale} 0,${1.5*scale} ${-3*scale},${3*scale}`}
-                  fill="#F97316" 
+                  fill="hsl(var(--primary))"
                   stroke="#fff"
                   strokeWidth={1}
                 />

--- a/client/src/components/palette-picker.tsx
+++ b/client/src/components/palette-picker.tsx
@@ -1,0 +1,53 @@
+import { Palette as PaletteIcon, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useTheme, palettes } from "@/components/theme-provider";
+import { cn } from "@/lib/utils";
+
+export function PalettePicker() {
+  const { palette, setPalette } = useTheme();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          data-testid="button-palette-picker"
+        >
+          <PaletteIcon className="h-5 w-5" />
+          <span className="sr-only">Choose color palette</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-2" align="end">
+        <p className="text-sm font-medium px-2 py-1.5 text-muted-foreground">Color Palette</p>
+        <div className="max-h-72 overflow-y-auto">
+          {palettes.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => setPalette(p.id)}
+              className={cn(
+                "flex items-center gap-3 w-full px-2 py-1.5 rounded-md text-sm transition-colors",
+                "hover:bg-accent hover:text-accent-foreground",
+                palette === p.id && "bg-accent text-accent-foreground"
+              )}
+            >
+              <span
+                className="w-5 h-5 rounded-full shrink-0 border border-border"
+                style={{ backgroundColor: p.color }}
+              />
+              <span className="flex-1 text-left">{p.label}</span>
+              {palette === p.id && (
+                <Check className="h-4 w-4 shrink-0" />
+              )}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/client/src/components/theme-provider.tsx
+++ b/client/src/components/theme-provider.tsx
@@ -2,32 +2,71 @@ import { createContext, useContext, useEffect, useState } from "react";
 
 type Theme = "dark" | "light" | "system";
 
+export type Palette =
+  | "sunset" | "ocean" | "forest" | "royal" | "rose" | "crimson"
+  | "amber" | "teal" | "indigo" | "slate" | "coral" | "lavender";
+
+export const palettes: { id: Palette; label: string; color: string }[] = [
+  { id: "sunset", label: "Sunset Orange", color: "hsl(25, 95%, 53%)" },
+  { id: "ocean", label: "Ocean Blue", color: "hsl(210, 90%, 50%)" },
+  { id: "forest", label: "Forest Green", color: "hsl(150, 70%, 40%)" },
+  { id: "royal", label: "Royal Purple", color: "hsl(270, 70%, 55%)" },
+  { id: "rose", label: "Rose Pink", color: "hsl(345, 80%, 55%)" },
+  { id: "crimson", label: "Crimson Red", color: "hsl(0, 85%, 50%)" },
+  { id: "amber", label: "Amber Gold", color: "hsl(45, 95%, 50%)" },
+  { id: "teal", label: "Teal", color: "hsl(175, 75%, 40%)" },
+  { id: "indigo", label: "Indigo", color: "hsl(240, 65%, 55%)" },
+  { id: "slate", label: "Slate", color: "hsl(215, 20%, 50%)" },
+  { id: "coral", label: "Coral", color: "hsl(16, 90%, 60%)" },
+  { id: "lavender", label: "Lavender", color: "hsl(280, 55%, 65%)" },
+];
+
 type ThemeProviderProps = {
   children: React.ReactNode;
   defaultTheme?: Theme;
+  defaultPalette?: Palette;
   storageKey?: string;
 };
 
 type ThemeProviderState = {
   theme: Theme;
   setTheme: (theme: Theme) => void;
+  palette: Palette;
+  setPalette: (palette: Palette) => void;
 };
 
 const initialState: ThemeProviderState = {
   theme: "system",
   setTheme: () => null,
+  palette: "sunset",
+  setPalette: () => null,
 };
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
+  return match ? decodeURIComponent(match[2]) : null;
+}
+
+function setCookie(name: string, value: string, days: number = 365) {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax`;
+}
+
 export function ThemeProvider({
   children,
   defaultTheme = "light",
+  defaultPalette = "sunset",
   storageKey = "artverse-theme",
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
     () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  );
+
+  const [palette, setPalette] = useState<Palette>(
+    () => (getCookie("artverse-palette") as Palette) || defaultPalette
   );
 
   useEffect(() => {
@@ -48,11 +87,25 @@ export function ThemeProvider({
     root.classList.add(theme);
   }, [theme]);
 
+  useEffect(() => {
+    const root = window.document.documentElement;
+    const paletteClasses = palettes.map((p) => `palette-${p.id}`);
+    root.classList.remove(...paletteClasses);
+    if (palette !== "sunset") {
+      root.classList.add(`palette-${palette}`);
+    }
+  }, [palette]);
+
   const value = {
     theme,
     setTheme: (theme: Theme) => {
       localStorage.setItem(storageKey, theme);
       setTheme(theme);
+    },
+    palette,
+    setPalette: (palette: Palette) => {
+      setCookie("artverse-palette", palette);
+      setPalette(palette);
     },
   };
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -165,6 +165,451 @@
   --destructive-border: hsl(from hsl(var(--destructive)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
 }
 
+/* COLOR PALETTES — override primary + accent colors */
+/* Default palette is "sunset" (orange) — defined in :root and .dark above */
+
+/* Ocean Blue */
+.palette-ocean {
+  --primary: 210 90% 50%;
+  --ring: 210 90% 50%;
+  --secondary: 210 30% 92%;
+  --secondary-foreground: 210 20% 15%;
+  --muted: 210 15% 90%;
+  --muted-foreground: 210 10% 40%;
+  --accent: 210 40% 94%;
+  --accent-foreground: 210 20% 15%;
+  --input: 210 20% 82%;
+  --chart-1: 210 80% 50%;
+  --chart-2: 220 75% 55%;
+  --chart-3: 200 70% 48%;
+  --chart-4: 230 65% 52%;
+  --chart-5: 205 72% 45%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-ocean {
+  --secondary: 210 15% 18%;
+  --secondary-foreground: 210 10% 90%;
+  --muted: 210 10% 20%;
+  --muted-foreground: 210 10% 65%;
+  --accent: 210 20% 18%;
+  --accent-foreground: 210 10% 95%;
+  --input: 210 15% 24%;
+  --chart-1: 210 80% 60%;
+  --chart-2: 220 75% 65%;
+  --chart-3: 200 70% 58%;
+  --chart-4: 230 65% 62%;
+  --chart-5: 205 72% 55%;
+}
+
+/* Forest Green */
+.palette-forest {
+  --primary: 150 70% 40%;
+  --ring: 150 70% 40%;
+  --secondary: 150 30% 92%;
+  --secondary-foreground: 150 20% 15%;
+  --muted: 150 15% 90%;
+  --muted-foreground: 150 10% 40%;
+  --accent: 150 40% 94%;
+  --accent-foreground: 150 20% 15%;
+  --input: 150 20% 82%;
+  --chart-1: 150 70% 40%;
+  --chart-2: 160 65% 45%;
+  --chart-3: 140 60% 38%;
+  --chart-4: 170 55% 42%;
+  --chart-5: 145 62% 35%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-forest {
+  --secondary: 150 15% 18%;
+  --secondary-foreground: 150 10% 90%;
+  --muted: 150 10% 20%;
+  --muted-foreground: 150 10% 65%;
+  --accent: 150 20% 18%;
+  --accent-foreground: 150 10% 95%;
+  --input: 150 15% 24%;
+  --chart-1: 150 70% 50%;
+  --chart-2: 160 65% 55%;
+  --chart-3: 140 60% 48%;
+  --chart-4: 170 55% 52%;
+  --chart-5: 145 62% 45%;
+}
+
+/* Royal Purple */
+.palette-royal {
+  --primary: 270 70% 55%;
+  --ring: 270 70% 55%;
+  --secondary: 270 30% 92%;
+  --secondary-foreground: 270 20% 15%;
+  --muted: 270 15% 90%;
+  --muted-foreground: 270 10% 40%;
+  --accent: 270 40% 94%;
+  --accent-foreground: 270 20% 15%;
+  --input: 270 20% 82%;
+  --chart-1: 270 70% 55%;
+  --chart-2: 280 65% 60%;
+  --chart-3: 260 60% 50%;
+  --chart-4: 290 55% 55%;
+  --chart-5: 265 62% 48%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-royal {
+  --secondary: 270 15% 18%;
+  --secondary-foreground: 270 10% 90%;
+  --muted: 270 10% 20%;
+  --muted-foreground: 270 10% 65%;
+  --accent: 270 20% 18%;
+  --accent-foreground: 270 10% 95%;
+  --input: 270 15% 24%;
+  --chart-1: 270 70% 65%;
+  --chart-2: 280 65% 70%;
+  --chart-3: 260 60% 60%;
+  --chart-4: 290 55% 65%;
+  --chart-5: 265 62% 58%;
+}
+
+/* Rose Pink */
+.palette-rose {
+  --primary: 345 80% 55%;
+  --ring: 345 80% 55%;
+  --secondary: 345 30% 92%;
+  --secondary-foreground: 345 20% 15%;
+  --muted: 345 15% 90%;
+  --muted-foreground: 345 10% 40%;
+  --accent: 345 40% 94%;
+  --accent-foreground: 345 20% 15%;
+  --input: 345 20% 82%;
+  --chart-1: 345 80% 55%;
+  --chart-2: 355 75% 60%;
+  --chart-3: 335 70% 50%;
+  --chart-4: 5 65% 55%;
+  --chart-5: 340 72% 48%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-rose {
+  --secondary: 345 15% 18%;
+  --secondary-foreground: 345 10% 90%;
+  --muted: 345 10% 20%;
+  --muted-foreground: 345 10% 65%;
+  --accent: 345 20% 18%;
+  --accent-foreground: 345 10% 95%;
+  --input: 345 15% 24%;
+  --chart-1: 345 80% 65%;
+  --chart-2: 355 75% 70%;
+  --chart-3: 335 70% 60%;
+  --chart-4: 5 65% 65%;
+  --chart-5: 340 72% 58%;
+}
+
+/* Crimson Red */
+.palette-crimson {
+  --primary: 0 85% 50%;
+  --ring: 0 85% 50%;
+  --secondary: 0 30% 92%;
+  --secondary-foreground: 0 20% 15%;
+  --muted: 0 15% 90%;
+  --muted-foreground: 0 10% 40%;
+  --accent: 0 40% 94%;
+  --accent-foreground: 0 20% 15%;
+  --input: 0 20% 82%;
+  --chart-1: 0 85% 50%;
+  --chart-2: 10 75% 55%;
+  --chart-3: 350 70% 48%;
+  --chart-4: 20 65% 52%;
+  --chart-5: 355 72% 45%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-crimson {
+  --secondary: 0 15% 18%;
+  --secondary-foreground: 0 10% 90%;
+  --muted: 0 10% 20%;
+  --muted-foreground: 0 10% 65%;
+  --accent: 0 20% 18%;
+  --accent-foreground: 0 10% 95%;
+  --input: 0 15% 24%;
+  --chart-1: 0 85% 60%;
+  --chart-2: 10 75% 65%;
+  --chart-3: 350 70% 58%;
+  --chart-4: 20 65% 62%;
+  --chart-5: 355 72% 55%;
+}
+
+/* Amber Gold */
+.palette-amber {
+  --primary: 45 95% 50%;
+  --primary-foreground: 0 0% 10%;
+  --ring: 45 95% 50%;
+  --secondary: 45 30% 92%;
+  --secondary-foreground: 45 20% 15%;
+  --muted: 45 15% 90%;
+  --muted-foreground: 45 10% 40%;
+  --accent: 45 40% 94%;
+  --accent-foreground: 45 20% 15%;
+  --input: 45 20% 82%;
+  --chart-1: 45 95% 50%;
+  --chart-2: 55 85% 55%;
+  --chart-3: 35 80% 48%;
+  --chart-4: 65 75% 52%;
+  --chart-5: 40 82% 45%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-amber {
+  --primary-foreground: 0 0% 10%;
+  --secondary: 45 15% 18%;
+  --secondary-foreground: 45 10% 90%;
+  --muted: 45 10% 20%;
+  --muted-foreground: 45 10% 65%;
+  --accent: 45 20% 18%;
+  --accent-foreground: 45 10% 95%;
+  --input: 45 15% 24%;
+  --chart-1: 45 95% 60%;
+  --chart-2: 55 85% 65%;
+  --chart-3: 35 80% 58%;
+  --chart-4: 65 75% 62%;
+  --chart-5: 40 82% 55%;
+}
+
+/* Teal */
+.palette-teal {
+  --primary: 175 75% 40%;
+  --ring: 175 75% 40%;
+  --secondary: 175 30% 92%;
+  --secondary-foreground: 175 20% 15%;
+  --muted: 175 15% 90%;
+  --muted-foreground: 175 10% 40%;
+  --accent: 175 40% 94%;
+  --accent-foreground: 175 20% 15%;
+  --input: 175 20% 82%;
+  --chart-1: 175 75% 40%;
+  --chart-2: 185 70% 45%;
+  --chart-3: 165 65% 38%;
+  --chart-4: 195 60% 42%;
+  --chart-5: 170 68% 35%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-teal {
+  --secondary: 175 15% 18%;
+  --secondary-foreground: 175 10% 90%;
+  --muted: 175 10% 20%;
+  --muted-foreground: 175 10% 65%;
+  --accent: 175 20% 18%;
+  --accent-foreground: 175 10% 95%;
+  --input: 175 15% 24%;
+  --chart-1: 175 75% 50%;
+  --chart-2: 185 70% 55%;
+  --chart-3: 165 65% 48%;
+  --chart-4: 195 60% 52%;
+  --chart-5: 170 68% 45%;
+}
+
+/* Indigo */
+.palette-indigo {
+  --primary: 240 65% 55%;
+  --ring: 240 65% 55%;
+  --secondary: 240 30% 92%;
+  --secondary-foreground: 240 20% 15%;
+  --muted: 240 15% 90%;
+  --muted-foreground: 240 10% 40%;
+  --accent: 240 40% 94%;
+  --accent-foreground: 240 20% 15%;
+  --input: 240 20% 82%;
+  --chart-1: 240 65% 55%;
+  --chart-2: 250 60% 60%;
+  --chart-3: 230 55% 50%;
+  --chart-4: 260 50% 55%;
+  --chart-5: 235 58% 48%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-indigo {
+  --secondary: 240 15% 18%;
+  --secondary-foreground: 240 10% 90%;
+  --muted: 240 10% 20%;
+  --muted-foreground: 240 10% 65%;
+  --accent: 240 20% 18%;
+  --accent-foreground: 240 10% 95%;
+  --input: 240 15% 24%;
+  --chart-1: 240 65% 65%;
+  --chart-2: 250 60% 70%;
+  --chart-3: 230 55% 60%;
+  --chart-4: 260 50% 65%;
+  --chart-5: 235 58% 58%;
+}
+
+/* Slate */
+.palette-slate {
+  --primary: 215 20% 50%;
+  --ring: 215 20% 50%;
+  --secondary: 215 15% 92%;
+  --secondary-foreground: 215 10% 15%;
+  --muted: 215 10% 90%;
+  --muted-foreground: 215 8% 40%;
+  --accent: 215 15% 94%;
+  --accent-foreground: 215 10% 15%;
+  --input: 215 12% 82%;
+  --chart-1: 215 20% 50%;
+  --chart-2: 225 18% 55%;
+  --chart-3: 205 16% 48%;
+  --chart-4: 235 14% 52%;
+  --chart-5: 210 17% 45%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-slate {
+  --secondary: 215 10% 18%;
+  --secondary-foreground: 215 8% 90%;
+  --muted: 215 8% 20%;
+  --muted-foreground: 215 8% 65%;
+  --accent: 215 12% 18%;
+  --accent-foreground: 215 8% 95%;
+  --input: 215 10% 24%;
+  --chart-1: 215 20% 60%;
+  --chart-2: 225 18% 65%;
+  --chart-3: 205 16% 58%;
+  --chart-4: 235 14% 62%;
+  --chart-5: 210 17% 55%;
+}
+
+/* Coral */
+.palette-coral {
+  --primary: 16 90% 60%;
+  --ring: 16 90% 60%;
+  --secondary: 16 30% 92%;
+  --secondary-foreground: 16 20% 15%;
+  --muted: 16 15% 90%;
+  --muted-foreground: 16 10% 40%;
+  --accent: 16 40% 94%;
+  --accent-foreground: 16 20% 15%;
+  --input: 16 20% 82%;
+  --chart-1: 16 90% 60%;
+  --chart-2: 26 85% 65%;
+  --chart-3: 6 80% 55%;
+  --chart-4: 36 75% 62%;
+  --chart-5: 11 82% 52%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-coral {
+  --secondary: 16 15% 18%;
+  --secondary-foreground: 16 10% 90%;
+  --muted: 16 10% 20%;
+  --muted-foreground: 16 10% 65%;
+  --accent: 16 20% 18%;
+  --accent-foreground: 16 10% 95%;
+  --input: 16 15% 24%;
+  --chart-1: 16 90% 70%;
+  --chart-2: 26 85% 75%;
+  --chart-3: 6 80% 65%;
+  --chart-4: 36 75% 72%;
+  --chart-5: 11 82% 62%;
+}
+
+/* Lavender */
+.palette-lavender {
+  --primary: 280 55% 65%;
+  --ring: 280 55% 65%;
+  --secondary: 280 30% 92%;
+  --secondary-foreground: 280 20% 15%;
+  --muted: 280 15% 90%;
+  --muted-foreground: 280 10% 40%;
+  --accent: 280 40% 94%;
+  --accent-foreground: 280 20% 15%;
+  --input: 280 20% 82%;
+  --chart-1: 280 55% 65%;
+  --chart-2: 290 50% 70%;
+  --chart-3: 270 45% 60%;
+  --chart-4: 300 40% 65%;
+  --chart-5: 275 48% 58%;
+  --primary-border: hsl(var(--primary));
+  --primary-border: hsl(from hsl(var(--primary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --secondary-border: hsl(var(--secondary));
+  --secondary-border: hsl(from hsl(var(--secondary)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --muted-border: hsl(var(--muted));
+  --muted-border: hsl(from hsl(var(--muted)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+  --accent-border: hsl(var(--accent));
+  --accent-border: hsl(from hsl(var(--accent)) h s calc(l + var(--opaque-button-border-intensity)) / alpha);
+}
+.dark.palette-lavender {
+  --secondary: 280 15% 18%;
+  --secondary-foreground: 280 10% 90%;
+  --muted: 280 10% 20%;
+  --muted-foreground: 280 10% 65%;
+  --accent: 280 20% 18%;
+  --accent-foreground: 280 10% 95%;
+  --input: 280 15% 24%;
+  --chart-1: 280 55% 75%;
+  --chart-2: 290 50% 80%;
+  --chart-3: 270 45% 70%;
+  --chart-4: 300 40% 75%;
+  --chart-5: 275 48% 68%;
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/client/src/pages/artists.tsx
+++ b/client/src/pages/artists.tsx
@@ -129,7 +129,7 @@ export default function Artists() {
                 </p>
 
                 <Link href={`/artists/${artist.id}`}>
-                  <Button variant="ghost" className="w-full bg-[#ff9a26]" data-testid={`button-view-artist-${artist.id}`}>
+                  <Button variant="ghost" className="w-full bg-primary text-primary-foreground hover:bg-primary/90" data-testid={`button-view-artist-${artist.id}`}>
                     View Profile
                     <ExternalLink className="h-4 w-4 ml-2" />
                   </Button>


### PR DESCRIPTION
## Summary

Closes #1

- Added 12 color palettes: Sunset Orange, Ocean Blue, Forest Green, Royal Purple, Rose Pink, Crimson Red, Amber Gold, Teal, Indigo, Slate, Coral, Lavender
- Palette picker popover in header (between cart and theme toggle) with color dots, labels, and checkmark on active palette
- Palette choice persisted via cookie (`artverse-palette`) as requested in the issue
- Each palette works with both light and dark modes
- Replaced hardcoded `#F97316` in 3D gallery SVGs with CSS variable `hsl(var(--primary))`
- Fixed hardcoded `bg-[#ff9a26]` on View Profile button to use `bg-primary`

## Test plan

- [ ] Open the app and verify the palette icon appears in the header
- [ ] Click the palette icon and verify 12 palettes are listed
- [ ] Switch between palettes and verify the UI updates (buttons, accents, charts)
- [ ] Toggle dark/light mode and verify palettes work in both
- [ ] Refresh the page and verify the palette choice persists (cookie)
- [ ] Check the Artists page — View Profile button should follow the palette
- [ ] Check the 3D gallery — player marker should follow the palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)