### PR TITLE
Backfill documentation: feature specs, ADRs, bug files

### DIFF
--- a/specs/architecture/ADR/ADR-0001-monolithic-architecture.md
+++ b/specs/architecture/ADR/ADR-0001-monolithic-architecture.md
@@ -1,0 +1,37 @@
+# ADR-0001: Monolithic Architecture (Express + React + PostgreSQL)
+
+**Status:** Active
+**Date:** 2026-02-01
+**Owner:** Architecture
+
+## Context
+
+ArtVerse needs a full-stack architecture for an art gallery platform with 3D rendering, marketplace, auctions, and artist dashboards. The project is developed by a solo developer. Key considerations: development speed, deployment simplicity, and the ability to share types and schemas between frontend and backend.
+
+## Options Considered
+
+1. **Monolith (Express + React + PostgreSQL)** — Single codebase, shared types, simple deployment
+   - Pros: Fast development, shared schema (Drizzle + Zod), single Docker image, easy debugging
+   - Cons: Scaling requires scaling everything, tighter coupling
+2. **Microservices** — Separate services for gallery, marketplace, auth, etc.
+   - Pros: Independent scaling, technology flexibility
+   - Cons: Massive overhead for solo dev, complex deployment, no type sharing
+3. **Serverless (Lambda/Vercel)** — Function-based backend
+   - Pros: Auto-scaling, no server management
+   - Cons: Cold starts affect 3D gallery experience, complex local dev, vendor lock-in
+
+## Decision
+
+Monolithic architecture with Express 5 backend, React 18 frontend (Vite), and PostgreSQL 16. Shared `schema.ts` serves as single source of truth for both database schema (Drizzle ORM) and API validation types (Zod). Single Docker image deployed to VPS.
+
+## Consequences
+
+- Positive: Rapid feature development with full-stack type safety; simple CI/CD pipeline; shared storage layer used by both routes and MCP server
+- Negative: Cannot independently scale frontend vs backend; large single codebase
+- Risks: May need to extract services if traffic patterns diverge significantly
+
+## References
+
+- `shared/schema.ts` — Shared types and schema
+- `server/routes.ts` — Express API handlers
+- `client/` — React frontend

--- a/specs/architecture/ADR/ADR-0002-vps-hosting-webdock.md
+++ b/specs/architecture/ADR/ADR-0002-vps-hosting-webdock.md
@@ -1,0 +1,37 @@
+# ADR-0002: VPS Hosting on Webdock
+
+**Status:** Active
+**Date:** 2026-03-10
+**Owner:** Architecture
+
+## Context
+
+ArtVerse needs a hosting solution for staging and production environments. The project serves a 3D WebGL gallery requiring consistent performance. The developer prefers infrastructure they can control and learn from.
+
+## Options Considered
+
+1. **VPS on Webdock** — Single VPS with separate Linux users for staging/production
+   - Pros: Full control, predictable costs, learning opportunity, Docker support
+   - Cons: Manual setup, responsible for security/updates
+2. **Managed platform (Railway/Render)** — Platform-as-a-service
+   - Pros: Zero ops, auto-scaling, managed databases
+   - Cons: Higher cost at scale, less control, vendor lock-in
+3. **Cloud VMs (AWS EC2/GCP)** — Large cloud provider
+   - Pros: Scalability, ecosystem integration
+   - Cons: Complex pricing, overkill for current scale
+
+## Decision
+
+Single Webdock VPS with two Linux users (`staging` on port 5003, `production` on port 5002). Docker Compose per environment. Nginx reverse proxy with Certbot SSL. SSH deploy key shared across users.
+
+## Consequences
+
+- Positive: Predictable cost, full control over deployment, good learning experience
+- Negative: Manual server management, single point of failure
+- Risks: Need to handle backups, security updates, and scaling manually
+
+## References
+
+- `deploy/staging/docker-compose.yml` — Staging Docker config
+- `deploy/production/docker-compose.yml` — Production Docker config
+- `specs/workflows/DEPLOYMENT.md` — Deployment procedures

--- a/specs/architecture/ADR/ADR-0003-drizzle-orm-dual-mode.md
+++ b/specs/architecture/ADR/ADR-0003-drizzle-orm-dual-mode.md
@@ -1,0 +1,42 @@
+# ADR-0003: Drizzle ORM with Dual-Mode Schema Management
+
+**Status:** Active
+**Date:** 2026-03-10
+**Owner:** Architecture
+
+## Context
+
+ArtVerse needs a database ORM that provides type safety and integrates with the TypeScript monolith. Schema changes need different handling in staging (fast iteration) vs production (safe, versioned).
+
+## Options Considered
+
+1. **Drizzle ORM with dual mode (push + migrate)** — Push for staging, migrations for production
+   - Pros: Type-safe queries, Zod integration, fast staging iteration, safe production deploys
+   - Cons: Two workflows to maintain
+2. **Prisma** — Popular TypeScript ORM
+   - Pros: Large ecosystem, visual schema editor
+   - Cons: Generated client adds build step, heavier runtime
+3. **Raw SQL + pg driver** — Direct PostgreSQL queries
+   - Pros: Maximum control, no ORM overhead
+   - Cons: No type safety, manual migration management
+
+## Decision
+
+Drizzle ORM with two modes controlled by `DB_MIGRATION_MODE` env var in `docker-entrypoint.sh`:
+- **Staging:** `drizzle-kit push --force` — Auto-applies schema changes on container start, staging data is disposable
+- **Production:** `drizzle-kit migrate` — Applies versioned SQL migration files from `migrations/`
+
+Schema defined in `shared/schema.ts`, shared between server and client for full type safety.
+
+## Consequences
+
+- Positive: Type-safe queries with Zod validation; fast staging iteration; safe, auditable production changes
+- Negative: Must generate and commit migration files before production deploy
+- Risks: Push mode can destructively alter staging data (acceptable since staging is disposable)
+
+## References
+
+- `shared/schema.ts` — Schema definitions
+- `migrations/` — SQL migration files
+- `docker-entrypoint.sh` — Dual-mode logic
+- `specs/architecture/DATA-MODEL.md` — Schema documentation

--- a/specs/architecture/ADR/ADR-0004-threejs-3d-gallery.md
+++ b/specs/architecture/ADR/ADR-0004-threejs-3d-gallery.md
@@ -1,0 +1,41 @@
+# ADR-0004: Three.js for 3D Gallery Rendering
+
+**Status:** Active
+**Date:** 2026-02-01
+**Owner:** Architecture
+
+## Context
+
+ArtVerse's core differentiator is a 3D virtual museum where visitors walk through gallery rooms and view artworks on walls. The rendering solution must work in browsers without plugins, support texture loading from various image sources, and integrate with React.
+
+## Options Considered
+
+1. **Three.js (raw)** — Direct WebGL rendering library
+   - Pros: Full control, lightweight, massive community, good React integration via refs
+   - Cons: More boilerplate than frameworks, manual scene management
+2. **React Three Fiber (R3F)** — React renderer for Three.js
+   - Pros: Declarative, React-native feel, ecosystem (drei helpers)
+   - Cons: Abstraction overhead, harder to debug, less control over render loop
+3. **Babylon.js** — Full 3D engine
+   - Pros: Built-in physics, GUI system, playground
+   - Cons: Heavier bundle, different paradigm, smaller React community
+4. **A-Frame** — HTML-based 3D framework
+   - Pros: Easy to learn, declarative
+   - Cons: Limited control, VR-focused, performance concerns
+
+## Decision
+
+Raw Three.js v0.182.0 integrated with React via `useRef` and `useEffect` hooks. Two main components: `HallwayGallery3D` (museum hallway) and `MazeGallery3D` (artist rooms). Server-side layout generation ensures consistent room geometry.
+
+## Consequences
+
+- Positive: Full control over rendering, lighting, and camera; efficient texture caching; custom collision detection
+- Negative: Large component files (~1,200 lines each); manual scene lifecycle management
+- Risks: WebGL performance on mobile devices; texture loading reliability for external images
+
+## References
+
+- `client/src/components/hallway-gallery-3d.tsx` — Museum hallway component
+- `client/src/components/maze-gallery-3d.tsx` — Artist room component
+- `server/storage.ts` — `generateWhiteRoomLayout()` algorithm
+- `specs/features/3d-gallery/SPEC.md` — Feature specification

