### PR TITLE
Add blog page and fix .env loading for local dev

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,8 @@ import Auctions from "@/pages/auctions";
 import Artists from "@/pages/artists";
 import ArtistDashboard from "@/pages/artist-dashboard";
 import ArtistProfile from "@/pages/artist-profile";
+import Blog from "@/pages/blog";
+import BlogPost from "@/pages/blog-post";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -28,6 +30,8 @@ function Router() {
       <Route path="/artists" component={Artists} />
       <Route path="/artists/:id" component={ArtistProfile} />
       <Route path="/dashboard" component={ArtistDashboard} />
+      <Route path="/blog" component={Blog} />
+      <Route path="/blog/:id" component={BlogPost} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, Image, ShoppingBag, Users, LayoutDashboard } from "lucide-react";
+import { Home, Image, ShoppingBag, Users, LayoutDashboard, BookOpen } from "lucide-react";
 import { useLocation, Link } from "wouter";
 import {
   Sidebar,
@@ -33,6 +33,11 @@ const menuItems = [
     title: "Artists",
     url: "/artists",
     icon: Users,
+  },
+  {
+    title: "Blog",
+    url: "/blog",
+    icon: BookOpen,
   },
   {
     title: "Artist Dashboard",

--- a/client/src/pages/blog-post.tsx
+++ b/client/src/pages/blog-post.tsx
@@ -1,0 +1,87 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import type { BlogPostWithArtist } from "@shared/schema";
+
+export default function BlogPost({ params }: { params: { id: string } }) {
+  const { data: post, isLoading } = useQuery<BlogPostWithArtist>({
+    queryKey: [`/api/blog/${params.id}`],
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen p-6 max-w-3xl mx-auto space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="aspect-[16/9] rounded-md" />
+        <Skeleton className="h-10 w-3/4" />
+        <Skeleton className="h-4 w-1/3" />
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!post) {
+    return (
+      <div className="min-h-screen p-6 flex flex-col items-center justify-center">
+        <h2 className="font-serif text-2xl font-semibold mb-2">Post not found</h2>
+        <p className="text-muted-foreground mb-4">This blog post doesn't exist or has been removed.</p>
+        <Button asChild variant="outline">
+          <Link href="/blog">Back to Blog</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen p-6 max-w-3xl mx-auto space-y-6">
+      <Button asChild variant="ghost" size="sm">
+        <Link href="/blog">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Blog
+        </Link>
+      </Button>
+
+      {post.coverImageUrl && (
+        <div className="aspect-[16/9] rounded-lg overflow-hidden">
+          <img
+            src={post.coverImageUrl}
+            alt={post.title}
+            className="w-full h-full object-cover"
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <h1 className="font-serif text-3xl font-bold">{post.title}</h1>
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <Link
+            href={`/artists/${post.artist.id}`}
+            className="hover:text-primary transition-colors"
+          >
+            {post.artist.name}
+          </Link>
+          <span>·</span>
+          <time dateTime={new Date(post.createdAt).toISOString()}>
+            {new Date(post.createdAt).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </time>
+        </div>
+      </div>
+
+      <article className="prose prose-neutral dark:prose-invert max-w-none">
+        {post.content.split("\n").map((paragraph, i) =>
+          paragraph.trim() ? <p key={i}>{paragraph}</p> : null
+        )}
+      </article>
+    </div>
+  );
+}

--- a/client/src/pages/blog.tsx
+++ b/client/src/pages/blog.tsx
@@ -1,0 +1,89 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Skeleton } from "@/components/ui/skeleton";
+import { BookOpen } from "lucide-react";
+import type { BlogPostWithArtist } from "@shared/schema";
+
+export default function Blog() {
+  const { data: posts, isLoading } = useQuery<BlogPostWithArtist[]>({
+    queryKey: ["/api/blog"],
+  });
+
+  return (
+    <div className="min-h-screen p-6 space-y-6">
+      <div className="space-y-1">
+        <h1 className="font-serif text-3xl font-bold">Blog</h1>
+        <p className="text-muted-foreground">
+          Stories, insights, and inspiration from our artists
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="space-y-3">
+              <Skeleton className="aspect-[16/9] rounded-md" />
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-1/2" />
+            </div>
+          ))}
+        </div>
+      ) : !posts || posts.length === 0 ? (
+        <div className="text-center py-16">
+          <div className="w-20 h-20 rounded-full bg-muted flex items-center justify-center mx-auto mb-4">
+            <BookOpen className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <h3 className="font-serif text-xl font-semibold mb-2">No blog posts yet</h3>
+          <p className="text-muted-foreground">
+            Check back soon for stories and insights from our artists.
+          </p>
+        </div>
+      ) : (
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {posts.map((post) => (
+            <Link
+              key={post.id}
+              href={`/blog/${post.id}`}
+              className="group bg-card rounded-lg border overflow-hidden hover-elevate transition-shadow"
+            >
+              {post.coverImageUrl ? (
+                <div className="aspect-[16/9] overflow-hidden">
+                  <img
+                    src={post.coverImageUrl}
+                    alt={post.title}
+                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                  />
+                </div>
+              ) : (
+                <div className="aspect-[16/9] bg-muted flex items-center justify-center">
+                  <BookOpen className="h-10 w-10 text-muted-foreground" />
+                </div>
+              )}
+              <div className="p-4 space-y-2">
+                <h2 className="font-serif text-lg font-semibold line-clamp-2 group-hover:text-primary transition-colors">
+                  {post.title}
+                </h2>
+                {post.excerpt && (
+                  <p className="text-sm text-muted-foreground line-clamp-3">
+                    {post.excerpt}
+                  </p>
+                )}
+                <div className="flex items-center justify-between text-xs text-muted-foreground pt-2">
+                  <span>{post.artist.name}</span>
+                  <time dateTime={new Date(post.createdAt).toISOString()}>
+                    {new Date(post.createdAt).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </time>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.3.1",
         "drizzle-orm": "^0.39.3",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -5332,6 +5333,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.3.1",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import path from "path";
 import { registerRoutes } from "./routes";


### PR DESCRIPTION
## Summary
- Add `/blog` listing page and `/blog/:id` detail page (closes #19)
- Add Blog navigation item to sidebar
- Install `dotenv` and load `.env` in `server/index.ts` so OIDC and other env vars work when running `npm run dev` outside Docker

## Test plan
- [ ] Visit http://localhost:5000/blog — blog listing renders (or empty state if no posts)
- [ ] Click a blog post card — navigates to `/blog/:id` with full post content
- [ ] Sidebar shows "Blog" link between Artists and Artist Dashboard
- [ ] `npm run dev` loads `.env` automatically — `/api/login` returns 302 (OAuth works)
- [ ] CI passes (types, tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)