### PR TITLE
Fix gallery room size for artists with 3 artworks

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -388,7 +388,8 @@ export class DatabaseStorage implements IStorage {
 
 export function generateWhiteRoomLayout(artworkCount: number): MazeLayout {
   const totalSlots = artworkCount > 0 ? artworkCount + 1 : 0;
-  const wallsPerSide = Math.max(1, Math.ceil(totalSlots / 4));
+  // +1 accounts for the door consuming one south wall slot
+  const wallsPerSide = Math.max(1, Math.ceil((totalSlots + 1) / 4));
   const roomWidth = Math.max(3, wallsPerSide + 2);
   const roomHeight = Math.max(3, wallsPerSide + 2);
 


### PR DESCRIPTION
## Summary
- Fix room size calculation in `generateWhiteRoomLayout` to account for the door consuming one south wall slot (closes #25)
- A 3x3 room only had 3 usable wall slots but needed 4 for 3 artworks + poster; now correctly generates a 4x4 room

## Root cause
`wallsPerSide = ceil(totalSlots / 4)` assumed all 4 walls contribute equally, but the south wall loses one slot to the door. Fixed to `ceil((totalSlots + 1) / 4)`.

## Test plan
- [ ] Artist with 3 exhibition-ready artworks shows all 3 + poster in gallery
- [ ] Artists with 1, 2, 4+ artworks still render correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)