--- a/specs/architecture/ADR/ADR-0005-passport-auth-strategy.md
+++ b/specs/architecture/ADR/ADR-0005-passport-auth-strategy.md
@@ -1,0 +1,38 @@
+# ADR-0005: Passport.js with OIDC + Local Auth Strategy
+
+**Status:** Active
+**Date:** 2026-03-12
+**Owner:** Architecture
+
+## Context
+
+ArtVerse initially supported only Google OIDC login. Users without Google accounts could not access the platform. A second authentication method was needed while keeping the existing OIDC flow intact.
+
+## Options Considered
+
+1. **Passport.js with OIDC + local strategy** — Add email/password alongside existing Google login
+   - Pros: Passport already in use, local strategy is simple, magic links ensure email ownership
+   - Cons: Two auth flows to maintain, password storage responsibility
+2. **Auth0/Clerk** — Managed authentication service
+   - Pros: Handles everything, social logins built in
+   - Cons: External dependency, cost, less control
+3. **Custom JWT auth** — Roll own token-based auth
+   - Pros: Full control, stateless
+   - Cons: More complex, need to handle refresh tokens, session management
+
+## Decision
+
+Extend existing Passport.js setup with `passport-local` strategy for email/password login. Magic link signup via Resend ensures email ownership before password creation. Bcryptjs (12 salt rounds) for password hashing. Both auth methods share the same session infrastructure (PostgreSQL via connect-pg-simple).
+
+## Consequences
+
+- Positive: Users without Google accounts can now sign up; magic links verify email ownership; existing OIDC flow unchanged
+- Negative: Password storage responsibility (mitigated by bcrypt); two auth flows to test
+- Risks: Email deliverability depends on Resend service availability
+
+## References
+
+- `server/replit_integrations/auth/replitAuth.ts` — Both auth strategies
+- `server/email.ts` — Magic link email sending
+- `specs/features/email-login/SPEC.md` — Email login specification
+- `specs/features/authentication/SPEC.md` — Authentication specification

--- a/specs/architecture/ADR/ADR-0006-resend-transactional-email.md
+++ b/specs/architecture/ADR/ADR-0006-resend-transactional-email.md
@@ -1,0 +1,40 @@
+# ADR-0006: Resend for Transactional Email
+
+**Status:** Active
+**Date:** 2026-03-12
+**Owner:** Architecture
+
+## Context
+
+ArtVerse needs transactional email for magic link signup verification and order notifications (buyer confirmations, artist alerts). The previous email integration (Replit connector) was non-functional. A reliable, simple email service was needed.
+
+## Options Considered
+
+1. **Resend** — Modern email API
+   - Pros: Simple API, good free tier (100 emails/day), handles deliverability, good DX
+   - Cons: Newer service, free tier limits
+2. **SendGrid** — Established email service
+   - Pros: Battle-tested, large scale
+   - Cons: More complex setup, heavier SDK
+3. **AWS SES** — Amazon email service
+   - Pros: Very cheap at scale, AWS ecosystem
+   - Cons: Complex setup, domain verification, AWS dependency
+4. **Nodemailer + SMTP** — Direct SMTP sending
+   - Pros: No vendor dependency
+   - Cons: Deliverability issues, need SMTP server, spam filtering challenges
+
+## Decision
+
+Resend v4.8.0 with API key authentication. Used for magic link verification emails and order notification emails. Graceful fallback when API key not configured (logs warning, no crash). Sender address configurable via `RESEND_FROM_EMAIL` env var.
+
+## Consequences
+
+- Positive: Simple integration (single API call), good deliverability, free tier sufficient for current scale
+- Negative: Vendor dependency for email delivery
+- Risks: Free tier limit (100/day) may need upgrade if user signups grow
+
+## References
+
+- `server/email.ts` — Resend integration
+- `server/routes.ts` — Order notification emails
+- `specs/features/email-login/SPEC.md` — Magic link email flow

--- a/specs/architecture/ADR/ADR-0007-docker-deployment-ghcr.md
+++ b/specs/architecture/ADR/ADR-0007-docker-deployment-ghcr.md
@@ -1,0 +1,47 @@
+# ADR-0007: Docker-Based Deployment with GHCR
+
+**Status:** Active
+**Date:** 2026-03-10
+**Owner:** Architecture
+
+## Context
+
+ArtVerse needs a consistent deployment mechanism across staging and production environments on a single VPS. The build process involves Vite (client) + esbuild (server) bundling, and the runtime needs Node.js + PostgreSQL.
+
+## Options Considered
+
+1. **Docker + GHCR** — Build Docker image in CI, push to GitHub Container Registry, pull on VPS
+   - Pros: Consistent builds, version-tagged images, easy rollback, CI integration
+   - Cons: Image build time, registry storage
+2. **Direct deploy (rsync/scp)** — Copy built artifacts to VPS
+   - Pros: Simple, fast
+   - Cons: No image versioning, harder rollback, environment drift
+3. **Kubernetes** — Container orchestration
+   - Pros: Auto-scaling, self-healing
+   - Cons: Massive overkill for single VPS, complex setup
+
+## Decision
+
+Docker-based deployment with images pushed to GitHub Container Registry (GHCR). CI builds and tags images with commit SHA. VPS pulls images via SSH deploy. Docker Compose per environment with PostgreSQL sidecar. Dual-mode database migrations via `docker-entrypoint.sh`.
+
+Key deployment features:
+- Staging: auto-deploy on push to main, push mode for DB
+- Production: manual trigger via GitHub Actions, migration mode for DB
+- Rollback: `.previous_image_tag` file saves state, one-click rollback workflow
+- Telegram notifications on deploy/rollback events
+
+## Consequences
+
+- Positive: Reproducible builds, version-tagged images, instant rollback, consistent environments
+- Negative: Docker image build adds ~2 min to CI; GHCR storage usage
+- Risks: VPS disk space for Docker images (mitigated by periodic cleanup)
+
+## References
+
+- `Dockerfile` — Multi-stage build
+- `docker-entrypoint.sh` — Dual-mode DB setup
+- `.github/workflows/ci.yml` — CI/CD pipeline
+- `.github/workflows/deploy-production.yml` — Production deploy
+- `.github/workflows/rollback-production.yml` — Rollback workflow
+- `specs/workflows/CI-CD.md` — Pipeline documentation
+- `specs/workflows/DEPLOYMENT.md` — Deployment procedures

--- a/specs/bugs/BUG-0004-bug-hunter-agent.md
+++ b/specs/bugs/BUG-0004-bug-hunter-agent.md
@@ -1,0 +1,28 @@
+# BUG-0004: Bug Hunter Agent
+
+**Status:** Open
+**Severity:** Medium
+**Last Updated:** 2026-03-12
+**Reporter:** User
+
+## Description
+
+Need to implement a sub-agent that continuously checks issues and fixes them in order of priority. The agent should use the full CI/CD pipeline and push fixes while ensuring they are tested.
+
+This is a feature request tracked as a bug. It describes an automated bug detection and resolution system.
+
+## Reproduction Steps
+
+N/A — this is a feature request, not a reproducible bug.
+
+## Root Cause
+
+N/A — feature not yet implemented.
+
+## Fix
+
+Not yet resolved.
+
+## Workaround
+
+Manual bug triage and fixing via the standard development workflow described in `specs/workflows/LOCAL-DEV.md`.

