### PR TITLE
Switch production to push mode for DB schema

### DIFF
--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       DATABASE_URL: postgresql://artverse:${POSTGRES_PASSWORD}@db:5432/artverse_production
       SESSION_SECRET: ${SESSION_SECRET}
       SEED_DB: ${SEED_DB:-false}
-      DB_MIGRATION_MODE: migrate
+      DB_MIGRATION_MODE: push
       OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}

--- a/specs/issue-tracker.md
+++ b/specs/issue-tracker.md
@@ -29,7 +29,7 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 | 5 | Documentor | medium | documentation, devops | Open | — | Documentation tooling |
 | 6 | Email login | medium | enhancement | Open | — | Add email/password auth flow |
 | 7 | Role gallery curator | medium | feature | Open | — | Curator role for gallery management |
-| 11 | Fix Google OAuth login | high | bug | In Progress | `fix/issue-11-google-oauth` | Cookie fix + callback URL + OIDC config |
+| 11 | Fix Google OAuth login | high | bug | Done | `fix/issue-11-google-oauth` | Cookie fix + callback URL + OIDC config, PRs #13 #15 |
 
 ## Completed Issues
 


### PR DESCRIPTION
## Summary
- Production was using `DB_MIGRATION_MODE: migrate` but the Drizzle migrations tracking table was never properly initialized (DB was created via push mode originally)
- This caused deploy failures: `relation "artists" already exists`
- Switch to push mode (same as staging) — `drizzle-kit push --force` is idempotent and safe

Already applied on VPS manually to unblock production. This PR syncs the repo.

## Test plan
- [x] Production is running with push mode and healthy
- [ ] Next production deploy succeeds via workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)