### PR TITLE
Fix Resend sender address for magic link emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,5 @@ SEED_DB=false
 
 # Email (Resend) — required for magic link signup
 RESEND_API_KEY=re_xxxxx
-# Optional: custom from address (must be verified in Resend dashboard)
-# RESEND_FROM_EMAIL=ArtVerse <noreply@yourdomain.com>
+# Sender address (must be verified in Resend dashboard)
+RESEND_FROM_EMAIL=ArtVerse <gallery@idata.ro>

--- a/server/email.ts
+++ b/server/email.ts
@@ -14,7 +14,7 @@ export function getResendClient(): Resend {
 }
 
 export function getFromEmail(): string {
-  return process.env.RESEND_FROM_EMAIL || "ArtVerse <onboarding@resend.dev>";
+  return process.env.RESEND_FROM_EMAIL || "ArtVerse <gallery@idata.ro>";
 }
 
 export async function sendMagicLinkEmail(


### PR DESCRIPTION
## Summary
- Changed default email sender from `onboarding@resend.dev` (Resend sandbox) to `gallery@idata.ro` (verified domain)
- Resend sandbox only delivers to the account owner's email — this fix allows all users to receive magic link and order emails
- Updated `.env.example` to reflect the correct sender address

Closes #37

## Test plan
- [x] Tested locally: magic link email delivered to non-owner email address
- [ ] CI passes (types, tests, build)
- [ ] Verify on staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)