### PR TITLE
Update Telegram notification format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,12 @@ jobs:
           if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
           STATUS="${{ job.status }}"
           if [ "$STATUS" = "success" ]; then EMOJI="✅"; else EMOJI="❌"; fi
+          REPO_NAME="${{ github.event.repository.name }}"
           curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_CHAT_ID}" \
             -d parse_mode="HTML" \
-            -d text="${EMOJI} <b>Staging Deploy: ${STATUS}</b>
+            -d text="@racu8_bot
+          ${EMOJI} <b>Staging deployment: ${STATUS}</b> [${REPO_NAME}]
+          Staging address: https://staging.artverse.idata.ro
           Tag: <code>${{ github.sha }}</code>
-          By: ${{ github.actor }}
-          <a href=\"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>"
+          By: ${{ github.actor }}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -65,10 +65,12 @@ jobs:
           if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
           STATUS="${{ job.status }}"
           if [ "$STATUS" = "success" ]; then EMOJI="✅"; else EMOJI="❌"; fi
+          REPO_NAME="${{ github.event.repository.name }}"
           curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_CHAT_ID}" \
             -d parse_mode="HTML" \
-            -d text="${EMOJI} <b>Production Deploy: ${STATUS}</b>
+            -d text="@racu8_bot
+          ${EMOJI} <b>Production deployment: ${STATUS}</b> [${REPO_NAME}]
+          Production address: https://artverse.idata.ro
           Tag: <code>${{ github.event.inputs.image_tag }}</code>
-          By: ${{ github.actor }}
-          <a href=\"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>"
+          By: ${{ github.actor }}"

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -68,10 +68,12 @@ jobs:
           if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
           STATUS="${{ job.status }}"
           if [ "$STATUS" = "success" ]; then EMOJI="⏪"; else EMOJI="❌"; fi
+          REPO_NAME="${{ github.event.repository.name }}"
           curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_CHAT_ID}" \
             -d parse_mode="HTML" \
-            -d text="${EMOJI} <b>Production Rollback: ${STATUS}</b>
+            -d text="@racu8_bot
+          ${EMOJI} <b>Production rollback: ${STATUS}</b> [${REPO_NAME}]
+          Production address: https://artverse.idata.ro
           Tag: <code>${{ github.event.inputs.image_tag || 'previous' }}</code>
-          By: ${{ github.actor }}
-          <a href=\"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>"
+          By: ${{ github.actor }}"


### PR DESCRIPTION
## Summary
- Add `@racu8_bot` header to all Telegram deploy notifications (closes #26)
- Add repo name and environment URL (staging/production address) to messages
- Remove "View run" link per new format
- Updated workflows: `ci.yml` (staging), `deploy-production.yml`, `rollback-production.yml`

## Test plan
- [ ] Merge to main — verify staging Telegram notification matches new format
- [ ] Trigger production deploy — verify production notification matches
- [ ] (Optional) Trigger rollback — verify rollback notification matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)