--- a/specs/bugs/BUG-0007-gallery-curator-role.md
+++ b/specs/bugs/BUG-0007-gallery-curator-role.md
@@ -1,0 +1,31 @@
+# BUG-0007: Gallery Curator Role
+
+**Status:** Open
+**Severity:** Medium
+**Last Updated:** 2026-03-12
+**Reporter:** User
+
+## Description
+
+Need to implement a new "gallery curator" role. A curator should be able to choose artworks from all artists and place them in their own gallery. Curator galleries should have:
+- Single room layout
+- User-chosen gallery name
+- Selection from predefined gallery templates
+
+Currently, only artists can have galleries, and only with their own artworks.
+
+## Reproduction Steps
+
+N/A — this is a feature request, not a reproducible bug.
+
+## Root Cause
+
+N/A — feature not yet implemented.
+
+## Fix
+
+Not yet resolved. Requires new database tables for curator role, curator-artwork associations, and gallery template definitions.
+
+## Workaround
+
+No workaround. Curated collections are not currently possible. Artists can only display their own artworks in auto-generated layouts.

--- a/specs/bugs/BUG-0008-admin-section.md
+++ b/specs/bugs/BUG-0008-admin-section.md
@@ -1,0 +1,31 @@
+# BUG-0008: Admin Section
+
+**Status:** Open
+**Severity:** High
+**Last Updated:** 2026-03-12
+**Reporter:** User
+
+## Description
+
+Need to create an admin role and admin section with the ability to:
+- Delete artworks
+- Delete artists
+- Delete galleries
+
+Currently there is no admin role or administrative interface. All management is done through individual artist dashboards or direct database access.
+
+## Reproduction Steps
+
+N/A — this is a feature request, not a reproducible bug.
+
+## Root Cause
+
+N/A — feature not yet implemented.
+
+## Fix
+
+Not yet resolved. Requires admin role in user model, admin middleware, admin routes, and admin UI.
+
+## Workaround
+
+Administrative operations (deletion of artworks, artists, galleries) can be performed via direct database queries or MCP tools (`delete_artwork`). No user-facing admin interface exists.

--- a/specs/bugs/BUG-0012-artist-profile-picture.md
+++ b/specs/bugs/BUG-0012-artist-profile-picture.md
@@ -1,0 +1,31 @@
+# BUG-0012: Artist Profile Picture Upload
+
+**Status:** Open
+**Severity:** Low
+**Last Updated:** 2026-03-12
+**Reporter:** User
+
+## Description
+
+In the artist profile edit form, the profile picture field accepts a URL link instead of providing an image upload field. It should be changed to use a local image upload (like artwork images) instead of requiring a manual URL.
+
+Currently, `artists.avatarUrl` stores external URLs (typically from OAuth providers). The field should use the same upload mechanism as artwork images (`/api/upload/artwork`).
+
+## Reproduction Steps
+
+1. Log in and go to artist dashboard
+2. Open Profile tab
+3. Observe that the avatar/profile picture field is a text input for a URL
+4. Expected: An image upload field with file picker (like artwork images)
+
+## Root Cause
+
+The profile picture field was originally designed for OIDC provider avatar URLs (Google profile pictures). When local upload was added for artworks, the avatar field was not updated to use the same upload mechanism.
+
+## Fix
+
+Not yet resolved. Change the avatar field in the dashboard Profile tab from a URL text input to a `FileUploadField` component that uploads via `/api/upload/artwork` and stores the local path.
+
+## Workaround
+
+Artists can manually upload an image via the artwork upload endpoint and paste the resulting URL into the avatar field.

--- a/specs/bugs/BUG-0014-multiple-gallery-templates.md
+++ b/specs/bugs/BUG-0014-multiple-gallery-templates.md
@@ -1,0 +1,30 @@
+# BUG-0014: Multiple Gallery Templates
+
+**Status:** Open
+**Severity:** Low
+**Last Updated:** 2026-03-12
+**Reporter:** User
+
+## Description
+
+Currently all artist galleries use the same auto-generated white room layout (`generateWhiteRoomLayout`). The system should offer multiple gallery templates for artists to choose from, providing visual variety across the museum.
+
+## Reproduction Steps
+
+N/A — this is an enhancement request, not a reproducible bug.
+
+## Root Cause
+
+N/A — only one layout algorithm exists (`generateWhiteRoomLayout` in `server/storage.ts`).
+
+## Fix
+
+Not yet resolved. Requires:
+- Multiple layout generation algorithms (e.g., dark room, L-shaped, circular)
+- Template selection UI in artist dashboard
+- Template preference stored on artist record
+- Layout regeneration using selected template
+
+## Workaround
+
+No workaround. All galleries use the single white room template. The `MazeGallery3D` component supports white/dark room modes, but the server only generates white room layouts.

--- a/specs/bugs/BUG-0032-museum-gallery-names.md
+++ b/specs/bugs/BUG-0032-museum-gallery-names.md
@@ -1,0 +1,37 @@
+# BUG-0032: Museum Gallery Artist Names
+
+**Status:** Open
+**Severity:** Medium
+**Last Updated:** 2026-03-12
+**Reporter:** User
+
+## Description
+
+In the museum hallway gallery, artist names are not visible when walking through the hallway. Names only become visible when exiting a room. The hallway should have:
+- Indicators hanging from the ceiling with artist names at each room entrance
+- Directional indicators on walls pointing visitors toward artist galleries
+
+Currently, name plaques exist but are not prominent enough or positioned correctly for hallway navigation.
+
+## Reproduction Steps
+
+1. Navigate to `/gallery` and enter 3D mode
+2. Walk through the hallway
+3. Observe that artist room names are difficult to see
+4. Enter a room and then exit — names become visible on exit
+5. Expected: Clear hanging signs and wall indicators visible while walking the hallway
+
+## Root Cause
+
+Name plaques in `hallway-gallery-3d.tsx` are positioned at room entrances but may be oriented incorrectly or too small. No ceiling-hanging indicators or wall-mounted directional signs exist.
+
+## Fix
+
+Not yet resolved. Requires updates to `hallway-gallery-3d.tsx`:
+- Add ceiling-mounted hanging signs with artist names
+- Add wall-mounted directional indicators
+- Improve name plaque visibility (size, positioning, lighting)
+
+## Workaround
+
+No workaround. Visitors must explore rooms to discover which artist's gallery they are entering.

