### PR TITLE
Lock down order endpoints — fix PII exposure

### DIFF
--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -133,6 +133,44 @@ describe("GET /api/exhibitions/active", () => {
   });
 });
 
+// ----- Auth-protected GET endpoints -----
+
+describe("GET /api/orders", () => {
+  const testArtist = { id: "art1", name: "Alice", bio: "Bio", userId: "test-user-id" };
+
+  it("returns only the logged-in artist's orders", async () => {
+    (mockStorage.getArtistByUserId as ReturnType<typeof vi.fn>).mockResolvedValue(testArtist);
+    const orders = [{ id: "o1", artworkId: "a1", status: "pending" }];
+    (mockStorage.getOrdersByArtist as ReturnType<typeof vi.fn>).mockResolvedValue(orders);
+
+    const res = await request(app).get("/api/orders");
+    expect(res.status).toBe(200);
+    expect(mockStorage.getOrdersByArtist).toHaveBeenCalledWith("art1");
+    expect(res.body).toEqual(orders);
+  });
+});
+
+describe("GET /api/artists/:id/orders", () => {
+  const testArtist = { id: "art1", name: "Alice", bio: "Bio", userId: "test-user-id" };
+
+  it("returns orders when artist views their own", async () => {
+    (mockStorage.getArtistByUserId as ReturnType<typeof vi.fn>).mockResolvedValue(testArtist);
+    const orders = [{ id: "o1", artworkId: "a1", status: "pending" }];
+    (mockStorage.getOrdersByArtist as ReturnType<typeof vi.fn>).mockResolvedValue(orders);
+
+    const res = await request(app).get("/api/artists/art1/orders");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(orders);
+  });
+
+  it("returns 403 when viewing another artist's orders", async () => {
+    (mockStorage.getArtistByUserId as ReturnType<typeof vi.fn>).mockResolvedValue(testArtist);
+
+    const res = await request(app).get("/api/artists/other-artist/orders");
+    expect(res.status).toBe(403);
+  });
+});
+
 // ----- POST validation -----
 
 describe("POST /api/orders", () => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -433,17 +433,28 @@ export async function registerRoutes(
   });
 
   // Orders routes
-  app.get("/api/orders", async (req, res) => {
+  app.get("/api/orders", isAuthenticated, async (req: any, res) => {
     try {
-      const orders = await storage.getOrders();
+      const userId = req.user?.claims?.sub;
+      const artist = await storage.getArtistByUserId(userId);
+      if (!artist) {
+        return res.status(403).json({ error: "Not authorized" });
+      }
+      // Return only this artist's orders (no admin role exists yet)
+      const orders = await storage.getOrdersByArtist(artist.id);
       res.json(orders);
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch orders" });
     }
   });
 
-  app.get("/api/artists/:id/orders", async (req, res) => {
+  app.get("/api/artists/:id/orders", isAuthenticated, async (req: any, res) => {
     try {
+      const userId = req.user?.claims?.sub;
+      const artist = await storage.getArtistByUserId(userId);
+      if (!artist || artist.id !== req.params.id) {
+        return res.status(403).json({ error: "Not authorized to view another artist's orders" });
+      }
       const artistOrders = await storage.getOrdersByArtist(req.params.id);
       res.json(artistOrders);
     } catch (error) {

--- a/specs/issue-tracker.md
+++ b/specs/issue-tracker.md
@@ -34,7 +34,7 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 | 73 | Upgrade Node.js 20→25 | high | bug | Open | — | Dependabot PR #57 closed (major) |
 | 77 | Security Audit — Critical findings | critical | devops | In Progress | — | Parent. Sub-issues: #78, #79, #80, #81. 4 P0s, 6 P1s, 7 P2s. |
 | 78 | Add auth to 9 unprotected write endpoints | critical | bug | In Progress | `fix/issue-78-auth-write-endpoints` | Sub of #77 |
-| 79 | Lock down order endpoints (PII exposure) | critical | bug | Open | — | Sub of #77 |
+| 79 | Lock down order endpoints (PII exposure) | critical | bug | In Progress | `fix/issue-79-lock-order-endpoints` | Sub of #77 |
 | 80 | Add auth to MCP server endpoint | critical | bug | Open | — | Sub of #77 |
 | 81 | Fix SSRF in image proxy endpoint | critical | bug | Open | — | Sub of #77 |
 | 74 | Upgrade react-resizable-panels 2→4 | high | bug | Open | — | Dependabot PR #68 closed (major) |


### PR DESCRIPTION
## Summary
- `GET /api/orders` now requires auth and returns only the logged-in artist's orders (was returning all orders with buyer PII to anyone)
- `GET /api/artists/:id/orders` now requires auth and restricts access to the owning artist only
- Added 3 tests for order endpoint authorization

Closes #79
Part of #77 (Security Audit)

## Test plan
- [x] 39 tests pass (3 new authorization tests)
- [x] ESLint: 0 errors
- [x] Artist dashboard order tab works for logged-in artist
- [x] Unauthenticated requests to order endpoints return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)