### PR TITLE
Fix all 6 P1 security findings from audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Lint, Type Check, Test & Build
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -32,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
           cache: npm
@@ -71,13 +77,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -88,7 +94,7 @@ jobs:
         run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           push: true
@@ -103,12 +109,15 @@ jobs:
     needs: build-image
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Sync docker-compose to VPS
-        uses: appleboy/scp-action@v1.0.0
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: staging
@@ -118,15 +127,18 @@ jobs:
           strip_components: 2
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: staging
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: DEPLOY_SHA
           script: |
             cd ~/app
-            docker pull ghcr.io/ilv78/art-world-hub:${{ github.sha }}
-            sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG=${{ github.sha }}/' .env || echo 'IMAGE_TAG=${{ github.sha }}' >> .env
+            docker pull ghcr.io/ilv78/art-world-hub:$DEPLOY_SHA
+            sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$DEPLOY_SHA/" .env || echo "IMAGE_TAG=$DEPLOY_SHA" >> .env
             docker compose up -d --remove-orphans
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do
@@ -145,16 +157,18 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          DEPLOY_STATUS: ${{ job.status }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          DEPLOY_SHA: ${{ github.sha }}
+          TRIGGERED_BY: ${{ github.actor }}
         run: |
           if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
-          STATUS="${{ job.status }}"
-          if [ "$STATUS" = "success" ]; then EMOJI="✅"; else EMOJI="❌"; fi
-          REPO_NAME="${{ github.event.repository.name }}"
+          if [ "$DEPLOY_STATUS" = "success" ]; then EMOJI="✅"; else EMOJI="❌"; fi
           curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_CHAT_ID}" \
             -d parse_mode="HTML" \
             -d text="@racu8_bot
-          ${EMOJI} <b>Staging deployment: ${STATUS}</b> [${REPO_NAME}]
+          ${EMOJI} <b>Staging deployment: ${DEPLOY_STATUS}</b> [${REPO_NAME}]
           Staging address: https://staging.artverse.idata.ro
-          Tag: <code>${{ github.sha }}</code>
-          By: ${{ github.actor }}"
+          Tag: <code>${DEPLOY_SHA}</code>
+          By: ${TRIGGERED_BY}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,17 +8,23 @@ on:
         required: true
         default: "latest"
 
+permissions:
+  contents: read
+
 jobs:
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Sync docker-compose to VPS
-        uses: appleboy/scp-action@v1.0.0
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: production
@@ -28,21 +34,24 @@ jobs:
           strip_components: 2
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: production
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: IMAGE_TAG
           script: |
             cd ~/app
             # Save current IMAGE_TAG for rollback
             CURRENT_TAG=$(grep '^IMAGE_TAG=' .env | cut -d= -f2 || true)
-            if [ -n "$CURRENT_TAG" ] && [ "$CURRENT_TAG" != "${{ github.event.inputs.image_tag }}" ]; then
+            if [ -n "$CURRENT_TAG" ] && [ "$CURRENT_TAG" != "$IMAGE_TAG" ]; then
               echo "Saving current tag for rollback: $CURRENT_TAG"
               echo "$CURRENT_TAG" > .previous_image_tag
             fi
-            docker pull ghcr.io/ilv78/art-world-hub:${{ github.event.inputs.image_tag }}
-            sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG=${{ github.event.inputs.image_tag }}/' .env || echo 'IMAGE_TAG=${{ github.event.inputs.image_tag }}' >> .env
+            docker pull ghcr.io/ilv78/art-world-hub:$IMAGE_TAG
+            sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env || echo "IMAGE_TAG=$IMAGE_TAG" >> .env
             docker compose up -d --remove-orphans
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do

--- a/.github/workflows/doc-agent.yml
+++ b/.github/workflows/doc-agent.yml
@@ -25,14 +25,14 @@ jobs:
           HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
         run: echo "has_key=$HAS_KEY" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-key.outputs.has_key == 'true'
         with:
           fetch-depth: 0
 
       - name: Run Documentation Agent (Enforce)
         if: steps.check-key.outputs.has_key == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1
         with:
           prompt: |
             You are the ArtVerse Documentation Agent in ENFORCE mode.
@@ -88,7 +88,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -116,14 +116,19 @@ jobs:
         if: steps.audit.outputs.has_findings == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUDIT_ERRORS: ${{ steps.audit.outputs.errors }}
