### PR TITLE
Fix magic link emails not sent in Docker (closes #34)

### DIFF
--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-}
     ports:
       - 127.0.0.1:5002:5000
     volumes:

--- a/deploy/staging/docker-compose.yml
+++ b/deploy/staging/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-}
     ports:
       - 127.0.0.1:5003:5000
     volumes:

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -51,7 +51,7 @@ ArtVerse is a full-stack art gallery platform that combines e-commerce with an i
 ```
 Art-World-Hub/
 ├── client/src/           React frontend
-│   ├── pages/            8 page components
+│   ├── pages/            10 page components
 │   ├── components/       3D galleries, cards, dialogs, 47 Shadcn UI components
 │   ├── hooks/            use-auth, use-toast, use-mobile
 │   └── lib/              queryClient, cart-store, utils

--- a/specs/cicd-pipeline.md
+++ b/specs/cicd-pipeline.md
@@ -335,9 +335,18 @@ Telegram notifications on every deploy, rollback, and failure.
    - `ci.yml` → `deploy-staging` job: notifies on staging deploy success/failure
    - `deploy-production.yml`: notifies on production deploy success/failure
    - `rollback-production.yml`: notifies on rollback success/failure
-2. Each notification includes: status emoji, environment, image tag, actor, and link to the GitHub Actions run
+2. Each notification includes: `@racu8_bot` header, status emoji, environment name with repo name, environment URL, image tag, and actor
 3. Notifications use `if: always()` so they fire even on failure
 4. Gracefully skip if `TELEGRAM_BOT_TOKEN` secret is not set
+
+**Notification format:**
+```
+@racu8_bot
+✅ Staging deployment: success [Art-World-Hub]
+Staging address: https://staging.artverse.idata.ro
+Tag: <commit-sha>
+By: username
+```
 
 **GitHub Secrets required:**
 - `TELEGRAM_BOT_TOKEN` — Telegram bot token from @BotFather
@@ -575,3 +584,4 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
 | 2026-03-11 | Step 10 done — rollback mechanism. `deploy-production.yml` saves current tag to `.previous_image_tag` before deploying. Created `rollback-production.yml` workflow (auto-rollback to previous or specified tag). |
 | 2026-03-11 | Step 11 done — Telegram notifications on all deploy/rollback workflows. Requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets. |
 | 2026-03-11 | Replaced old pipeline diagram with 5 comprehensive diagrams: development workflow, CI/CD pipeline, production deploy, rollback, and infrastructure overview. Updated Telegram secrets status to Set. |
+| 2026-03-11 | Updated Telegram notification format: added @racu8_bot header, repo name, environment URLs. Removed "View run" link. (Issue #26, PR #27) |

--- a/specs/development-procedures.md
+++ b/specs/development-procedures.md
@@ -23,8 +23,10 @@ git checkout -b feature/my-feature-name    # or fix/bug-description
 ### Running locally
 
 ```bash
-npm run dev          # Start dev server on port 5000
+npm run dev          # Start dev server on port 5000 (loads .env via dotenv)
 ```
+
+The server uses `dotenv` to load `.env` automatically. For local development outside Docker, ensure your `.env` has the correct `DATABASE_URL` pointing to `localhost:5433` (not the Docker-internal `db` hostname).
 
 Or with Docker (matches production environment):
 
@@ -345,7 +347,7 @@ Deploy notifications are sent to Telegram automatically. You'll receive a messag
 - **Production deploys** — after manual deploy (success or failure)
 - **Production rollbacks** — after rollback (success or failure)
 
-Each notification includes the status, image tag, who triggered it, and a link to the GitHub Actions run.
+Each notification includes the `@racu8_bot` tag, status, repo name, environment URL, image tag, and who triggered it.
 
 **Setup:** Requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` GitHub secrets. If not set, notifications are silently skipped.
 
@@ -394,3 +396,4 @@ After installing, commit both `package.json` and `package-lock.json`. The CI and
 | 2026-03-10 | Updated database section for dual-mode schema management (push for staging, migrate for production) |
 | 2026-03-11 | Added rollback procedures (one-click, specific version, emergency SSH) and commands |
 | 2026-03-11 | Added notifications section (Telegram) and updated GitHub secrets table |
