### PR TITLE
Fix upload dirs: create in entrypoint for Docker volumes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Ensure upload subdirectories exist (volume mount may lack new ones)
+mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars
+
 if [ "$DB_MIGRATION_MODE" = "migrate" ]; then
   echo "Running database migrations..."
   npx drizzle-kit migrate


### PR DESCRIPTION
## Summary
- Moves upload subdirectory creation from Dockerfile to `docker-entrypoint.sh`
- The `uploads` volume mount overrides the image filesystem, so `mkdir` in the Dockerfile has no effect on existing deployments
- The entrypoint now runs `mkdir -p` for all upload subdirs at container startup

Fixes the staging crash from PR #91 / #92.

## Test plan
- [ ] Staging deploys and starts successfully
- [ ] Avatar upload works on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)