+          AUDIT_WARNINGS: ${{ steps.audit.outputs.warnings }}
+          AUDIT_INFOS: ${{ steps.audit.outputs.infos }}
+          AUDIT_REPORT: ${{ steps.audit.outputs.report }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
-          TITLE="📋 Docs Audit: ${DATE} — ${{ steps.audit.outputs.errors }} errors, ${{ steps.audit.outputs.warnings }} warnings, ${{ steps.audit.outputs.infos }} info"
+          TITLE="📋 Docs Audit: ${DATE} — ${AUDIT_ERRORS} errors, ${AUDIT_WARNINGS} warnings, ${AUDIT_INFOS} info"
           gh issue create \
             --title "$TITLE" \
             --label "docs-audit" \
-            --assignee "${{ github.repository_owner }}" \
-            --body "${{ steps.audit.outputs.report }}"
+            --assignee "$REPO_OWNER" \
+            --body "$AUDIT_REPORT"
 
       - name: Log clean audit
         if: steps.audit.outputs.has_findings == 'false'

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -8,23 +8,31 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   rollback-production:
     name: Rollback Production
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Rollback via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        env:
+          ROLLBACK_TAG: ${{ github.event.inputs.image_tag }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: production
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: ROLLBACK_TAG
           script: |
             cd ~/app
 
             # Determine which tag to roll back to
-            ROLLBACK_TAG="${{ github.event.inputs.image_tag }}"
             if [ -z "$ROLLBACK_TAG" ]; then
               if [ ! -f .previous_image_tag ]; then
                 echo "ERROR: No previous image tag found and none specified"

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       DATABASE_URL: postgresql://artverse:${POSTGRES_PASSWORD}@db:5432/artverse_production
       SESSION_SECRET: ${SESSION_SECRET}
       SEED_DB: ${SEED_DB:-false}
-      DB_MIGRATION_MODE: push
+      DB_MIGRATION_MODE: migrate
       OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertArtworkSchema, insertArtistSchema, insertBidSchema, insertOrderSchema, insertBlogPostSchema, ORDER_TRANSITIONS, ORDER_STATUSES } from "@shared/schema";
+import { insertArtworkSchema, updateArtworkSchema, insertBidSchema, insertOrderSchema, insertBlogPostSchema, updateBlogPostSchema, updateArtistSchema, ORDER_TRANSITIONS, ORDER_STATUSES } from "@shared/schema";
 import type { Artist, ArtworkWithArtist, Order, InsertOrder } from "@shared/schema";
 import { z } from "zod";
 import { setupAuth, registerAuthRoutes, isAuthenticated } from "./replit_integrations/auth";
@@ -12,6 +12,15 @@ import multer from "multer";
 import path from "path";
 import fs from "fs";
 import crypto from "crypto";
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 
 async function sendOrderNotificationEmail(
   artist: Artist,
@@ -33,16 +42,16 @@ async function sendOrderNotificationEmail(
   const html = `
     <div style="font-family: Georgia, serif; max-width: 600px; margin: 0 auto; padding: 20px;">
       <h1 style="color: #1a1a2e; border-bottom: 2px solid #F97316; padding-bottom: 10px;">New Artwork Order</h1>
-      <p>Dear ${artist.name},</p>
+      <p>Dear ${escapeHtml(artist.name)},</p>
       <p>Great news! One of your artworks has been purchased.</p>
 
       <div style="background: #faf8f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
         <h2 style="color: #1a1a2e; margin-top: 0;">Order Details</h2>
         <table style="width: 100%; border-collapse: collapse;">
-          <tr><td style="padding: 8px 0; color: #666;">Order ID:</td><td style="padding: 8px 0; font-weight: bold;">${order.id}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Artwork:</td><td style="padding: 8px 0; font-weight: bold;">${artwork.title}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${artwork.medium}</td></tr>
-          ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${artwork.dimensions}</td></tr>` : ""}
+          <tr><td style="padding: 8px 0; color: #666;">Order ID:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(order.id)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Artwork:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(artwork.title)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${escapeHtml(artwork.medium)}</td></tr>
+          ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${escapeHtml(artwork.dimensions)}</td></tr>` : ""}
           <tr><td style="padding: 8px 0; color: #666;">Price:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()}</td></tr>
         </table>
       </div>
@@ -50,9 +59,9 @@ async function sendOrderNotificationEmail(
       <div style="background: #f0f0f0; padding: 20px; border-radius: 8px; margin: 20px 0;">
         <h2 style="color: #1a1a2e; margin-top: 0;">Buyer Information</h2>
         <table style="width: 100%; border-collapse: collapse;">
-          <tr><td style="padding: 8px 0; color: #666;">Name:</td><td style="padding: 8px 0; font-weight: bold;">${orderData.buyerName}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Email:</td><td style="padding: 8px 0;">${orderData.buyerEmail}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Shipping Address:</td><td style="padding: 8px 0;">${orderData.shippingAddress}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Name:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(orderData.buyerName)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Email:</td><td style="padding: 8px 0;">${escapeHtml(orderData.buyerEmail)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Shipping Address:</td><td style="padding: 8px 0;">${escapeHtml(orderData.shippingAddress)}</td></tr>
         </table>
       </div>
 
@@ -89,26 +98,26 @@ async function sendBuyerConfirmationEmail(
   const html = `
     <div style="font-family: Georgia, serif; max-width: 600px; margin: 0 auto; padding: 20px;">
       <h1 style="color: #1a1a2e; border-bottom: 2px solid #F97316; padding-bottom: 10px;">Order Confirmation</h1>
-      <p>Dear ${orderData.buyerName},</p>
+      <p>Dear ${escapeHtml(orderData.buyerName)},</p>
       <p>Thank you for your purchase! Your order has been received and the artist has been notified.</p>
-      
+
       <div style="background: #faf8f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
         <h2 style="color: #1a1a2e; margin-top: 0;">Order Summary</h2>
         <table style="width: 100%; border-collapse: collapse;">
-          <tr><td style="padding: 8px 0; color: #666;">Order ID:</td><td style="padding: 8px 0; font-weight: bold;">${order.id}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Artwork:</td><td style="padding: 8px 0; font-weight: bold;">${artwork.title}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Artist:</td><td style="padding: 8px 0;">${artist.name}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${artwork.medium}</td></tr>
-          ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${artwork.dimensions}</td></tr>` : ""}
+          <tr><td style="padding: 8px 0; color: #666;">Order ID:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(order.id)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Artwork:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(artwork.title)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Artist:</td><td style="padding: 8px 0;">${escapeHtml(artist.name)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${escapeHtml(artwork.medium)}</td></tr>
+          ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${escapeHtml(artwork.dimensions)}</td></tr>` : ""}
           <tr><td style="padding: 8px 0; color: #666;">Total:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()}</td></tr>
         </table>
       </div>
