### PR TITLE
Sync docker-compose to VPS on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync docker-compose to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: staging
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: deploy/staging/docker-compose.yml
+          target: ~/app/
+          strip_components: 2
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,6 +14,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync docker-compose to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: production
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: deploy/production/docker-compose.yml
+          target: ~/app/
+          strip_components: 2
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
         with:


### PR DESCRIPTION
## Summary
- Deploy workflows were only updating the image tag but never syncing the `docker-compose.yml` to the VPS
- This caused new env vars (OIDC) and volume mounts (uploads) to never reach staging or production
- Both CI staging deploy and manual production deploy now copy the compose file via SCP before deploying

Follow-up to #11 / PR #13.

## Test plan
- [ ] Next push to main syncs `deploy/staging/docker-compose.yml` to VPS before deploying
- [ ] Manual production deploy syncs `deploy/production/docker-compose.yml` to VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)