### PR TITLE
Replace profile picture URL input with file upload

### DIFF
--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -145,6 +145,7 @@ export default function ArtistDashboard() {
 
   const [artworkUploading, setArtworkUploading] = useState(false);
   const [blogCoverUploading, setBlogCoverUploading] = useState(false);
+  const [avatarUploading, setAvatarUploading] = useState(false);
 
   const handleImageUpload = async (
     file: File,
@@ -1163,7 +1164,22 @@ export default function ArtistDashboard() {
                     </AvatarFallback>
                   </Avatar>
                   {profileEditing && (
-                    <span className="text-xs text-muted-foreground">Update URL below</span>
+                    <FileUploadField
+                      id="profile-avatar"
+                      label=""
+                      uploading={avatarUploading}
+                      imageUrl=""
+                      previewAlt="Profile picture"
+                      onFileSelect={(file) =>
+                        handleImageUpload(
+                          file,
+                          "/api/upload/avatar",
+                          (imageUrl) => setProfileForm({ ...profileForm, avatarUrl: imageUrl }),
+                          setAvatarUploading,
+                        )
+                      }
+                      testId="input-profile-avatar"
+                    />
                   )}
                 </div>
                 {!profileEditing ? (
@@ -1213,16 +1229,6 @@ export default function ArtistDashboard() {
                         onChange={(e) => setProfileForm({ ...profileForm, name: e.target.value })}
                         placeholder="Your name"
                         data-testid="input-profile-name"
-                      />
-                    </div>
-                    <div className="grid gap-2">
-                      <Label htmlFor="profile-avatar">Profile Picture URL</Label>
-                      <Input
-                        id="profile-avatar"
-                        value={profileForm.avatarUrl}
-                        onChange={(e) => setProfileForm({ ...profileForm, avatarUrl: e.target.value })}
-                        placeholder="https://..."
-                        data-testid="input-profile-avatar"
                       />
                     </div>
                     <div className="grid grid-cols-2 gap-4">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -220,8 +220,10 @@ export async function registerRoutes(
   // Image upload endpoints
   const artworkUpload = createUploadMiddleware("artworks");
   const blogCoverUpload = createUploadMiddleware("blog-covers");
+  const avatarUpload = createUploadMiddleware("avatars");
   app.post("/api/upload/artwork", isAuthenticated, createUploadHandler(artworkUpload, "artworks"));
   app.post("/api/upload/blog-cover", isAuthenticated, createUploadHandler(blogCoverUpload, "blog-covers"));
+  app.post("/api/upload/avatar", isAuthenticated, createUploadHandler(avatarUpload, "avatars"));
 
   // SSRF-safe image proxy: block private/internal IP ranges
   function isPrivateHostname(hostname: string): boolean {


### PR DESCRIPTION
## Summary
- Replaces the text URL input for profile pictures with a proper file upload field
- Adds `POST /api/upload/avatar` endpoint (stores in `uploads/avatars/`, same security as artwork/blog uploads)
- Reuses existing `FileUploadField` component and `handleImageUpload` handler

Closes #12

## Test plan
- [ ] Log in and go to Artist Dashboard
- [ ] Click "Edit Profile" — file upload input should appear below the avatar
- [ ] Upload a JPEG/PNG/WebP/GIF — avatar should update immediately
- [ ] Save profile — avatar should persist after page reload
- [ ] Verify files are stored in `uploads/avatars/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)