+| 2026-03-11 | Updated notification format description. Added dotenv note for local dev. |

--- a/specs/issue-tracker.md
+++ b/specs/issue-tracker.md
@@ -26,9 +26,12 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 |---|-------|----------|----------|--------|--------|-------|
 | 4 | Bug hunter | medium | devops | Open | — | Automated bug detection/testing |
 | 5 | Documentor | medium | documentation, devops | Open | — | Documentation tooling |
-| 6 | Email login | medium | enhancement | Open | — | Add email/password auth flow |
 | 7 | Role gallery curator | medium | feature | Open | — | Curator role for gallery management |
-| 20 | CI/CD pipeline e2e test | high | devops | In Progress | `test/issue-20-cicd-e2e-test` | Testing full pipeline + Telegram notifications |
+| 8 | Create admin section | high | feature | Open | — | Admin panel for platform management |
+| 12 | Correct artist profile picture | low | bug | Open | — | Profile picture display issue |
+| 14 | Multiple gallery templates | low | enhancement | Open | — | Support different gallery room layouts |
+| 32 | Correct names in museum gallery | medium | bug | Open | — | Artist room names incorrect |
+| 34 | Email signup magic link not sent | high | bug | Open | — | Magic link emails not being sent on signup (staging + prod) |
 
 ## Completed Issues
 
@@ -36,8 +39,16 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 |---|-------|----------|----------|-----------|--------|----|
 | 1 | A new color palette | — | — | 2026-03-11 | `feature/issue-1-color-palettes` | #2 |
 | 3 | Store images | high | feature | 2026-03-11 | `feature/issue-3-store-images` | #10 |
+| 9 | Classic view gallery arrows | high | bug | 2026-03-11 | `fix/issue-9-classic-gallery-arrows` | #31 |
 | 11 | Fix Google OAuth login | high | bug | 2026-03-11 | `fix/issue-11-google-oauth` | #13 #15 |
 | 17 | Deduplicate upload code | low | refactor | 2026-03-11 | `refactor/issue-17-deduplicate-upload-code` | #18 |
+| 19 | /blog route SPA 404 | high | bug | 2026-03-11 | `fix/issue-19-blog-route` | #24 |
+| 20 | CI/CD pipeline e2e test | high | devops | 2026-03-11 | `test/issue-20-cicd-e2e-test` | #21 |
+| 22 | Add README.md | — | documentation | 2026-03-11 | `feature/issue-22-readme` | #23 |
+| 25 | Missing artwork in gallery | high | bug | 2026-03-11 | `fix/issue-25-gallery-slot-count` | #30 |
+| 26 | Telegram announcing format | low | enhancement | 2026-03-11 | `enhancement/issue-26-telegram-format` | #27 |
+| 28 | Galleries not ok in museum | high | bug | 2026-03-11 | `fix/issue-28-museum-gallery-stale-layout` | #29 |
+| 6 | Email login | medium | enhancement | 2026-03-12 | `feature/issue-6-email-login` | #33 |
 
 ---
 
@@ -47,3 +58,6 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 |------|--------|
 | 2026-03-11 | Initial version — catalogued all existing GitHub issues |
 | 2026-03-11 | Moved #3, #11 to Completed. Added #17 (upload code refactor). |
+| 2026-03-11 | Bulk update: completed #9, #19, #20, #22, #25, #26, #28. Added open #8, #12, #14, #32. |
+| 2026-03-12 | Moved #6 (email login) to Completed — deployed to production. |
+| 2026-03-12 | Added #34 (email signup magic link not sent) — high priority bug. |


### PR DESCRIPTION
## Summary
- Add `RESEND_API_KEY` and `RESEND_FROM_EMAIL` to both `deploy/staging/docker-compose.yml` and `deploy/production/docker-compose.yml`
- The env vars existed in `.env` on the VPS but were never forwarded into the Docker container, causing `RESEND_API_KEY is not configured` errors on signup
- Also includes spec file updates from recent completed work

## Test plan
- [ ] Merge and let CI deploy to staging
- [ ] Test signup with email at https://staging.artverse.idata.ro/auth
- [ ] Verify magic link email is received
- [ ] Deploy to production and repeat test

🤖 Generated with [Claude Code](https://claude.com/claude-code)