### PR TITLE
Fix staging crash: add avatars upload dir to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=build /app/shared ./shared
 COPY --from=build /app/drizzle.config.ts ./
 COPY --from=build /app/migrations ./migrations
 COPY --from=build /app/docker-entrypoint.sh ./
-RUN chmod +x docker-entrypoint.sh && mkdir -p /app/uploads/artworks /app/uploads/blog-covers
+RUN chmod +x docker-entrypoint.sh && mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars
 RUN addgroup --system appgroup && adduser --system --home /home/appuser --ingroup appgroup appuser \
     && chown -R appuser:appgroup /app
 USER appuser


### PR DESCRIPTION
## Summary
- Adds `/app/uploads/avatars` to the `mkdir` command in Dockerfile
- The app runs as non-root `appuser` and can't create directories at runtime
- This was missed in PR #91 and caused staging to crash

## Test plan
- [ ] Staging deploys successfully after merge
- [ ] Avatar upload works on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)