### PR TITLE
Refactor: consolidate duplicated auth, email, and frontend code

### DIFF
--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useLocation } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
+import { apiRequest } from "@/lib/queryClient";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -10,6 +11,14 @@ import { useToast } from "@/hooks/use-toast";
 import { Loader2, Mail, ArrowLeft } from "lucide-react";
 
 type AuthMode = "login" | "signup" | "check-email";
+
+const errorMessages: Record<string, string> = {
+  invalid_token: "Invalid verification link.",
+  expired_token: "This link has expired. Please sign up again.",
+  login_failed: "Login failed. Please try again.",
+  google_failed: "Google login failed. Please try again.",
+  verification_failed: "Email verification failed. Please try again.",
+};
 
 export default function AuthPage() {
   const [, navigate] = useLocation();
@@ -24,24 +33,13 @@ export default function AuthPage() {
 
   const { data: authConfig } = useQuery<{ googleEnabled: boolean }>({
     queryKey: ["/api/auth/config"],
-    queryFn: async () => {
-      const res = await fetch("/api/auth/config");
-      return res.json();
-    },
-    staleTime: Infinity,
   });
   const googleEnabled = authConfig?.googleEnabled ?? false;
 
   const signupMutation = useMutation({
     mutationFn: async (email: string) => {
-      const res = await fetch("/api/auth/signup", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message);
-      return data;
+      const res = await apiRequest("POST", "/api/auth/signup", { email });
+      return res.json();
     },
     onSuccess: () => setMode("check-email"),
     onError: (err: Error) => {
@@ -51,15 +49,8 @@ export default function AuthPage() {
 
   const loginMutation = useMutation({
     mutationFn: async ({ email, password }: { email: string; password: string }) => {
-      const res = await fetch("/api/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
-        credentials: "include",
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message);
-      return data;
+      const res = await apiRequest("POST", "/api/auth/login", { email, password });
+      return res.json();
     },
     onSuccess: () => {
       window.location.href = "/";
@@ -75,14 +66,6 @@ export default function AuthPage() {
     return null;
   }
 
-  const errorMessages: Record<string, string> = {
-    invalid_token: "Invalid verification link.",
-    expired_token: "This link has expired. Please sign up again.",
-    login_failed: "Login failed. Please try again.",
-    google_failed: "Google login failed. Please try again.",
-    verification_failed: "Email verification failed. Please try again.",
-  };
-
   if (authLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
@@ -90,6 +73,38 @@ export default function AuthPage() {
       </div>
     );
   }
+
+  const errorBanner = errorParam && (
+    <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md">
+      {errorMessages[errorParam] || "Something went wrong."}
+    </div>
+  );
+
+  const googleLoginSection = googleEnabled && (
+    <>
+      <div className="relative my-4">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-card px-2 text-muted-foreground">Or</span>
+        </div>
+      </div>
+      <Button
+        variant="outline"
+        className="w-full"
+        onClick={() => { window.location.href = "/api/login/google"; }}
+      >
+        <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
+          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+        </svg>
+        Continue with Google
+      </Button>
+    </>
+  );
 
   return (
     <div className="flex items-center justify-center min-h-[80vh] p-4">
@@ -125,11 +140,7 @@ export default function AuthPage() {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {errorParam && (
-                <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md">
-                  {errorMessages[errorParam] || "Something went wrong."}
-                </div>
-              )}
+              {errorBanner}
               <form
                 onSubmit={(e) => {
                   e.preventDefault();
@@ -158,32 +169,7 @@ export default function AuthPage() {
                 </Button>
               </form>
 
-              {googleEnabled && (
-                <>
-                  <div className="relative my-4">
-                    <div className="absolute inset-0 flex items-center">
-                      <span className="w-full border-t" />
-                    </div>
-                    <div className="relative flex justify-center text-xs uppercase">
-                      <span className="bg-card px-2 text-muted-foreground">Or</span>
-                    </div>
-                  </div>
-
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    onClick={() => { window.location.href = "/api/login/google"; }}
-                  >
-                    <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
-                      <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-                      <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-                      <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-                      <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-                    </svg>
-                    Continue with Google
-                  </Button>
-                </>
-              )}
+              {googleLoginSection}
 
               <p className="text-center text-sm text-muted-foreground">
                 Already have an account?{" "}
@@ -206,11 +192,7 @@ export default function AuthPage() {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {errorParam && (
-                <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md">
-                  {errorMessages[errorParam] || "Something went wrong."}
-                </div>
-              )}
+              {errorBanner}
               <form
                 onSubmit={(e) => {
                   e.preventDefault();
@@ -249,32 +231,7 @@ export default function AuthPage() {
                 </Button>
               </form>
 
-              {googleEnabled && (
-                <>
-                  <div className="relative my-4">
-                    <div className="absolute inset-0 flex items-center">
-                      <span className="w-full border-t" />
-                    </div>
-                    <div className="relative flex justify-center text-xs uppercase">
-                      <span className="bg-card px-2 text-muted-foreground">Or</span>
-                    </div>
-                  </div>
-
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    onClick={() => { window.location.href = "/api/login/google"; }}
-                  >
-                    <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
-                      <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-                      <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-                      <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-                      <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-                    </svg>
-                    Continue with Google
-                  </Button>
-                </>
-              )}
+              {googleLoginSection}
 
               <p className="text-center text-sm text-muted-foreground">
                 Don't have an account?{" "}

--- a/client/src/pages/set-password.tsx
+++ b/client/src/pages/set-password.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
+import { apiRequest } from "@/lib/queryClient";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,15 +17,8 @@ export default function SetPassword() {
 
   const setPasswordMutation = useMutation({
     mutationFn: async (password: string) => {
-      const res = await fetch("/api/auth/set-password", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password }),
-        credentials: "include",
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message);
-      return data;
+      const res = await apiRequest("POST", "/api/auth/set-password", { password });
+      return res.json();
     },
     onSuccess: () => {
       toast({ title: "Password set!", description: "Your account is ready." });

--- a/server/email.ts
+++ b/server/email.ts
@@ -2,7 +2,7 @@ import { Resend } from "resend";
 
 let resendClient: Resend | null = null;
 
-function getResendClient(): Resend {
+export function getResendClient(): Resend {
   if (!resendClient) {
     const apiKey = process.env.RESEND_API_KEY;
     if (!apiKey) {
@@ -13,7 +13,7 @@ function getResendClient(): Resend {
   return resendClient;
 }
 
-function getFromEmail(): string {
+export function getFromEmail(): string {
   return process.env.RESEND_FROM_EMAIL || "ArtVerse <onboarding@resend.dev>";
 }
 

--- a/server/replit_integrations/auth/replitAuth.ts
+++ b/server/replit_integrations/auth/replitAuth.ts
@@ -12,6 +12,18 @@ import connectPg from "connect-pg-simple";
 import { authStorage } from "./storage";
 import { sendMagicLinkEmail } from "../../email";
 import { z } from "zod";
+import type { User } from "@shared/models/auth";
+
+function buildSessionUser(user: { id: string; email: string | null; firstName: string | null; lastName: string | null }) {
+  return {
+    claims: {
+      sub: user.id,
+      email: user.email,
+      first_name: user.firstName,
+      last_name: user.lastName,
+    },
+  };
+}
 
 /**
  * Generic OIDC auth (used for Google OAuth in production).
@@ -151,16 +163,7 @@ export async function setupAuth(app: Express) {
           if (!valid) {
             return done(null, false, { message: "Invalid email or password" });
           }
-          // Build session object matching OIDC shape so the rest of the app works
-          const sessionUser = {
-            claims: {
-              sub: user.id,
-              email: user.email,
-              first_name: user.firstName,
-              last_name: user.lastName,
-            },
-          };
-          return done(null, sessionUser);
+          return done(null, buildSessionUser(user));
         } catch (err) {
           return done(err);
         }
@@ -219,17 +222,7 @@ export async function setupAuth(app: Express) {
         emailVerified: true,
       });
 
-      // Log the user in
-      const sessionUser = {
-        claims: {
-          sub: user.id,
-          email: user.email,
-          first_name: user.firstName,
-          last_name: user.lastName,
-        },
-      };
-
-      req.login(sessionUser, (err) => {
+      req.login(buildSessionUser(user), (err) => {
         if (err) {
           console.error("Login after verify error:", err);
           return res.redirect("/auth?error=login_failed");

--- a/server/replit_integrations/auth/storage.ts
+++ b/server/replit_integrations/auth/storage.ts
@@ -75,25 +75,18 @@ class AuthStorage implements IAuthStorage {
   }
 
   async consumeMagicLink(token: string): Promise<MagicLink | undefined> {
-    // Find valid, unused, non-expired token
+    // Atomic: find valid token and mark as used in one query (prevents double-consumption)
     const [link] = await db
-      .select()
-      .from(magicLinks)
+      .update(magicLinks)
+      .set({ usedAt: new Date() })
       .where(
         and(
           eq(magicLinks.token, token),
           isNull(magicLinks.usedAt),
           gt(magicLinks.expiresAt, new Date())
         )
-      );
-
-    if (!link) return undefined;
-
-    // Mark as used
-    await db
-      .update(magicLinks)
-      .set({ usedAt: new Date() })
-      .where(eq(magicLinks.id, link.id));
+      )
+      .returning();
 
     return link;
   }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7,22 +7,11 @@ import { z } from "zod";
 import { setupAuth, registerAuthRoutes, isAuthenticated } from "./replit_integrations/auth";
 import https from "https";
 import http from "http";
-import { Resend } from "resend";
+import { getResendClient, getFromEmail } from "./email";
 import multer from "multer";
 import path from "path";
 import fs from "fs";
 import crypto from "crypto";
-
-function getResendClient(): { client: Resend; fromEmail: string } {
-  const apiKey = process.env.RESEND_API_KEY;
-  if (!apiKey) {
-    throw new Error("RESEND_API_KEY is not configured");
-  }
-  return {
-    client: new Resend(apiKey),
-    fromEmail: process.env.RESEND_FROM_EMAIL || "ArtVerse <onboarding@resend.dev>",
-  };
-}
 
 async function sendOrderNotificationEmail(
   artist: Artist,
@@ -32,9 +21,9 @@ async function sendOrderNotificationEmail(
 ) {
   if (!artist.email) return;
 
-  let resendClient: { client: Resend; fromEmail: string };
+  let client;
   try {
-    resendClient = getResendClient();
+    client = getResendClient();
   } catch (e) {
     console.log("Resend not configured, skipping email notification:", (e as Error).message);
     return;
@@ -46,7 +35,7 @@ async function sendOrderNotificationEmail(
       <h1 style="color: #1a1a2e; border-bottom: 2px solid #F97316; padding-bottom: 10px;">New Artwork Order</h1>
       <p>Dear ${artist.name},</p>
       <p>Great news! One of your artworks has been purchased.</p>
-      
+
       <div style="background: #faf8f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
         <h2 style="color: #1a1a2e; margin-top: 0;">Order Details</h2>
         <table style="width: 100%; border-collapse: collapse;">
@@ -57,7 +46,7 @@ async function sendOrderNotificationEmail(
           <tr><td style="padding: 8px 0; color: #666;">Price:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()}</td></tr>
         </table>
       </div>
-      
+
       <div style="background: #f0f0f0; padding: 20px; border-radius: 8px; margin: 20px 0;">
         <h2 style="color: #1a1a2e; margin-top: 0;">Buyer Information</h2>
         <table style="width: 100%; border-collapse: collapse;">
@@ -66,7 +55,7 @@ async function sendOrderNotificationEmail(
           <tr><td style="padding: 8px 0; color: #666;">Shipping Address:</td><td style="padding: 8px 0;">${orderData.shippingAddress}</td></tr>
         </table>
       </div>
-      
+
       <p style="color: #666; font-size: 14px; margin-top: 30px;">
         Please prepare the artwork for shipping. You can view all your orders in your artist dashboard.
       </p>
@@ -74,8 +63,8 @@ async function sendOrderNotificationEmail(
     </div>
   `;
 
-  await resendClient.client.emails.send({
-    from: resendClient.fromEmail,
+  await client.emails.send({
+    from: getFromEmail(),
     to: artist.email,
     subject,
     html,
@@ -88,9 +77,9 @@ async function sendBuyerConfirmationEmail(
   order: Order,
   orderData: InsertOrder,
 ) {
-  let resendClient: { client: Resend; fromEmail: string };
+  let client;
   try {
-    resendClient = getResendClient();
+    client = getResendClient();
   } catch (e) {
     console.log("Resend not configured, skipping buyer confirmation:", (e as Error).message);
     return;
@@ -130,8 +119,8 @@ async function sendBuyerConfirmationEmail(
     </div>
   `;
 
-  await resendClient.client.emails.send({
-    from: resendClient.fromEmail,
+  await client.emails.send({
+    from: getFromEmail(),
     to: orderData.buyerEmail,
     subject,
     html,


### PR DESCRIPTION
## Summary
- Consolidate Resend client: `routes.ts` imports cached singleton from `email.ts` (-1 duplicate factory, prevents new instance per call)
- Extract `buildSessionUser()` helper in `replitAuth.ts` (replaces 2 duplicate object literals)
- Fix TOCTOU race in `consumeMagicLink`: atomic `UPDATE...RETURNING` prevents double-consumption
- Use `apiRequest()` in auth pages instead of hand-rolled `fetch` (3 mutations)
- Remove redundant custom `queryFn` for `/api/auth/config`
- Deduplicate Google OAuth button + error banner JSX (26-line block x2 → shared variable)
- Hoist static `errorMessages` outside component

Net: **-74 lines** (85 added, 159 removed)

Closes #53

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run check` — type check clean
- [x] `npm test` — 32/32 tests pass
- [x] `npm run build` — production build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)