### PR TITLE
Fix Q-003 false positive in DOC-AGENT-SPEC.md

### DIFF
--- a/specs/DOC-AGENT-SPEC.md
+++ b/specs/DOC-AGENT-SPEC.md
@@ -109,7 +109,7 @@ The agent enforces rules at three severity levels: **ERROR** (blocks merge), **W
 |---|---|
 | Q-001 | SPEC.md files with fewer than 100 words are flagged as stubs |
 | Q-002 | ADR files missing `## Consequences` section |
-| Q-003 | Any `TODO` or `TBD` placeholder in an Active document |
+| Q-003 | Any unfinished-work placeholder (to-do / to-be-determined) in an Active document |
 | Q-004 | Broken internal links between spec files |
 
 ---


### PR DESCRIPTION
## Summary
- The Q-003 audit rule description in `DOC-AGENT-SPEC.md` contained the literal words "TODO" and "TBD", triggering a false positive on itself
- Rephrased to "to-do / to-be-determined" to avoid matching the grep pattern
- Audit now passes fully clean: 0 errors, 0 warnings, 0 info

Closes #50

## Test plan
- [x] `doc-audit.sh` runs clean with no findings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)