### PR TITLE
Fix audit job count parsing in doc-agent workflow

### DIFF
--- a/.github/workflows/doc-agent.yml
+++ b/.github/workflows/doc-agent.yml
@@ -101,9 +101,12 @@ jobs:
           echo "AUDIT_EOF" >> "$GITHUB_OUTPUT"
 
           # Count findings
-          ERRORS=$(echo "$REPORT" | grep -c '^\- \[ \] \[S-\|^\- \[ \] \[C-' || echo "0")
-          WARNINGS=$(echo "$REPORT" | grep -c '^\- \[ \] \[ST-' || echo "0")
-          INFOS=$(echo "$REPORT" | grep -c '^\- \[Q-' || echo "0")
+          ERRORS=$(echo "$REPORT" | grep -cE '^\- \[ \] \[(S|C)-' || true)
+          WARNINGS=$(echo "$REPORT" | grep -cE '^\- \[ \] \[ST-' || true)
+          INFOS=$(echo "$REPORT" | grep -cE '^\- \[Q-' || true)
+          ERRORS=${ERRORS:-0}
+          WARNINGS=${WARNINGS:-0}
+          INFOS=${INFOS:-0}
           echo "errors=$ERRORS" >> "$GITHUB_OUTPUT"
           echo "warnings=$WARNINGS" >> "$GITHUB_OUTPUT"
           echo "infos=$INFOS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix `grep -c` count parsing that caused `syntax error in expression (error token is "0\n0")` in the audit job
- `|| echo "0"` appended an extra "0" after grep's own "0" output on no-match, creating multiline values that broke shell arithmetic
- Switch to `|| true` (grep -c already outputs "0") and use extended regex (`-cE`) for proper alternation

Fixes the audit job failure from PR #44 merge.

## Test plan
- [x] Ran `doc-audit.sh` locally and verified counts parse correctly: `ERRORS=0 WARNINGS=0 INFOS=1`
- [ ] Merge to main and verify the audit job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)