-      
+
       <div style="background: #f0f0f0; padding: 20px; border-radius: 8px; margin: 20px 0;">
         <h2 style="color: #1a1a2e; margin-top: 0;">Shipping Details</h2>
         <table style="width: 100%; border-collapse: collapse;">
-          <tr><td style="padding: 8px 0; color: #666;">Name:</td><td style="padding: 8px 0; font-weight: bold;">${orderData.buyerName}</td></tr>
-          <tr><td style="padding: 8px 0; color: #666;">Address:</td><td style="padding: 8px 0;">${orderData.shippingAddress}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Name:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(orderData.buyerName)}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Address:</td><td style="padding: 8px 0;">${escapeHtml(orderData.shippingAddress)}</td></tr>
         </table>
       </div>
       
@@ -163,6 +172,26 @@ export async function registerRoutes(
     });
   }
 
+  // Magic byte signatures for image validation
+  const MAGIC_BYTES: Record<string, number[][]> = {
+    "image/jpeg": [[0xFF, 0xD8, 0xFF]],
+    "image/png": [[0x89, 0x50, 0x4E, 0x47]],
+    "image/gif": [[0x47, 0x49, 0x46, 0x38]],
+    "image/webp": [[0x52, 0x49, 0x46, 0x46]], // RIFF header (WebP starts with RIFF....WEBP)
+  };
+
+  function validateMagicBytes(filePath: string, mimeType: string): boolean {
+    const signatures = MAGIC_BYTES[mimeType];
+    if (!signatures) return false;
+    const buffer = Buffer.alloc(12);
+    const fd = fs.openSync(filePath, "r");
+    fs.readSync(fd, buffer, 0, 12, 0);
+    fs.closeSync(fd);
+    return signatures.some((sig) =>
+      sig.every((byte, i) => buffer[i] === byte)
+    );
+  }
+
   function createUploadHandler(upload: multer.Multer, subdir: string) {
     return (req: any, res: any) => {
       upload.single("image")(req, res, (err: any) => {
@@ -177,6 +206,11 @@ export async function registerRoutes(
         }
         if (!req.file) {
           return res.status(400).json({ error: "No image file provided" });
+        }
+        // Validate file content via magic bytes (not just client-provided MIME)
+        if (!validateMagicBytes(req.file.path, req.file.mimetype)) {
+          fs.unlinkSync(req.file.path);
+          return res.status(400).json({ error: "File content does not match an allowed image type" });
         }
         res.json({ imageUrl: `/uploads/${subdir}/${req.file.filename}` });
       });
@@ -673,7 +707,8 @@ export async function registerRoutes(
       if (existing.artistId !== artist.id) {
         return res.status(403).json({ error: "Not authorized to edit another artist's post" });
       }
-      const post = await storage.updateBlogPost(req.params.id, req.body);
+      const data = updateBlogPostSchema.parse(req.body);
+      const post = await storage.updateBlogPost(req.params.id, data);
       res.json(post!);
     } catch (error) {
       res.status(500).json({ error: "Failed to update blog post" });
@@ -709,12 +744,16 @@ export async function registerRoutes(
       if (!currentArtist || currentArtist.id !== req.params.id) {
         return res.status(403).json({ error: "Not authorized to edit another artist's profile" });
       }
-      const artist = await storage.updateArtist(req.params.id, req.body);
+      const data = updateArtistSchema.parse(req.body);
+      const artist = await storage.updateArtist(req.params.id, data);
       if (!artist) {
         return res.status(404).json({ error: "Artist not found" });
       }
       res.json(artist);
     } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.errors[0].message });
+      }
       res.status(500).json({ error: "Failed to update artist" });
     }
   });
