### PR TITLE
Update specs to reflect P0+P1 security fixes

### DIFF
--- a/specs/architecture/OVERVIEW.md
+++ b/specs/architecture/OVERVIEW.md
@@ -1,7 +1,7 @@
 # ArtVerse — Architecture Overview
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 **Owner:** Architecture
 
 ---
@@ -119,9 +119,9 @@ All routes defined in `server/routes.ts`. Base path: `/api/`.
 ### Orders
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/api/orders` | No | List all orders |
-| POST | `/api/orders` | No | Create order (marks artwork not-for-sale, sends email) |
-| PATCH | `/api/orders/:id/status` | Yes | Transition order status (enforces state machine) |
+| GET | `/api/orders` | Yes | List orders for current user's artist profile only (ownership enforced) |
+| POST | `/api/orders` | Yes | Create order (marks artwork not-for-sale, sends email) |
+| PATCH | `/api/orders/:id/status` | Yes | Transition order status (enforces state machine + ownership) |
 
 ### Exhibitions
 | Method | Path | Auth | Description |
@@ -147,7 +147,7 @@ All routes defined in `server/routes.ts`. Base path: `/api/`.
 ### Utilities
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/api/image-proxy` | No | Proxy external images (CORS bypass, 1-day cache) |
+| GET | `/api/image-proxy` | No | Proxy external images (CORS bypass, 1-day cache, SSRF-protected) |
 
 ### Authentication
 | Method | Path | Auth | Description |
@@ -163,9 +163,9 @@ All routes defined in `server/routes.ts`. Base path: `/api/`.
 | POST | `/api/logout` | Yes | End session |
 
 ### MCP (Model Context Protocol)
-| Method | Path | Description |
-|--------|------|-------------|
-| POST/GET/DELETE | `/mcp` | Stateful MCP endpoint (session per connection) |
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST/GET/DELETE | `/mcp` | Yes | Stateful MCP endpoint (session per connection, requires authentication) |
 
 ---
 
@@ -293,7 +293,7 @@ Implemented in `server/replit_integrations/auth/`.
 
 ## 8. MCP Server
 
-Endpoint: `POST/GET/DELETE /mcp` with `mcp-session-id` header. Stateful per-session instances using Streamable HTTP transport.
+Endpoint: `POST/GET/DELETE /mcp` with `mcp-session-id` header. Stateful per-session instances using Streamable HTTP transport. **All routes require authentication** via `isAuthenticated` middleware (P0 fix — 2026-03-13).
 
 ### Resources (14)
 Data access points for AI clients: all-artists, artist-by-id, all-artworks, artworks-by-artist, artwork-by-id, all-auctions, auction-by-id, auction-bids, orders-by-artist, blog-posts, blog-posts-by-artist, artist-gallery, exhibitions.
@@ -321,6 +321,37 @@ Data access points for AI clients: all-artists, artist-by-id, all-artworks, artw
 | `blog_draft` | Draft 400-800 word blog post in artist voice |
 | `order_summary` | Analyze artist's sales data and recommend next steps |
 | `artist_bio` | Write professional 2-3 paragraph bio |
