### PR TITLE
Fix Google OAuth login across all environments (closes #11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ server/public
 vite.config.ts.*
 *.tar.gz
 uploads/
+*.secret

--- a/deploy/staging/docker-compose.yml
+++ b/deploy/staging/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       DATABASE_URL: postgresql://artverse:${POSTGRES_PASSWORD}@db:5432/artverse_staging
       SESSION_SECRET: ${SESSION_SECRET}
       SEED_DB: ${SEED_DB:-false}
+      OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
     ports:
       - 127.0.0.1:5003:5000
     volumes:

--- a/server/replit_integrations/auth/replitAuth.ts
+++ b/server/replit_integrations/auth/replitAuth.ts
@@ -75,7 +75,7 @@ export function getSession() {
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
       maxAge: sessionTtl,
     },
@@ -116,22 +116,6 @@ export async function setupAuth(app: Express) {
     console.warn(
       "[auth] OIDC_CLIENT_ID / OIDC_CLIENT_SECRET not set; auth routes will be disabled"
     );
-
-    // Dev-only: fake login so the dashboard is testable without OIDC
-    if (process.env.NODE_ENV === "development") {
-      console.warn("[auth] DEV MODE: auto-login enabled for testing");
-      const devUser = {
-        claims: { sub: "dev-user-1", email: "dev@localhost", given_name: "Dev", family_name: "User" },
-        expires_at: Math.floor(Date.now() / 1000) + 86400,
-      };
-      await upsertUser(devUser.claims);
-      app.use((req, _res, next) => {
-        (req as any).user = devUser;
-        (req as any).isAuthenticated = () => true;
-        next();
-      });
-    }
-
     return;
   }
 
@@ -149,15 +133,22 @@ export async function setupAuth(app: Express) {
 
   const registeredStrategies = new Set<string>();
 
-  const ensureStrategy = (domain: string) => {
-    const strategyName = `oidc:${domain}`;
+  // Build the origin (protocol + host + port) for callback URLs
+  function getOrigin(req: any): string {
+    const proto = process.env.NODE_ENV === "production" ? "https" : req.protocol;
+    const host = req.get("host"); // includes port if non-standard
+    return `${proto}://${host}`;
+  }
+
+  const ensureStrategy = (host: string, origin: string) => {
+    const strategyName = `oidc:${host}`;
     if (!registeredStrategies.has(strategyName)) {
       const strategy = new Strategy(
         {
           name: strategyName,
           config,
           scope: "openid email profile",
-          callbackURL: `https://${domain}/api/callback`,
+          callbackURL: `${origin}/api/callback`,
         },
         verify
       );
@@ -170,13 +161,14 @@ export async function setupAuth(app: Express) {
   passport.deserializeUser((user: Express.User, cb) => cb(null, user));
 
   app.get("/api/login", (req, res, next) => {
+    const host = req.get("host")!;
     try {
       assertHostAllowed(req.hostname);
     } catch (e) {
       return res.status(400).json({ message: "Invalid host" });
     }
-    ensureStrategy(req.hostname);
-    passport.authenticate(`oidc:${req.hostname}`, {
+    ensureStrategy(host, getOrigin(req));
+    passport.authenticate(`oidc:${host}`, {
       prompt: "consent",
       access_type: "offline",
       scope: ["openid", "email", "profile"],
@@ -184,13 +176,14 @@ export async function setupAuth(app: Express) {
   });
 
   app.get("/api/callback", (req, res, next) => {
+    const host = req.get("host")!;
     try {
       assertHostAllowed(req.hostname);
     } catch (e) {
       return res.status(400).json({ message: "Invalid host" });
     }
-    ensureStrategy(req.hostname);
-    passport.authenticate(`oidc:${req.hostname}`, {
+    ensureStrategy(host, getOrigin(req));
+    passport.authenticate(`oidc:${host}`, {
       successReturnToOrRedirect: "/",
       failureRedirect: "/api/login",
     })(req, res, next);

--- a/specs/issue-tracker.md
+++ b/specs/issue-tracker.md
@@ -24,11 +24,12 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 
 | # | Title | Priority | Category | Status | Branch | Notes |
 |---|-------|----------|----------|--------|--------|-------|
-| 3 | Store images | high | feature | In Progress | `feature/issue-3-store-images` | Filesystem uploads, local paths in DB |
+| 3 | Store images | high | feature | Done (staging) | `feature/issue-3-store-images` | PR #10, merged, on staging |
 | 4 | Bug hunter | medium | devops | Open | — | Automated bug detection/testing |
 | 5 | Documentor | medium | documentation, devops | Open | — | Documentation tooling |
 | 6 | Email login | medium | enhancement | Open | — | Add email/password auth flow |
 | 7 | Role gallery curator | medium | feature | Open | — | Curator role for gallery management |
+| 11 | Fix Google OAuth login | high | bug | In Progress | `fix/issue-11-google-oauth` | Cookie fix + callback URL + OIDC config |
 
 ## Completed Issues
 


### PR DESCRIPTION
## Summary
- Fix session cookie `secure` flag — was hardcoded `true`, blocking cookies on `http://localhost`
- Fix callback URL to include port — `req.hostname` returns `localhost` without port, now uses `req.get("host")` which returns `localhost:5000`
- Add OIDC env vars to staging docker-compose (were missing, so credentials from `.env` were never passed to the container)
- Remove dev-only auto-login hack (no longer needed with real OAuth working)
- Add `*.secret` to `.gitignore`

OIDC credentials have been configured on staging and production VPS `.env` files.

Closes #11

## Test plan
- [x] Local dev: `/api/login` redirects to Google with correct `redirect_uri=http://localhost:5000/api/callback`
- [x] Local dev: Google login completes successfully, session cookie set
- [ ] Staging: login works at `https://staging.artverse.idata.ro`
- [ ] Production: login works at `https://artverse.idata.ro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)