@@ -757,7 +796,8 @@ export async function registerRoutes(
       if (existingArtwork.artist.id !== artist.id) {
         return res.status(403).json({ error: "Not authorized to edit another artist's artwork" });
       }
-      const artwork = await storage.updateArtwork(req.params.id, req.body);
+      const data = updateArtworkSchema.parse(req.body);
+      const artwork = await storage.updateArtwork(req.params.id, data);
       if (!artwork) {
         return res.status(404).json({ error: "Artwork not found" });
       }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -21,6 +21,7 @@ export const artists = pgTable("artists", {
 });
 
 export const insertArtistSchema = createInsertSchema(artists).omit({ id: true });
+export const updateArtistSchema = insertArtistSchema.partial().omit({ userId: true });
 export type InsertArtist = z.infer<typeof insertArtistSchema>;
 export type Artist = typeof artists.$inferSelect;
 
@@ -43,6 +44,7 @@ export const artworks = pgTable("artworks", {
 });
 
 export const insertArtworkSchema = createInsertSchema(artworks).omit({ id: true });
+export const updateArtworkSchema = insertArtworkSchema.partial().omit({ artistId: true });
 export type InsertArtwork = z.infer<typeof insertArtworkSchema>;
 export type Artwork = typeof artworks.$inferSelect;
 
@@ -117,6 +119,7 @@ export const blogPosts = pgTable("blog_posts", {
 });
 
 export const insertBlogPostSchema = createInsertSchema(blogPosts).omit({ id: true, createdAt: true, updatedAt: true });
+export const updateBlogPostSchema = insertBlogPostSchema.partial().omit({ artistId: true });
 export type InsertBlogPost = z.infer<typeof insertBlogPostSchema>;
 export type BlogPost = typeof blogPosts.$inferSelect;
 

--- a/specs/issue-tracker.md
+++ b/specs/issue-tracker.md
@@ -32,7 +32,7 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 | 32 | Correct names in museum gallery | medium | bug | Open | — | Artist room names incorrect |
 | 36 | Role securitas - in CI/CD | high | devops | In Progress | — | Parent: spec at `specs/SECURITY_AGENT.md`. Sub-issue #55 done. Audit completed → issue #77 (4×P0, 6×P1, 7×P2). |
 | 73 | Upgrade Node.js 20→25 | high | bug | Open | — | Dependabot PR #57 closed (major) |
-| 77 | Security Audit — Critical findings | critical | devops | In Progress | — | Parent. All 4 P0s done. 6 P1s, 7 P2s remaining. |
+| 77 | Security Audit — Critical findings | critical | devops | In Progress | — | Parent. All 4 P0s done, all 6 P1s done. 7 P2s remaining. |
 | 74 | Upgrade react-resizable-panels 2→4 | high | bug | Open | — | Dependabot PR #68 closed (major) |
 | 75 | Upgrade recharts 2→3 | high | bug | Open | — | Dependabot PR #69 closed (major) |
 | 76 | Upgrade Vite 7→8 | high | bug | Open | — | Dependabot PR #70 closed (major) |


### PR DESCRIPTION
## Summary
Addresses all 6 P1 (fix this sprint) findings from the security audit (#77):

1. **Zod validation on PATCH endpoints** — new `updateArtworkSchema`, `updateBlogPostSchema`, `updateArtistSchema` partial schemas prevent field injection via raw `req.body`
2. **Email HTML injection** — `escapeHtml()` applied to all user-supplied values (artist name, artwork title, buyer info) in email templates
3. **Actions pinned to SHAs** — all GitHub Actions in ci.yml, deploy-production, rollback-production, doc-agent now pinned to commit SHAs
4. **Shell injection** — moved all `${{ }}` GitHub context vars to `env:` blocks, referenced as shell vars in `run:` steps
5. **Production DB migration mode** — switched from `push` to `migrate` for safer schema changes
6. **File upload magic bytes** — validates JPEG/PNG/GIF/WebP file content via magic bytes, not just client MIME header

Part of #77 (Security Audit)

## Test plan
- [x] 39 tests pass
- [x] TypeScript type check passes
- [x] ESLint: 0 errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)