+
+---
+
+## 8b. Security Hardening (2026-03-13)
+
+The following security measures were implemented as part of the security audit (issue #77):
+
+### HTTP Security Headers (Helmet)
+Express uses `helmet` middleware to set security headers in production:
+- `Content-Security-Policy` — restricts script sources (disabled in dev for Vite HMR inline scripts)
+- `Strict-Transport-Security` (HSTS) — enforces HTTPS
+- `X-Frame-Options` — prevents clickjacking
+- `X-Content-Type-Options: nosniff` — prevents MIME sniffing
+- `Referrer-Policy` — limits referrer information
+
+### Endpoint Authorization
+All write endpoints (POST/PATCH/DELETE) for artworks, blog posts, and artist profiles enforce **ownership authorization** — the authenticated user must own the artist profile associated with the resource. Cross-artist mutations return `403 Forbidden`.
+
+Order endpoints (`GET /api/orders`, `GET /api/artists/:id/orders`) are scoped to the authenticated user's own artist profile, preventing PII exposure (buyer names, emails, addresses).
+
+### Input Validation
+All PATCH endpoints validate request bodies against Zod partial schemas (`updateArtworkSchema`, `updateBlogPostSchema`, `updateArtistSchema`) before passing data to the database layer. Invalid fields are rejected with `400 Bad Request`.
+
+### SSRF Protection
+The image proxy (`GET /api/image-proxy`) blocks requests to private/internal IP ranges (RFC 1918, loopback, link-local, cloud metadata endpoints). Redirect targets are also validated.
+
+### File Upload Hardening
+Uploaded files are validated via magic byte inspection (file signature matching) in addition to MIME type filtering. Mismatched files are rejected.
+
+### Email Template Security
+All user-supplied values in email templates (order notifications) are HTML-escaped to prevent injection of malicious HTML/scripts into emails.
 
 ---
 

--- a/specs/decisions/DECISION-LOG.md
+++ b/specs/decisions/DECISION-LOG.md
@@ -1,7 +1,7 @@
 # ArtVerse — Decision Log
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 
 Lightweight log for minor decisions that don't warrant a full ADR. For significant architectural decisions, create an ADR in `specs/architecture/ADR/`.
 
@@ -19,3 +19,11 @@ Lightweight log for minor decisions that don't warrant a full ADR. For significa
 | 2026-03-12 | Use Resend for transactional email | Simple API, good free tier, handles deliverability — replaced dead Replit connector | Architecture |
 | 2026-03-12 | Restructure specs/ into taxonomy | Per DOC-AGENT-SPEC.md — enables automated documentation validation | Architecture |
 | 2026-03-12 | Doc agent: Claude for PRs, shell script for audits | claude-code-action API doesn't support scheduled/push triggers well; shell script is reliable and free for structural checks | Architecture |
+| 2026-03-13 | Pin all GitHub Actions to commit SHAs | Mutable tags (@v3, @v6) can be moved to malicious code — SHA pinning prevents supply chain attacks on CI/CD | Architecture |
+| 2026-03-13 | Move `${{ }}` interpolation to `env:` blocks in workflows | Direct `${{ }}` in `run:` steps is vulnerable to shell injection if attacker controls the value (PR title, dispatch input) | Architecture |
+| 2026-03-13 | Add ownership authorization to all write endpoints | Auth alone isn't enough — artist A could modify artist B's data. Ownership checks enforce resource-level access control | Architecture |
+| 2026-03-13 | Add auth to MCP server endpoint | MCP exposed full CRUD with zero authentication — any HTTP client could manipulate all data | Architecture |
+| 2026-03-13 | Block private IPs in image proxy (SSRF) | Image proxy could be used to scan internal network or access cloud metadata (169.254.169.254) | Architecture |
+| 2026-03-13 | Validate file uploads via magic bytes, not just MIME header | Client-supplied MIME type is trivially spoofed — magic byte inspection verifies actual file content | Architecture |
+| 2026-03-13 | HTML-escape user values in email templates | Unescaped user input (buyer name, address) could inject malicious HTML/phishing into notification emails | Architecture |
+| 2026-03-13 | Use `DB_MIGRATION_MODE=migrate` in production | Push mode can destructively alter schema without review; migration mode requires explicit versioned SQL files committed to git | Architecture |

--- a/specs/features/authentication/SPEC.md
+++ b/specs/features/authentication/SPEC.md
@@ -1,7 +1,7 @@
 # Feature: Authentication
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 **Owner:** Architecture
 
 ## Summary
@@ -20,6 +20,8 @@ As a visitor, I want to sign in with my Google account or email/password, so tha
 - [x] Auto-creation of artist profile on first login
 - [x] Token refresh for OIDC sessions (checks `expires_at`, uses refresh token)
 - [x] `isAuthenticated` middleware protects all mutation routes
+- [x] Ownership authorization on write endpoints (artist can only modify their own resources)
+- [x] MCP endpoint requires authentication
 - [x] `GET /api/auth/config` exposes available auth methods to frontend
 - [x] Auth page at `/auth` with login/signup tabs
 
@@ -75,6 +77,24 @@ Authentication lives in `server/replit_integrations/auth/` with four files:
 - `connect-pg-simple` v10.0.0 — PostgreSQL session store
 - `bcryptjs` v3.0.3 — Password hashing (12 salt rounds)
 - `memoizee` v0.4.17 — Cache OIDC config (3600s TTL)
+
+### Endpoint Authorization (2026-03-13)
+
+Beyond `isAuthenticated` (which verifies the user is logged in), write endpoints enforce **ownership authorization**:
+
+1. The authenticated user's ID is matched to an artist profile via `getArtistByUserId()`
+2. The target resource's `artistId` is compared to the authenticated artist's ID
+3. Mismatches return `403 Forbidden`
+
+This applies to:
+- `POST/PATCH/DELETE /api/artworks` — artist can only manage their own artworks
+- `POST/PATCH/DELETE /api/blog` — artist can only manage their own blog posts
+- `PATCH /api/artists/:id` — artist can only update their own profile
+- `POST /api/orders` — requires authentication
+- `GET /api/orders`, `GET /api/artists/:id/orders` — scoped to own artist profile (prevents PII exposure)
+- `POST/GET/DELETE /mcp` — requires authentication (added P0 fix, PR #84)
+
+(P0 fixes — PRs #82, #83, #84)
 
 ## Open Questions
 

--- a/specs/features/email-login/SPEC.md
+++ b/specs/features/email-login/SPEC.md
@@ -1,7 +1,7 @@
 # Feature: Email Login
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 **Owner:** Architecture
 
 ## Summary
@@ -58,6 +58,10 @@ HTML email sent via Resend with:
 - CTA button linking to `/api/auth/verify-email?token=...`
 - Footer: "Link expires in 1 hour"
 - Styled with serif font, primary orange (#F97316) accent
+
+### Email Security
+
+All user-supplied values interpolated into email HTML templates (order notifications, magic link emails) are passed through an `escapeHtml()` function that escapes `&`, `<`, `>`, `"`, and `'` characters. This prevents HTML injection attacks where a malicious buyer name or address could inject scripts or phishing content into notification emails. (P1 fix — 2026-03-13, PR #85)
 
 ### Environment Variables
 

--- a/specs/features/image-upload/SPEC.md
+++ b/specs/features/image-upload/SPEC.md
@@ -1,7 +1,7 @@
 # Feature: Image Upload and Proxy
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 **Owner:** Architecture
 
 ## Summary
@@ -47,10 +47,21 @@ As a visitor, I want external images to load without CORS issues, so that I can 
 ### Image Proxy
 
 - Query param: `url` (external image URL)
-- Follows HTTP redirects (3xx)
+- **SSRF protection:** Before fetching, the proxy validates the target URL against a blocklist of private/internal addresses. Blocked ranges include `localhost`, `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.169.254` (cloud metadata), and `metadata.google.internal`. Requests to blocked hosts return `403 Forbidden`. (P0 fix — 2026-03-13, PR #84)
+- Follows HTTP redirects (3xx) — redirect targets are also validated against the SSRF blocklist
 - Sets response headers: `Content-Type`, `Cache-Control: public, max-age=86400`, `Access-Control-Allow-Origin: *`
 - Timeout: 10 seconds (returns 504)
 - Error handling: 502 on connection errors, forwards 4xx/5xx from remote
+
+### File Upload Validation
+
+- **MIME type:** multer `fileFilter` accepts `image/jpeg`, `image/png`, `image/webp`, `image/gif`
+- **Magic byte validation:** After upload, the first bytes of the file are checked against known image file signatures to ensure the file content matches the claimed MIME type. This prevents uploading malicious files (e.g., scripts) renamed with image extensions. Supported magic bytes:
+  - JPEG: `FF D8 FF`
+  - PNG: `89 50 4E 47`
+  - GIF: `47 49 46 38`
+  - WebP: `52 49 46 46`
+- Files that fail magic byte validation are deleted and the upload returns `400 Bad Request`. (P1 fix — 2026-03-13, PR #85)
 
 ### Database Storage
 

--- a/specs/features/mcp-server/SPEC.md
+++ b/specs/features/mcp-server/SPEC.md
@@ -1,7 +1,7 @@
 # Feature: MCP Server
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 **Owner:** Architecture
 
 ## Summary
@@ -28,6 +28,7 @@ As an AI assistant (Claude), I want to access ArtVerse data and perform operatio
 ### Transport
 
 - **Protocol:** Streamable HTTP over `POST/GET/DELETE /mcp`
+- **Authentication:** All three MCP routes (`POST`, `GET`, `DELETE /mcp`) require `isAuthenticated` middleware. Unauthenticated requests receive `401 Unauthorized`. This was added as a P0 security fix (2026-03-13, PR #84) — previously the MCP endpoint had no authentication, exposing full CRUD access to anyone.
 - **Session management:** Random UUID per session, stored in memory `Map<sessionId, {transport, server}>`
 - **Headers:** `mcp-session-id` header for subsequent requests after initialization
 - **Lifecycle:** Session created on first POST, cleaned up on DELETE or transport close

--- a/specs/issue-tracker.md
+++ b/specs/issue-tracker.md
@@ -32,7 +32,7 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 | 32 | Correct names in museum gallery | medium | bug | Open | — | Artist room names incorrect |
 | 36 | Role securitas - in CI/CD | high | devops | In Progress | — | Parent: spec at `specs/SECURITY_AGENT.md`. Sub-issue #55 done. Audit completed → issue #77 (4×P0, 6×P1, 7×P2). |
 | 73 | Upgrade Node.js 20→25 | high | bug | Open | — | Dependabot PR #57 closed (major) |
-| 77 | Security Audit — Critical findings | critical | devops | In Progress | — | Parent. All 4 P0s done, all 6 P1s done. 7 P2s remaining. |
+| 77 | Security Audit — Critical findings | critical | devops | In Progress | — | Parent. All 4 P0s done (PRs #82–#84), all 6 P1s done (PR #85). 6 P2s remaining (1 P2 was done in P1 batch). |
 | 74 | Upgrade react-resizable-panels 2→4 | high | bug | Open | — | Dependabot PR #68 closed (major) |
 | 75 | Upgrade recharts 2→3 | high | bug | Open | — | Dependabot PR #69 closed (major) |
 | 76 | Upgrade Vite 7→8 | high | bug | Open | — | Dependabot PR #70 closed (major) |
@@ -85,3 +85,5 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 | 2026-03-12 | Added #73, #74, #75, #76 (major dep upgrades from closed Dependabot PRs). Uploaded security agent spec. |
 | 2026-03-12 | Security audit completed. Created #77 (critical — 4 P0s, 6 P1s, 7 P2s). Updated #36 status. |
 | 2026-03-13 | All 4 P0s completed: #78 (PR #82), #79 (PR #83), #80+#81 (PR #84). Deployed to staging. |
+| 2026-03-13 | All 6 P1s completed (PR #85): Helmet headers, email HTML escaping, Zod PATCH validation, magic byte upload validation, Actions SHA pinning, shell injection fixes, DB_MIGRATION_MODE→migrate. Deployed to production (`f80196af`). 6 P2s remaining. |
+| 2026-03-13 | Added #86 (update specs to reflect security fixes). Updated 8 spec files: CI-CD, OVERVIEW, DEPLOYMENT, DECISION-LOG, authentication, email-login, image-upload, mcp-server. |

--- a/specs/workflows/CI-CD.md
+++ b/specs/workflows/CI-CD.md
@@ -1,7 +1,7 @@
 # ArtVerse — CI/CD Pipeline Specification
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 
 ---
 
@@ -572,7 +572,63 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
 
 ---
 
-## 6. Revision Log
+## 6. Security Hardening (2026-03-13)
+
+### 6.1 GitHub Actions Hardening
+
+All third-party actions across all workflow files are **pinned to commit SHAs** (not mutable version tags like `@v3` or `@v6`). This prevents supply chain attacks where a compromised action tag is silently redirected to malicious code.
+
+| Action | Pinned SHA |
+|--------|-----------|
+| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
+| `actions/setup-node` | `53b83947a5a98c8d113130e565377fae1a50d02f` |
+| `docker/setup-buildx-action` | `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` |
+| `docker/login-action` | `c94ce9fb468520275223c153574b00df6fe4bcc9` |
+| `docker/build-push-action` | `d08e5c354a6adb9ed34480a06d141179aa583294` |
+| `appleboy/scp-action` | `ff85246acaad7bdce478db94a363cd2bf7c90345` |
+| `appleboy/ssh-action` | `0ff4204d59e8e51228ff73bce53f80d53301dee2` |
+| `anthropics/claude-code-action` | `5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5` |
+
+**Applies to:** `ci.yml`, `deploy-production.yml`, `rollback-production.yml`, `doc-agent.yml`
+
+### 6.2 Shell Injection Prevention
+
+All GitHub context variables (`${{ github.sha }}`, `${{ github.actor }}`, `${{ github.event.inputs.* }}`, `${{ steps.*.outputs.* }}`) are moved from inline `${{ }}` interpolation in `run:` blocks to `env:` blocks. Shell scripts reference them as `$ENV_VAR` instead. This prevents shell injection if an attacker can control the input value (e.g., PR title, workflow dispatch input).
+
+For SSH deploy steps, variables are passed via `appleboy/ssh-action`'s `envs:` parameter rather than embedded in the script string.
+
+### 6.3 Explicit Permissions Blocks
+
+All workflow files now declare explicit `permissions:` blocks at the top level and/or job level, following the principle of least privilege:
+
+| Workflow | Permissions |
+|----------|------------|
+| `ci.yml` | `contents: read`, `packages: write` (Docker job only) |
+| `deploy-production.yml` | `contents: read` |
+| `rollback-production.yml` | `contents: read` |
+| `doc-agent.yml` | `contents: read`, `pull-requests: write` (enforce), `issues: write` (audit) |
+
+### 6.4 Security Scanning Pipeline
+
+`.github/workflows/security.yml` runs 7 security scanning jobs on every push and PR:
+
+| Job | Tool | Purpose |
+|-----|------|---------|
+| `gitleaks` | Gitleaks | Scan git history for committed secrets |
+| `npm-audit` | npm audit | Check for known vulnerabilities in dependencies |
+| `semgrep` | Semgrep | Static analysis for security anti-patterns |
+| `hadolint` | Hadolint | Dockerfile best practice linting |
+| `trivy` | Trivy | Container image vulnerability scanning |
+| `custom-checks` | `.github/scripts/security-checks.sh` | ArtVerse-specific security checks |
+| `gate` | — | Aggregation gate — fails if any upstream job fails |
+
+All actions in `security.yml` are pinned to commit SHAs. The pipeline has explicit `permissions: contents: read` and runs on `push` and `pull_request` triggers.
+
+**Spec:** `specs/SECURITY_AGENT.md` defines the audit scope and methodology.
+
+---
+
+## 7. Revision Log
 
 | Date | Change |
 |------|--------|
@@ -590,3 +646,4 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
 | 2026-03-11 | Step 11 done — Telegram notifications on all deploy/rollback workflows. Requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets. |
 | 2026-03-11 | Replaced old pipeline diagram with 5 comprehensive diagrams: development workflow, CI/CD pipeline, production deploy, rollback, and infrastructure overview. Updated Telegram secrets status to Set. |
 | 2026-03-11 | Updated Telegram notification format: added @racu8_bot header, repo name, environment URLs. Removed "View run" link. (Issue #26, PR #27) |
+| 2026-03-13 | Added Section 6: Security hardening — SHA-pinned actions, shell injection prevention, explicit permissions blocks, security scanning pipeline documentation. (Issue #77, PR #85) |

--- a/specs/workflows/DEPLOYMENT.md
+++ b/specs/workflows/DEPLOYMENT.md
@@ -1,7 +1,7 @@
 # ArtVerse — Deployment Procedures
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 
 ---
 
@@ -79,6 +79,10 @@ docker compose up -d --remove-orphans
 ```
 
 **Note:** Rollback only affects the app image. If a database migration already ran, you may need to restore from a DB backup for destructive schema changes.
+
+### Database migration mode (security)
+
+Production uses `DB_MIGRATION_MODE=migrate` in `docker-compose.yml`. This means the app runs `drizzle-kit migrate` on startup, applying only versioned SQL files from the `migrations/` directory. This is a deliberate security choice — the alternative (`push` mode, used in staging) can destructively alter the schema without review, potentially dropping columns or tables. Migration mode ensures all schema changes are explicit, versioned, code-reviewed SQL files committed to git. (P1 fix — 2026-03-13, PR #85)
 
 ### Database backup (before destructive changes)
 


### PR DESCRIPTION
## Summary
- Updates 8 spec files that were stale after the security audit fixes (PRs #82–#85)
- Documents all P0+P1 security hardening in the appropriate specs
- Adds 8 security decisions to DECISION-LOG.md

## Files Updated
| File | What was added |
|------|---------------|
| `specs/workflows/CI-CD.md` | Security pipeline (security.yml), SHA pinning, shell injection prevention, permissions blocks |
| `specs/architecture/OVERVIEW.md` | Section 8b (security hardening), endpoint auth updates, MCP auth, SSRF note |
| `specs/workflows/DEPLOYMENT.md` | DB_MIGRATION_MODE=migrate security rationale |
| `specs/decisions/DECISION-LOG.md` | 8 security decisions from the audit |
| `specs/features/authentication/SPEC.md` | Ownership authorization, endpoint access control |
| `specs/features/email-login/SPEC.md` | HTML escaping in email templates |
| `specs/features/image-upload/SPEC.md` | SSRF protection, magic byte validation |
| `specs/features/mcp-server/SPEC.md` | Authentication requirement |

Closes #86

## Test plan
- [ ] Verify all spec files render correctly on GitHub
- [ ] Confirm no broken internal links between specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)