### PR TITLE
Fix museum gallery artwork rendering in right-side rooms

### DIFF
--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -610,7 +610,8 @@ export function HallwayGallery3D({ artistRooms }: HallwayGallery3DProps) {
         if (p.isLeft) {
           worldRotY = localRotY - Math.PI / 2;
         } else {
-          worldRotY = localRotY + Math.PI / 2;
+          // Right-side transform is a reflection, not a rotation — negate localRotY
+          worldRotY = -localRotY + Math.PI / 2;
         }
 
         if (si === 0 && hasPoster) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -348,8 +348,17 @@ export async function registerRoutes(
       const artistRooms = await Promise.all(
         artists.map(async (artist) => {
           const readyArtworks = await storage.getExhibitionReadyArtworks(artist.id);
+          // Regenerate layout if stale or missing
+          let layout = artist.galleryLayout;
+          if (readyArtworks.length > 0) {
+            const existingSlots = layout ? (layout as any).cells?.flatMap((c: any) => c.artworkSlots || []).length ?? 0 : 0;
+            const expectedSlots = readyArtworks.length + 1; // +1 for poster
+            if (!layout || existingSlots !== expectedSlots) {
+              layout = await storage.regenerateArtistGallery(artist.id);
+            }
+          }
           return {
-            artist: { id: artist.id, name: artist.name, avatarUrl: artist.avatarUrl, specialization: artist.specialization, bio: artist.bio, country: artist.country, galleryLayout: artist.galleryLayout },
+            artist: { id: artist.id, name: artist.name, avatarUrl: artist.avatarUrl, specialization: artist.specialization, bio: artist.bio, country: artist.country, galleryLayout: layout },
             artworks: readyArtworks,
           };
         })


### PR DESCRIPTION
## Summary
- Regenerate stale gallery layouts in hallway endpoint when slot count doesn't match artwork count (closes #28)
- Fix artwork rotation for right-side rooms — the transform is a reflection, not a rotation, so east/west wall artworks were facing into walls instead of into the room

## Root cause
Two bugs combined:
1. **Stale layouts**: `/api/gallery/hallway` returned stored `galleryLayout` without checking if it matched the current exhibition-ready artwork count
2. **Wrong rotation**: Right-side rooms used `localRotY + π/2` but the coordinate transform is a reflection (not a rotation), requiring `-localRotY + π/2` instead. North/south walls happened to produce correct results with either formula, masking the bug for those walls.

## Test plan
- [ ] Open museum gallery — verify artworks appear in all artist rooms (left and right side)
- [ ] Add/remove exhibition-ready artworks — verify hallway updates with correct slot count
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)