--- a/specs/features/3d-gallery/CHANGELOG.md
+++ b/specs/features/3d-gallery/CHANGELOG.md
@@ -1,0 +1,18 @@
+# 3D Gallery — Changelog
+
+## 2026-03-11
+- Fixed missing artworks in gallery due to slot count mismatch (PR #30, closes #25)
+- Fixed stale gallery layouts in museum hallway (PR #29, closes #28)
+- Added auto-regeneration on hallway load when slot count mismatches artwork count
+- Fixed classic view gallery arrow navigation (PR #31, closes #9)
+
+## 2026-02 (Initial)
+- Hallway gallery: central corridor with per-artist rooms
+- Maze gallery: individual artist exhibition rooms with white/dark modes
+- Server-side layout generation algorithm (`generateWhiteRoomLayout`)
+- First-person navigation with WASD + mouse look (pointer lock)
+- Collision detection against walls
+- Texture loading with retry logic and caching
+- Image proxy for CORS-blocked external images
+- Artist poster and name plaques
+- Classic 2D carousel fallback view

--- a/specs/features/3d-gallery/SPEC.md
+++ b/specs/features/3d-gallery/SPEC.md
@@ -1,0 +1,101 @@
+# Feature: 3D Gallery System
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+WebGL-based 3D virtual museum built with Three.js. Two distinct gallery modes: a museum hallway containing multiple artist rooms (main gallery page), and individual maze-style exhibition rooms (artist profile page). Gallery layouts are auto-generated server-side based on exhibition-ready artworks and stored as JSONB on the `artists.galleryLayout` column.
+
+## User Story
+
+As a visitor, I want to walk through a virtual 3D museum, explore artist rooms, and view artworks on gallery walls, so that I can experience art in an immersive environment.
+
+## Acceptance Criteria
+
+- [x] Hallway gallery renders a central corridor with artist rooms on left and right
+- [x] Maze gallery renders a single-room exhibition with artworks on walls
+- [x] First-person navigation with WASD/arrow keys and mouse look (pointer lock)
+- [x] Click artwork to select and view details (exits pointer lock)
+- [x] Collision detection prevents walking through walls
+- [x] Artist poster displayed at first slot with name, country, specialization, bio, avatar
+- [x] Name plaques at hallway room entrances
+- [x] Texture loading with retry logic (3 attempts), caching, and fallback
+- [x] Image proxy for CORS-blocked external images
+- [x] Gallery layout auto-regenerates when `isReadyForExhibition` or `exhibitionOrder` changes
+- [x] Classic 2D carousel fallback view available on gallery page
+
+## Technical Design
+
+### Components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `HallwayGallery3D` | `client/src/components/hallway-gallery-3d.tsx` (1,148 lines) | Museum hallway with multiple artist rooms |
+| `MazeGallery3D` | `client/src/components/maze-gallery-3d.tsx` (1,288 lines) | Individual artist exhibition room |
+| Gallery page | `client/src/pages/gallery.tsx` | Main 3D/Classic toggle view |
+| Artist profile | `client/src/pages/artist-profile.tsx` | Artist's personal maze gallery tab |
+
+### Layout Generation Algorithm
+
+Server-side function `generateWhiteRoomLayout(artworkCount)` in `server/storage.ts`:
+
+1. Calculate room dimensions: `width = max(3, wallsPerSide + 2)`, `height = max(3, wallsPerSide + 2)`
+2. `wallsPerSide = ceil((artworkCount + 1) / 4)` — +1 accounts for door on south wall
+3. Create grid of cells with boundary walls (north/south/east/west)
+4. Place artwork slots around perimeter: north (L→R), west (T→B), south (R→L, skip door), east (T→B)
+5. Spawn point at center-x, 3 units from south wall
+6. Store as JSONB in `artists.galleryLayout`
+
+### Data Structures
+
+```typescript
+interface MazeCell {
+  x: number; z: number;
+  walls: { north: boolean; south: boolean; east: boolean; west: boolean };
+  artworkSlots: { wallId: string; position: number }[];
+}
+interface MazeLayout {
+  width: number; height: number;
+  cells: MazeCell[];
+  spawnPoint: { x: number; z: number };
+}
+```
+
+### Rendering Constants
+
+| Constant | Hallway | Maze |
+|----------|---------|------|
+| Cell size | 2.5 | 2.5 |
+| Wall height | 3.0 | 3.5 |
+| Player height | 1.5 | 1.5 |
+| Move speed | 0.08 | 0.1 |
+| Look speed | 0.002 | 0.003 |
+
+### API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/api/gallery/hallway` | All artist rooms with layouts and exhibition-ready artworks |
+| GET | `/api/artists/:id/gallery` | Individual artist room layout + artworks |
+
+### Regeneration Triggers
+
+Layout regenerates when:
+- Artwork `isReadyForExhibition` flag changes
+- Artwork `exhibitionOrder` changes
+- Exhibition-ready artwork is deleted
+- Manual via MCP tool `regenerate_gallery`
+- Stale layout detected on `/api/gallery/hallway` (slot count mismatch)
+
+## Dependencies
+
+- `three` v0.182.0 — WebGL 3D rendering
+- React 18 hooks (`useEffect`, `useRef`, `useState`, `useCallback`)
+- TanStack React Query — gallery data fetching
+- Image proxy (`/api/image-proxy`) for CORS-blocked textures
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/artist-dashboards/CHANGELOG.md
+++ b/specs/features/artist-dashboards/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Artist Dashboards — Changelog
+
+## 2026-03-12
+- Added email/password auth support in dashboard login flow
+- Blog management tab added to dashboard
+
+## 2026-03-11
+- Image upload deduplication refactor (PR #18, closes #17)
+
+## 2026-02 (Initial)
+- Tabbed dashboard: Profile, Artworks, Orders
+- Artist auto-creation on first login
+- Profile editing with 11 social platform links
+- Artwork CRUD with image upload
+- Exhibition toggle and ordering controls
+- Order management with status workflow
+- Public artist profile page with gallery, artworks, blog tabs

--- a/specs/features/artist-dashboards/SPEC.md
+++ b/specs/features/artist-dashboards/SPEC.md
@@ -1,0 +1,79 @@
+# Feature: Artist Dashboards
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Authenticated artist dashboard providing tabbed management of profile, artworks, blog posts, and orders. Artist profiles are auto-created on first login. The dashboard supports avatar upload, 11 social media platform links, artwork CRUD with exhibition controls, and order status management.
+
+## User Story
+
+As an artist, I want a dashboard to manage my profile, artworks, blog posts, and orders, so that I can maintain my presence on the platform and fulfill purchases.
+
+## Acceptance Criteria
+
+- [x] Dashboard at `/artist-dashboard` (requires authentication)
+- [x] Artist auto-created on first login via `/api/artists/me`
+- [x] Profile tab: edit name, bio, country, specialization, email, avatar, 11 social links
+- [x] Artworks tab: CRUD with image upload, sale/exhibition toggles, exhibition ordering
+- [x] Blog tab: create/edit/delete posts with cover image upload, publish toggle
+- [x] Orders tab: view/filter/search orders, update status through workflow
+- [x] Gallery regeneration triggered when exhibition settings change
+- [x] Public artist profile at `/artists/:id` with gallery, artworks, and blog tabs
+
+## Technical Design
+
+### Dashboard Tabs
+
+| Tab | Capabilities |
+|-----|-------------|
+| Profile | Edit name, bio, country, specialization, email, avatar (upload), 11 social platform links |
+| Artworks | Create/edit/delete artworks; image upload; toggle `isForSale`, `isReadyForExhibition`; set `exhibitionOrder` |
+| Blog | Create/edit/delete posts; cover image upload; toggle `isPublished` |
+| Orders | View orders for own artworks; filter by status; search by buyer; update status |
+
+### Social Links
+
+Stored as JSONB on `artists.socialLinks`. Supported platforms: Instagram, X (Twitter), Facebook, YouTube, TikTok, LinkedIn, Behance, Dribbble, DeviantArt, Pinterest, Website.
+
+### Artwork Management
+
+- Image upload via `POST /api/upload/artwork`
+- `isForSale` toggle controls marketplace visibility
+- `isReadyForExhibition` toggle gates 3D gallery display
+- `exhibitionOrder` field (shown only when ready) controls wall placement order
+- Changing exhibition settings triggers `regenerateArtistGallery()` server-side
+- Deletion cascades to orders, bids, auctions, exhibition_artworks
+
+### Key Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/api/artists/me` | Get/create artist profile |
+| PATCH | `/api/artists/:id` | Update artist profile |
+| POST | `/api/artworks` | Create artwork |
+| PATCH | `/api/artworks/:id` | Update artwork |
+| DELETE | `/api/artworks/:id` | Delete artwork (cascades) |
+| GET | `/api/artists/:id/orders` | Get artist's orders |
+| PATCH | `/api/orders/:id/status` | Update order status |
+
+### Key Files
+
+- `client/src/pages/artist-dashboard.tsx` — Dashboard UI (55.6 KB, tabbed interface)
+- `client/src/pages/artist-profile.tsx` — Public artist profile (15.5 KB)
+- `server/routes.ts` — API endpoints for all CRUD operations
+- `server/storage.ts` — Database queries and gallery regeneration
+
+## Dependencies
+
+- Authentication feature — Dashboard requires login
+- Image upload system — Avatar and artwork image uploads
+- 3D Gallery feature — Layout regeneration on exhibition changes
+- Marketplace feature — Order management
+- Blog feature — Blog post management
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/auctions/CHANGELOG.md
+++ b/specs/features/auctions/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Auctions — Changelog
+
+## 2026-02 (Initial)
+- Auction listing page with Active/Upcoming/Ended tabs
+- Time-based status derivation from start/end timestamps
+- Bid placement with minimum increment validation
+- Bid history display in modal
+- Progress bar visualization
+- Anonymous bidding (no authentication required)

--- a/specs/features/auctions/SPEC.md
+++ b/specs/features/auctions/SPEC.md
@@ -1,0 +1,80 @@
+# Feature: Auction System
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Time-based auction system where artworks can be listed for bidding. Auctions have start/end times, starting prices, and minimum bid increments. Status is derived from timestamps (upcoming/active/ended). Bidding is anonymous (no authentication required). No payment processing — auctions are informational.
+
+## User Story
+
+As a visitor, I want to browse active auctions and place bids on artworks, so that I can participate in art acquisition events.
+
+## Acceptance Criteria
+
+- [x] Auctions page (`/auctions`) with tabs: Active, Upcoming, Ended
+- [x] Stats display: total auctions, active count, total value
+- [x] Auction cards show image, title, artist, current/starting price, status badge, time remaining
+- [x] Place bid modal for active auctions with name + amount fields
+- [x] Client-side validation: bid amount >= current bid + minimum increment
+- [x] Server-side validation: auction must be active (within time window), bid meets minimum
+- [x] Bid history shown in bid modal (top 5, newest first)
+- [x] Upcoming auctions show "Coming Soon" (disabled)
+- [x] Ended auctions show "Auction Ended" (disabled)
+- [x] Progress bar visualization for active auctions
+
+## Technical Design
+
+### Status Determination
+
+Status is derived client-side from timestamps (no server-side state transitions):
+- `now < startTime` → "upcoming"
+- `startTime <= now <= endTime` → "active"
+- `now > endTime` → "ended"
+
+### Database Tables
+
+- `auctions` — `id`, `artworkId`, `startingPrice`, `currentBid`, `minimumIncrement`, `startTime`, `endTime`, `status`, `winnerName`
+- `bids` — `id`, `auctionId`, `bidderName`, `amount`, `timestamp`
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/api/auctions` | No | List all auctions (with artwork + artist) |
+| GET | `/api/auctions/:id` | No | Auction detail with bids |
+| GET | `/api/auctions/:id/bids` | No | Bid history (newest first) |
+| POST | `/api/auctions/:id/bids` | No | Place bid (validates timing + amount) |
+
+### Bid Validation Rules
+
+1. Auction must exist (404 otherwise)
+2. Auction must be active: `startTime <= now <= endTime` (400 otherwise)
+3. Bid amount >= `currentBid` (or `startingPrice`) + `minimumIncrement`
+4. On success: creates bid record, updates auction `currentBid`
+
+### Progress Bar
+
+Calculated as: `min(100, ((currentBid - startingPrice) / startingPrice) * 100 + 50)`, capped at 100%.
+
+### Limitations
+
+- No authentication required for bidding (anonymous)
+- No automatic winner determination (manual post-auction)
+- `winnerName` field exists but is not populated automatically
+- No bid reversal/cancellation
+- No auction extension on last-second bids
+- No payment flow — auctions are informational
+- No admin UI for creating/editing auctions (manual DB inserts)
+
+## Dependencies
+
+- TanStack React Query — Auction data fetching
+- Zod — Bid input validation
+- Shared database storage layer
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/authentication/CHANGELOG.md
+++ b/specs/features/authentication/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Authentication — Changelog
+
+## 2026-03-12
+- Added email/password login alongside Google OIDC (PR #33)
+- Moved Google OAuth from `/api/login` to `/api/login/google`
+- Added `GET /api/auth/config` endpoint for frontend capability detection
+- Added `GET /api/login` redirect to `/auth` page
+
+## 2026-03-11
+- Fixed Google OAuth login across all environments (PR #13, #15, closes #11)
+- Added dynamic OIDC host validation via `OIDC_ALLOWED_HOSTS`
+- Fixed per-hostname strategy registration
+
+## 2026-02 (Initial)
+- Integrated Google OIDC authentication via Passport.js + openid-client
+- Auto-creation of user + artist profile on first login
+- Session storage in PostgreSQL via connect-pg-simple (7-day TTL)
+- `isAuthenticated` middleware for protected routes

--- a/specs/features/authentication/SPEC.md
+++ b/specs/features/authentication/SPEC.md
@@ -1,0 +1,81 @@
+# Feature: Authentication
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Multi-provider authentication system supporting Google OIDC single sign-on and local email/password login. Sessions are stored in PostgreSQL via `connect-pg-simple`. On first login, a user record and artist profile are auto-created.
+
+## User Story
+
+As a visitor, I want to sign in with my Google account or email/password, so that I can access my artist dashboard and manage my gallery.
+
+## Acceptance Criteria
+
+- [x] Google OIDC login via `/api/login/google` with callback handling
+- [x] Email/password login via `POST /api/auth/login` (Passport local strategy)
+- [x] Session persistence in PostgreSQL with 7-day TTL
+- [x] Auto-creation of artist profile on first login
+- [x] Token refresh for OIDC sessions (checks `expires_at`, uses refresh token)
+- [x] `isAuthenticated` middleware protects all mutation routes
+- [x] `GET /api/auth/config` exposes available auth methods to frontend
+- [x] Auth page at `/auth` with login/signup tabs
+
+## Technical Design
+
+### Architecture
+
+Authentication lives in `server/replit_integrations/auth/` with four files:
+- `replitAuth.ts` — Core OIDC strategy setup, Google OAuth flow, local strategy, magic link routes
+- `storage.ts` — `AuthStorage` class for user CRUD (upsert, find by email/ID)
+- `routes.ts` — Auth endpoints (`/api/auth/user`)
+- `index.ts` — Export barrel
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/api/auth/config` | No | Expose `{ googleEnabled }` to frontend |
+| GET | `/api/login/google` | No | Initiate Google OAuth flow |
+| GET | `/api/callback` | No | OAuth callback, redirect to `/` or `/auth?error=...` |
+| GET | `/api/logout` | No | Destroy session, redirect to `/` |
+| GET | `/api/auth/user` | Yes | Fetch current authenticated user (excludes password) |
+| POST | `/api/auth/login` | No | Local strategy: validate email + bcrypt password |
+| GET | `/api/artists/me` | Yes | Get/create artist profile for logged-in user |
+
+### Session Management
+
+- **Store:** PostgreSQL via `connect-pg-simple` (auto-creates `sessions` table)
+- **TTL:** 7 days, `httpOnly`, `secure` in production, `sameSite: lax`
+- **OIDC sessions:** Include `access_token`, `refresh_token`, `expires_at`
+- **Email sessions:** Session TTL manages validity (no token refresh)
+
+### Database Tables
+
+- `users` — `id`, `email`, `password` (nullable, bcrypt hash), `emailVerified`, `firstName`, `lastName`, `profileImageUrl`, `createdAt`, `updatedAt`
+- `sessions` — `sid` (PK), `sess` (JSONB), `expire` (indexed)
+
+### Environment Variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `SESSION_SECRET` | Yes | Express session signing key |
+| `OIDC_CLIENT_ID` | No | Google OAuth client ID (disables Google login if missing) |
+| `OIDC_CLIENT_SECRET` | No | Google OAuth client secret |
+| `OIDC_ISSUER_URL` | No | OIDC provider URL (default: `https://accounts.google.com`) |
+
+## Dependencies
+
+- `openid-client` v6.8.1 — OIDC/OAuth 2.0 client
+- `passport` v0.7.0 — Authentication middleware
+- `passport-local` v1.0.0 — Local strategy (email + password)
+- `express-session` v1.19.0 — Session middleware
+- `connect-pg-simple` v10.0.0 — PostgreSQL session store
+- `bcryptjs` v3.0.3 — Password hashing (12 salt rounds)
+- `memoizee` v0.4.17 — Cache OIDC config (3600s TTL)
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/blog/CHANGELOG.md
+++ b/specs/features/blog/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Blog — Changelog
+
+## 2026-02 (Initial)
+- Blog list page (`/blog`) with 3-column grid
+- Post detail page (`/blog/:id`) with cover image and artist link
+- Dashboard blog tab with create/edit/delete
+- Cover image upload via dedicated endpoint
+- Publish toggle (draft vs published visibility)

--- a/specs/features/blog/SPEC.md
+++ b/specs/features/blog/SPEC.md
@@ -1,0 +1,64 @@
+# Feature: Blog System
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Artist blogging system where each artist can create, edit, publish, and delete blog posts. Posts support cover images (uploaded via dedicated endpoint) and a publish toggle that controls public visibility. Published posts appear on the main blog page and the artist's profile blog tab.
+
+## User Story
+
+As an artist, I want to write and publish blog posts, so that I can share my thoughts, process, and updates with visitors.
+
+## Acceptance Criteria
+
+- [x] Blog list page (`/blog`) displays all published posts in a 3-column grid
+- [x] Post detail page (`/blog/:id`) shows full content with cover image and artist link
+- [x] Dashboard blog tab shows all posts (drafts + published) with status badges
+- [x] Create post dialog: title, excerpt, cover image upload, content, publish toggle
+- [x] Edit post: same form pre-populated, partial updates via PATCH
+- [x] Delete post: permanent removal
+- [x] Draft posts hidden from public `/blog` but visible in dashboard
+- [x] Cover images optional (fallback icon if missing)
+- [x] `updatedAt` auto-set on edits
+- [x] Artist profile blog tab shows only published posts
+
+## Technical Design
+
+### Database Table
+
+`blog_posts` — `id`, `artistId`, `title`, `content`, `excerpt`, `coverImageUrl`, `isPublished` (boolean), `createdAt`, `updatedAt`
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/api/blog` | No | List all published posts (with artist name) |
+| GET | `/api/blog/:id` | No | Single post detail (no publish check) |
+| GET | `/api/artists/:id/blog` | No | All posts by artist (includes drafts for owner) |
+| POST | `/api/blog` | Yes | Create blog post |
+| PATCH | `/api/blog/:id` | Yes | Update post fields |
+| DELETE | `/api/blog/:id` | Yes | Delete post |
+
+### Cover Image Upload
+
+- Endpoint: `POST /api/upload/blog-cover`
+- Storage: `uploads/blog-covers/` with UUID filenames
+- Max size: 10 MB
+- Accepted types: JPEG, PNG, WebP, GIF
+
+### Content Format
+
+Content stored as plain text. No server-side markdown rendering. Frontend displays content as-is with CSS formatting.
+
+## Dependencies
+
+- Authentication feature — CRUD operations require login
+- Image upload system — Blog cover image uploads
+- Artist dashboards feature — Blog management in dashboard tab
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/email-login/CHANGELOG.md
+++ b/specs/features/email-login/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Email Login — Changelog
+
+## 2026-03-12
+- Fixed magic link emails not sent in Docker (PR #38, closes #34)
+- Added `RESEND_API_KEY` and `RESEND_FROM_EMAIL` to staging/production docker-compose files
+
+## 2026-03-11
+- Initial implementation (PR #33, closes #6)
+- Magic link signup with Resend email delivery
+- Password-based signin with Passport local strategy + bcryptjs
+- Schema migration: `magic_links` table, `password` + `emailVerified` columns on `users`
+- Auth page at `/auth` with login/signup tabs
+- Set password page at `/auth/set-password`
+- Fixed React hooks order in auth page for rules-of-hooks lint

--- a/specs/features/email-login/SPEC.md
+++ b/specs/features/email-login/SPEC.md
@@ -1,0 +1,78 @@
+# Feature: Email Login
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Magic link email signup and password-based signin, extending the authentication system beyond Google OIDC. New users receive a verification email via Resend, click a magic link to verify their address, then set a password. Returning users sign in with email + password.
+
+## User Story
+
+As a user without a Google account, I want to sign up with my email address and set a password, so that I can access ArtVerse without relying on third-party OAuth providers.
+
+## Acceptance Criteria
+
+- [x] Signup via `POST /api/auth/signup` sends a magic link email
+- [x] Magic link token valid for 1 hour, single use
+- [x] `GET /api/auth/verify-email?token=...` verifies email, auto-logs in, redirects to set-password
+- [x] `POST /api/auth/set-password` hashes password with bcrypt (12 rounds), min 8 chars
+- [x] `POST /api/auth/login` authenticates with email + password via Passport local strategy
+- [x] Existing users with password cannot re-signup (must use login)
+- [x] Graceful fallback when Resend API key is not configured (logs warning, no crash)
+- [x] Auth page shows both Google and email login options when both are available
+
+## Technical Design
+
+### Magic Link Flow
+
+1. User enters email on `/auth` signup tab
+2. Server validates email (Zod), checks no existing password
+3. Generates 32-byte random hex token, stores in `magic_links` table with 1-hour expiry
+4. Sends HTML email via Resend with verification link
+5. User clicks link → `GET /api/auth/verify-email?token=TOKEN`
+6. Server validates token (exists, unused, not expired), marks `usedAt`, upserts user with `emailVerified: true`
+7. Auto-logs in, redirects to `/auth/set-password` (if no password) or `/` (if password exists)
+8. User sets password (min 8 chars) → bcrypt hash stored
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| POST | `/api/auth/signup` | No | Send magic link to email |
+| GET | `/api/auth/verify-email` | No | Consume magic link token, auto-login |
+| POST | `/api/auth/set-password` | Yes | Set password after email verification |
+| POST | `/api/auth/login` | No | Email + password authentication |
+
+### Database
+
+- `magic_links` — `id`, `email`, `token` (unique), `expiresAt`, `usedAt` (nullable), `createdAt`
+- `users` — Added `password` (varchar, nullable) and `emailVerified` (boolean, default false)
+- Migration: `migrations/0001_illegal_famine.sql`
+
+### Email Template
+
+HTML email sent via Resend with:
+- Header: "Welcome to ArtVerse"
+- CTA button linking to `/api/auth/verify-email?token=...`
+- Footer: "Link expires in 1 hour"
+- Styled with serif font, primary orange (#F97316) accent
+
+### Environment Variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `RESEND_API_KEY` | No | Resend email service API key |
+| `RESEND_FROM_EMAIL` | No | Sender address (default: "ArtVerse <onboarding@resend.dev>") |
+
+## Dependencies
+
+- `resend` v4.8.0 — Email delivery service
+- `bcryptjs` v3.0.3 — Password hashing
+- `passport-local` v1.0.0 — Local strategy
+- Authentication feature (Google OIDC + session management)
+
+## Open Questions
+
+None — feature deployed to production 2026-03-12.

--- a/specs/features/exhibitions/CHANGELOG.md
+++ b/specs/features/exhibitions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Exhibitions — Changelog
+
+## 2026-03-11
+- Fixed stale gallery layouts in museum (PR #29, closes #28)
+
+## 2026-02 (Initial)
+- Exhibition data model with name, description, layout, active flag
+- Exhibition-artworks junction table with wall/position mapping
+- API endpoints for listing exhibitions and active exhibition
+- Per-artist gallery layout generation from exhibition-ready artworks
+- Integration with 3D hallway and maze gallery rendering

--- a/specs/features/exhibitions/SPEC.md
+++ b/specs/features/exhibitions/SPEC.md
@@ -1,0 +1,70 @@
+# Feature: Exhibition System
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Exhibition management system that organizes artworks into curated gallery displays. Exhibitions are named collections with layout metadata, linked to artworks via a junction table specifying wall placement and position. Each artist's personal gallery is auto-generated from their exhibition-ready artworks. The system powers both the hallway museum view and individual artist gallery rooms.
+
+## User Story
+
+As a visitor, I want to explore curated exhibitions of artworks in a virtual gallery, so that I can discover art in a meaningful, organized context.
+
+## Acceptance Criteria
+
+- [x] `exhibitions` table stores named collections with description, layout, and active flag
+- [x] `exhibition_artworks` junction table links artworks to exhibitions with wall/position
+- [x] `GET /api/exhibitions` lists all exhibitions (ordered by creation date)
+- [x] `GET /api/exhibitions/active` returns the currently active exhibition
+- [x] `GET /api/exhibitions/:id` returns exhibition with populated artworks
+- [x] Artist toggles `isReadyForExhibition` on artworks to include in their gallery
+- [x] `exhibitionOrder` field controls artwork placement order on walls
+- [x] Gallery layout auto-regenerates when exhibition settings change
+- [x] Hallway gallery loads all artists with exhibition-ready artworks
+- [x] Classic 2D view available as fallback
+
+## Technical Design
+
+### Database Tables
+
+- `exhibitions` — `id`, `name`, `description`, `layout` (text, JSON string), `isActive` (boolean), `createdAt`
+- `exhibition_artworks` — `id`, `exhibitionId`, `artworkId`, `wallId`, `position`
+- `artists.galleryLayout` — JSONB column storing per-artist maze layout
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/api/exhibitions` | No | List all exhibitions |
+| GET | `/api/exhibitions/active` | No | Get active exhibition |
+| GET | `/api/exhibitions/:id` | No | Exhibition with artworks |
+| GET | `/api/gallery/hallway` | No | All artist rooms for hallway view |
+| GET | `/api/artists/:id/gallery` | No | Individual artist gallery layout + artworks |
+
+### Exhibition-Ready Artwork Flow
+
+1. Artist creates artwork and sets `isReadyForExhibition: true` + `exhibitionOrder`
+2. Server calls `storage.regenerateArtistGallery(artistId)`
+3. Fetches all ready artworks ordered by `exhibitionOrder`, then title
+4. Calls `generateWhiteRoomLayout(count)` to create maze layout
+5. Stores layout in `artists.galleryLayout` JSONB column
+6. Frontend fetches layout + artworks for 3D rendering
+
+### Limitations
+
+- No admin UI for creating/managing exhibitions (API only)
+- MCP tools available for exhibition management
+- Only one exhibition can be active at a time
+- Artist exhibition control is indirect (via artwork flags, not exhibition entity)
+
+## Dependencies
+
+- 3D Gallery feature — Rendering of exhibition rooms
+- Artist dashboards — Exhibition toggle and ordering UI
+- Shared database storage layer
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/image-upload/CHANGELOG.md
+++ b/specs/features/image-upload/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Image Upload and Proxy — Changelog
+
+## 2026-03-11
+- Deduplicated upload code across artwork and blog cover endpoints (PR #18, closes #17)
+
+## 2026-02 (Initial)
+- Artwork image upload via multer with UUID filenames
+- Blog cover image upload via dedicated endpoint
+- Static file serving at `/uploads/*`
+- Image proxy at `/api/image-proxy` for external CORS-blocked images
+- Redirect following, 24-hour cache, 10-second timeout

--- a/specs/features/image-upload/SPEC.md
+++ b/specs/features/image-upload/SPEC.md
@@ -1,0 +1,78 @@
+# Feature: Image Upload and Proxy
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Image handling system with two capabilities: file upload for artwork and blog cover images (multer-based, disk storage with UUID filenames), and an image proxy for fetching external images with CORS headers. Uploaded images are served as static files via Express.
+
+## User Story
+
+As an artist, I want to upload images for my artworks and blog posts, so that they display in the gallery and store.
+
+As a visitor, I want external images to load without CORS issues, so that I can see all artwork in the 3D gallery.
+
+## Acceptance Criteria
+
+- [x] Upload artwork images via `POST /api/upload/artwork` (authenticated)
+- [x] Upload blog cover images via `POST /api/upload/blog-cover` (authenticated)
+- [x] Max file size: 10 MB
+- [x] Accepted types: JPEG, PNG, WebP, GIF
+- [x] UUID-based filenames prevent collisions
+- [x] Uploaded files served as static assets at `/uploads/*`
+- [x] Image proxy at `GET /api/image-proxy?url=...` for external images
+- [x] Proxy handles redirects, sets CORS headers, caches for 24 hours
+- [x] Proxy timeout: 10 seconds (504 on timeout)
+
+## Technical Design
+
+### Upload Architecture
+
+- **Middleware:** multer v2.1.1 with `diskStorage`
+- **Storage directories:** `uploads/artworks/`, `uploads/blog-covers/`
+- **Filename:** `crypto.randomUUID() + originalExtension`
+- **Response:** `{ imageUrl: "/uploads/{subdir}/{uuid}.{ext}" }`
+- **Static serving:** `express.static("uploads")` mounted at `/uploads`
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| POST | `/api/upload/artwork` | Yes | Upload artwork image |
+| POST | `/api/upload/blog-cover` | Yes | Upload blog cover image |
+| GET | `/api/image-proxy` | No | Proxy external image with CORS |
+
+### Image Proxy
+
+- Query param: `url` (external image URL)
+- Follows HTTP redirects (3xx)
+- Sets response headers: `Content-Type`, `Cache-Control: public, max-age=86400`, `Access-Control-Allow-Origin: *`
+- Timeout: 10 seconds (returns 504)
+- Error handling: 502 on connection errors, forwards 4xx/5xx from remote
+
+### Database Storage
+
+Image URLs stored as text in:
+- `artworks.imageUrl` — Artwork image (required)
+- `artists.avatarUrl` — Artist profile picture (optional)
+- `blog_posts.coverImageUrl` — Blog cover (optional)
+
+### Client Integration
+
+`FileUploadField` component in artist dashboard provides:
+- File input accepting image MIME types
+- Loading spinner during upload
+- Image preview after upload
+- `handleImageUpload()` utility: FormData POST → parse response → update state
+
+## Dependencies
+
+- `multer` v2.1.1 — File upload middleware
+- Express static middleware — File serving
+- Authentication feature — Upload routes require login
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/marketplace/CHANGELOG.md
+++ b/specs/features/marketplace/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Marketplace — Changelog
+
+## 2026-03-12
+- Fixed order notification emails in Docker (PR #38, closes #34)
+- Resend integration refactored: routes.ts uses `RESEND_API_KEY` env var directly
+
+## 2026-02 (Initial)
+- Store page with artwork listing, filtering, and search
+- Zustand cart with localStorage persistence
+- Checkout dialog with buyer details
+- Order creation with automatic `isForSale` flag clearing
+- Order status state machine (pending → communicating → sending → closed + canceled)
+- Artist order management in dashboard
+- Email notifications to buyer and artist via Resend

--- a/specs/features/marketplace/SPEC.md
+++ b/specs/features/marketplace/SPEC.md
@@ -1,0 +1,81 @@
+# Feature: Marketplace
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Art marketplace where visitors browse artworks for sale, add items to a persistent cart, and place orders. Artists manage incoming orders through a status workflow. Email notifications are sent to both buyer and artist on order creation via Resend.
+
+## User Story
+
+As a buyer, I want to browse artworks, add them to my cart, and place an order, so that I can purchase art from ArtVerse artists.
+
+As an artist, I want to manage my orders through a status workflow, so that I can track fulfillment from purchase to delivery.
+
+## Acceptance Criteria
+
+- [x] Store page (`/store`) lists all artworks where `isForSale = true`
+- [x] Filter by category, search by text, sort options
+- [x] Artwork detail dialog with full specs, artist info, add-to-cart button
+- [x] Cart sidebar (Zustand + localStorage persistence) with item count badge
+- [x] Checkout dialog: buyer name, email, shipping address
+- [x] One order created per cart item (parallel POST requests)
+- [x] Artwork marked `isForSale = false` immediately on order creation
+- [x] Email confirmation sent to buyer and artist (via Resend)
+- [x] Artist dashboard Orders tab shows all orders for their artworks
+- [x] Order status transitions enforced by state machine
+
+## Technical Design
+
+### Order Status State Machine
+
+```
+pending → communicating → sending → closed
+   ↓           ↓             ↓         ↓
+canceled    canceled      canceled   canceled
+```
+
+Any non-canceled status can transition to `canceled`. Transitions validated server-side via `ORDER_TRANSITIONS` map.
+
+### Database Tables
+
+- `artworks` — `id`, `title`, `description`, `imageUrl`, `artistId`, `price`, `medium`, `dimensions`, `year`, `isForSale`, `isInGallery`, `isReadyForExhibition`, `exhibitionOrder`, `category`
+- `orders` — `id`, `artworkId`, `buyerName`, `buyerEmail`, `shippingAddress`, `totalAmount`, `status`, `createdAt`
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/api/artworks` | No | List all artworks (with artist embedded) |
+| GET | `/api/artworks/:id` | No | Artwork detail |
+| POST | `/api/orders` | No | Create order, mark artwork not for sale, send emails |
+| GET | `/api/orders` | No | List all orders |
+| GET | `/api/artists/:id/orders` | Yes | Orders for artist's artworks |
+| PATCH | `/api/orders/:id/status` | Yes | Update order status (artist must own artwork) |
+
+### Cart Architecture
+
+- **State manager:** Zustand store (`client/src/lib/cart-store.ts`)
+- **Persistence:** localStorage
+- **Quantity:** Fixed at 1 per artwork (no quantity selector)
+- **Checkout:** Creates one `POST /api/orders` per cart item
+
+### Email Notifications
+
+On order creation:
+- **Buyer:** Confirmation email with order summary, artwork details, shipping info
+- **Artist:** New order alert with buyer details, artwork details
+- Sent via Resend; gracefully skips if not configured
+
+## Dependencies
+
+- Zustand — Cart state management with localStorage persistence
+- TanStack React Query — Server state fetching
+- Resend — Email notifications
+- Authentication feature — Artist order management requires login
+
+## Open Questions
+
+None — feature is stable and deployed.

--- a/specs/features/mcp-server/CHANGELOG.md
+++ b/specs/features/mcp-server/CHANGELOG.md
@@ -1,0 +1,10 @@
+# MCP Server — Changelog
+
+## 2026-02 (Initial)
+- MCP endpoint at `POST/GET/DELETE /mcp`
+- Streamable HTTP transport with stateful per-session instances
+- 13 resources for querying all major entities
+- 12 tools for CRUD operations on artworks, blog, orders, bids, profiles, gallery
+- 4 prompt templates for AI-assisted content generation
+- Zod schema validation on all tool inputs
+- `@ts-expect-error` workarounds for MCP SDK deep type instantiation issues

--- a/specs/features/mcp-server/SPEC.md
+++ b/specs/features/mcp-server/SPEC.md
@@ -1,0 +1,95 @@
+# Feature: MCP Server
+
+**Status:** Active
+**Last Updated:** 2026-03-12
+**Owner:** Architecture
+
+## Summary
+
+Model Context Protocol (MCP) server exposing ArtVerse data and operations to AI assistants. Provides 13 resources for reading data, 12 tools for mutations, and 4 prompt templates for AI-assisted content generation. Uses Streamable HTTP transport with stateful per-session instances.
+
+## User Story
+
+As an AI assistant (Claude), I want to access ArtVerse data and perform operations via MCP, so that I can help artists manage their galleries, artworks, and content.
+
+## Acceptance Criteria
+
+- [x] MCP endpoint at `POST/GET/DELETE /mcp`
+- [x] Stateful per-session instances with UUID session IDs
+- [x] 13 resources for querying artists, artworks, auctions, orders, blog, gallery, exhibitions
+- [x] 12 tools for creating/updating/deleting artworks, blog posts, orders, bids, artist profiles, gallery
+- [x] 4 prompt templates for content generation (artwork description, blog draft, order summary, artist bio)
+- [x] Zod schema validation on all tool inputs
+- [x] Uses shared `DatabaseStorage` singleton for all data access
+- [x] Session cleanup on transport close
+
+## Technical Design
+
+### Transport
+
+- **Protocol:** Streamable HTTP over `POST/GET/DELETE /mcp`
+- **Session management:** Random UUID per session, stored in memory `Map<sessionId, {transport, server}>`
+- **Headers:** `mcp-session-id` header for subsequent requests after initialization
+- **Lifecycle:** Session created on first POST, cleaned up on DELETE or transport close
+
+### Resources (13)
+
+| Resource | URI Pattern | Description |
+|----------|-------------|-------------|
+| all-artists | `artverse://artists` | List all artists |
+| artist-by-id | `artverse://artists/{artistId}` | Artist profile by ID |
+| all-artworks | `artverse://artworks` | All artworks with artist info |
+| artworks-by-artist | `artverse://artists/{artistId}/artworks` | Artworks for specific artist |
+| artwork-by-id | `artverse://artworks/{artworkId}` | Artwork details |
+| all-auctions | `artverse://auctions` | All auctions |
+| auction-by-id | `artverse://auctions/{auctionId}` | Auction with bids |
+| auction-bids | `artverse://auctions/{auctionId}/bids` | Bids for auction |
+| orders-by-artist | `artverse://artists/{artistId}/orders` | Orders for artist's artworks |
+| blog-posts | `artverse://blog` | All published blog posts |
+| blog-posts-by-artist | `artverse://artists/{artistId}/blog` | Blog posts by artist |
+| artist-gallery | `artverse://artists/{artistId}/gallery` | Gallery layout + artworks |
+| exhibitions | `artverse://exhibitions` | All exhibitions |
+
+### Tools (12)
+
+| Tool | Purpose |
+|------|---------|
+| `create_artwork` | Create new artwork listing |
+| `update_artwork` | Update artwork details |
+| `delete_artwork` | Delete artwork |
+| `search_artworks` | Search/filter artworks by query, category, medium, sale status |
+| `place_bid` | Place bid on active auction |
+| `create_order` | Create purchase order (marks artwork not for sale) |
+| `update_order_status` | Transition order through status workflow |
+| `update_artist_profile` | Update artist info and social links |
+| `create_blog_post` | Create blog post |
+| `update_blog_post` | Update blog post |
+| `delete_blog_post` | Delete blog post |
+| `regenerate_gallery` | Regenerate 3D gallery layout |
+
+### Prompt Templates (4)
+
+| Prompt | Parameters | Purpose |
+|--------|-----------|---------|
+| `artwork_description` | title, medium, artistName, style?, dimensions?, inspiration? | Generate compelling artwork description |
+| `blog_draft` | artistName, topic, tone?, keyPoints? | Draft blog post (400-800 words) |
+| `order_summary` | artistId | Analyze orders and provide sales insights |
+| `artist_bio` | name, specialization?, country?, existingBio?, highlights? | Write/improve artist biography |
+
+### Known Issues
+
+3 MCP `tool()` calls have `@ts-expect-error` comments due to deep type instantiation errors in the MCP SDK during CI type checking. Functionality is unaffected.
+
+### Key File
+
+`server/mcp.ts` — 817 lines, contains all resource definitions, tool implementations, and prompt templates.
+
+## Dependencies
+
+- `@modelcontextprotocol/sdk` v1.26.0 — MCP server framework
+- Shared `DatabaseStorage` singleton from `server/storage.ts`
+- Zod — Tool input validation schemas
+
+## Open Questions
+
+None — feature is stable and deployed.


### PR DESCRIPTION
## Summary
- 10 feature specs (SPEC.md + CHANGELOG.md each) covering all existing features
- 7 Architecture Decision Records (ADR-0001 through ADR-0007)
- 6 bug files for all open issues with Workaround sections (rule C-005)
- 33 new files, 1,407 lines of documentation

### Feature Specs
authentication, email-login, 3d-gallery, marketplace, auctions, artist-dashboards, blog, exhibitions, mcp-server, image-upload

### ADRs
1. Monolithic architecture (Express + React + PostgreSQL)
2. VPS hosting on Webdock
3. Drizzle ORM with dual-mode schema management
4. Three.js for 3D gallery rendering
5. Passport.js with OIDC + local auth
6. Resend for transactional email
7. Docker-based deployment with GHCR

### Bug Files
BUG-0004, BUG-0007, BUG-0008, BUG-0012, BUG-0014, BUG-0032

Closes #42

## Test plan
- [x] `doc-audit.sh` passes with 0 errors
- [x] All SPEC.md files >100 words (Q-001 compliant)
- [x] No TODO/TBD placeholders in Active documents (Q-003 compliant)
- [x] All ADRs follow `ADR-XXXX-title.md` naming (S-004 compliant)
- [x] All bug files follow `BUG-XXXX-title.md` naming (S-005 compliant)
- [x] All open bugs include Workaround section (C-005 compliant)
- [ ] Doc agent workflow validates on PR (if ANTHROPIC_API_KEY configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)