### PR TITLE
Fix Docker volume permissions for upload directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,8 @@ jobs:
             cd ~/app
             docker pull ghcr.io/ilv78/art-world-hub:$DEPLOY_SHA
             sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$DEPLOY_SHA/" .env || echo "IMAGE_TAG=$DEPLOY_SHA" >> .env
+            # Ensure upload subdirs exist on the Docker volume (new subdirs may be missing)
+            docker compose run --rm --no-deps --user root --entrypoint sh app -c "mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars && chown -R appuser:appgroup /app/uploads"
             docker compose up -d --remove-orphans
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,6 +52,8 @@ jobs:
             fi
             docker pull ghcr.io/ilv78/art-world-hub:$IMAGE_TAG
             sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env || echo "IMAGE_TAG=$IMAGE_TAG" >> .env
+            # Ensure upload subdirs exist on the Docker volume (new subdirs may be missing)
+            docker compose run --rm --no-deps --user root --entrypoint sh app -c "mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars && chown -R appuser:appgroup /app/uploads"
             docker compose up -d --remove-orphans
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ COPY --from=build /app/drizzle.config.ts ./
 COPY --from=build /app/migrations ./migrations
 COPY --from=build /app/docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh && mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars
-RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
 RUN addgroup --system appgroup && adduser --system --home /home/appuser --ingroup appgroup appuser \
     && chown -R appuser:appgroup /app
+USER appuser
 EXPOSE 5000
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node", "dist/index.cjs"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,19 +1,14 @@
 #!/bin/sh
 set -e
 
-# Ensure upload subdirs exist and are writable by appuser
-# (Docker volume mount may not have newly added subdirectories)
-mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars
-chown -R appuser:appgroup /app/uploads
-
 if [ "$DB_MIGRATION_MODE" = "migrate" ]; then
   echo "Running database migrations..."
-  gosu appuser npx drizzle-kit migrate
+  npx drizzle-kit migrate
   echo "Migrations complete."
 else
   echo "Pushing database schema..."
-  gosu appuser npx drizzle-kit push --force
+  npx drizzle-kit push --force
   echo "Schema push complete."
 fi
 
-exec gosu appuser "$@"
+exec "$@"


### PR DESCRIPTION
## Summary
- Creates missing upload subdirs on Docker volumes via `docker compose run --user root` before starting the container
- Applied to both staging (`ci.yml`) and production (`deploy-production.yml`) deploy steps
- Keeps `USER appuser` in Dockerfile (no security model change)

Fixes staging crash from avatar upload feature (#12).

## Test plan
- [ ] CI passes (hadolint, Semgrep, tests, build)
- [ ] Staging deploys and starts successfully
- [ ] Avatar upload works on staging