### PR TITLE
Add release management system (closes #35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
           tags: |
             ${{ steps.image.outputs.name }}:latest
             ${{ steps.image.outputs.name }}:${{ github.sha }}
+            ${{ steps.image.outputs.name }}:${{ github.run_number }}
+          build-args: |
+            APP_VERSION=${{ github.run_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -110,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout
@@ -144,7 +147,7 @@ jobs:
             docker compose up -d --remove-orphans
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do
-              if docker compose exec -T app node -e "fetch('http://localhost:5000/api/artists').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
+              if docker compose exec -T app node -e "fetch('http://localhost:5000/health').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
                 echo "Staging is healthy after ${i}s"
                 exit 0
               fi
@@ -153,6 +156,26 @@ jobs:
             echo "Health check failed"
             docker compose logs --tail=50 app
             exit 1
+
+      - name: Smoke test — health check
+        run: |
+          echo "Waiting for container to boot..."
+          sleep 15
+          HEALTH_URL="${{ secrets.STAGING_URL }}/health"
+          HTTP_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "$HEALTH_URL")
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "Health check failed — HTTP $HTTP_STATUS"
+            exit 1
+          fi
+          echo "Health check passed — staging deployment verified"
+
+      - name: Tag release in git
+        if: success()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "release-${{ github.run_number }}" "${{ github.sha }}"
+          git push origin "release-${{ github.run_number }}"
 
       - name: Notify Telegram
         if: always()
@@ -163,6 +186,7 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
           DEPLOY_SHA: ${{ github.sha }}
           TRIGGERED_BY: ${{ github.actor }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
           if [ "$DEPLOY_STATUS" = "success" ]; then EMOJI="✅"; else EMOJI="❌"; fi
@@ -173,4 +197,5 @@ jobs:
           ${EMOJI} <b>Staging deployment: ${DEPLOY_STATUS}</b> [${REPO_NAME}]
           Staging address: https://staging.artverse.idata.ro
           Tag: <code>${DEPLOY_SHA}</code>
+          Release: <code>release-${RUN_NUMBER}</code>
           By: ${TRIGGERED_BY}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Image tag to deploy (commit SHA or 'latest')"
+        description: "Image tag to deploy (commit SHA, run_number, or 'latest')"
         required: true
         default: "latest"
 
@@ -57,13 +57,56 @@ jobs:
             docker compose up -d --remove-orphans
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do
-              if docker compose exec -T app node -e "fetch('http://localhost:5000/api/artists').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
+              if docker compose exec -T app node -e "fetch('http://localhost:5000/health').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
                 echo "Production is healthy after ${i}s"
                 exit 0
               fi
               sleep 2
             done
             echo "Health check failed"
+            docker compose logs --tail=50 app
+            exit 1
+
+      - name: Smoke test — health check
+        run: |
+          echo "Waiting for container to boot..."
+          sleep 15
+          HEALTH_URL="${{ secrets.PRODUCTION_URL }}/health"
+          HTTP_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "$HEALTH_URL")
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "Health check failed — HTTP $HTTP_STATUS"
+            echo "Triggering rollback..."
+            exit 1
+          fi
+          echo "Health check passed — production deployment verified"
+
+      - name: Rollback on failure
+        if: failure()
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: production
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd ~/app
+            if [ ! -f .previous_image_tag ]; then
+              echo "ERROR: No previous image tag found — cannot rollback"
+              exit 1
+            fi
+            ROLLBACK_TAG=$(cat .previous_image_tag)
+            echo "Rolling back to: $ROLLBACK_TAG"
+            docker pull ghcr.io/ilv78/art-world-hub:$ROLLBACK_TAG
+            sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$ROLLBACK_TAG/" .env
+            docker compose up -d --remove-orphans
+            echo "Waiting for rollback to be healthy..."
+            for i in $(seq 1 60); do
+              if docker compose exec -T app node -e "fetch('http://localhost:5000/health').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
+                echo "Rollback healthy after ${i}s"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "Rollback health check failed"
             docker compose logs --tail=50 app
             exit 1
 

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -57,7 +57,7 @@ jobs:
 
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do
-              if docker compose exec -T app node -e "fetch('http://localhost:5000/api/artists').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
+              if docker compose exec -T app node -e "fetch('http://localhost:5000/health').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
                 echo "Production rolled back successfully after ${i}s"
                 exit 0
               fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to ArtVerse will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Releases are tagged as `release-{run_number}` in git and correspond to Docker image tags of the same number.
+
+## [Unreleased]
+
+### Added
+- Release management system: image tagging, health checks, smoke tests, git release tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN npm run build
 FROM node:20-bookworm-slim AS run
 WORKDIR /app
 ENV NODE_ENV=production
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
 COPY --from=build /app/package.json /app/package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts
 COPY --from=build /app/dist ./dist

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,7 @@ import { serveStatic } from "./static";
 import { createServer } from "http";
 import { seedDatabase } from "./seed";
 import { registerMcpRoutes } from "./mcp";
+import healthRouter from "./routes/health";
 
 const app = express();
 const httpServer = createServer(app);
@@ -37,6 +38,9 @@ app.use(
 );
 
 app.use(express.urlencoded({ extended: false }));
+
+// Health check endpoint (registered before auth/session middleware)
+app.use("/", healthRouter);
 
 export function log(message: string, source = "express") {
   const formattedTime = new Date().toLocaleTimeString("en-US", {

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import { sql } from "drizzle-orm";
+import { db } from "../db";
+
+const router = Router();
+
+router.get("/health", async (_req, res) => {
+  try {
+    await db.execute(sql`SELECT 1`);
+    res.status(200).json({
+      status: "ok",
+      version: process.env.APP_VERSION ?? "unknown",
+      timestamp: new Date().toISOString(),
+    });
+  } catch {
+    res.status(503).json({
+      status: "error",
+      message: "Database unreachable",
+      timestamp: new Date().toISOString(),
+    });
+  }
+});
+
+export default router;

--- a/specs/features/release-management/SPEC.md
+++ b/specs/features/release-management/SPEC.md
@@ -1,0 +1,64 @@
+# Release Management — Feature Spec
+
+## Overview
+
+Structured release management system for ArtVerse that adds Docker image traceability, health-gated deploys, automated rollback, and git release identity.
+
+## Components
+
+### 1. Docker Image Tagging
+
+Every image pushed to GHCR gets three tags:
+- `latest` — always points to most recent build
+- `{commit_sha}` — full git traceability
+- `{run_number}` — human-readable monotonic integer for rollbacks
+
+### 2. Health Check Endpoint
+
+**Route:** `GET /health`
+
+- Returns `200 { status: "ok", version, timestamp }` when DB is reachable
+- Returns `503 { status: "error", message, timestamp }` when DB is unreachable
+- Uses Drizzle ORM `db.execute(sql\`SELECT 1\`)` for lightweight DB probe
+- `APP_VERSION` env var injected via Docker build arg (`github.run_number`)
+
+**Files:**
+- `server/routes/health.ts` — Express router
+- `server/index.ts` — registered before auth/session middleware
+
+### 3. Post-Deploy Smoke Test
+
+External HTTP check from GitHub Actions runner after deploy completes:
+- Staging: hits `${{ secrets.STAGING_URL }}/health`
+- Production: hits `${{ secrets.PRODUCTION_URL }}/health`
+- Fails the job if HTTP status != 200
+
+### 4. Automated Rollback (Production)
+
+Production deploy workflow (`deploy-production.yml`) has a rollback step with `if: failure()` that:
+- Reads `.previous_image_tag` from the VPS
+- Pulls and deploys the previous image
+- Verifies health after rollback
+
+### 5. Git Release Tags
+
+On successful staging deploy, the CI creates a git tag `release-{run_number}` pointing at the deployed commit SHA. This aligns with the Docker image tag for the same build.
+
+### 6. CHANGELOG.md
+
+Root-level changelog following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. `[Unreleased]` section updated per feature branch; moved to dated release section before merging to main.
+
+## Required Secrets
+
+- `STAGING_URL` — e.g. `https://staging.artverse.idata.ro`
+- `PRODUCTION_URL` — e.g. `https://artverse.idata.ro`
+
+## Files Changed
+
+- `.github/workflows/ci.yml` — image tagging, smoke test, release tag, updated health check
+- `.github/workflows/deploy-production.yml` — smoke test, rollback step, updated health check
+- `.github/workflows/rollback-production.yml` — updated health check to `/health`
+- `server/routes/health.ts` — new health endpoint
+- `server/index.ts` — health router registration
+- `Dockerfile` — `APP_VERSION` build arg
+- `CHANGELOG.md` — new file

--- a/specs/issue-tracker.md
+++ b/specs/issue-tracker.md
@@ -29,6 +29,7 @@ This ensures traceability, keeps the team aligned, and prevents work from gettin
 | 8 | Create admin section | high | feature | Open | — | Admin panel for platform management |
 | 14 | Multiple gallery templates | low | enhancement | Open | — | Support different gallery room layouts |
 | 32 | Correct names in museum gallery | medium | bug | Open | — | Artist room names incorrect |
+| 35 | Release workflow | medium | enhancement | In Progress | `feature/issue-35-release-management` | Release management: image tagging, health endpoint, smoke tests, rollback, git release tags |
 | 36 | Role securitas - in CI/CD | high | devops | In Progress | — | Parent: spec at `specs/SECURITY_AGENT.md`. Sub-issue #55 done. Audit completed → issue #77 (4×P0, 6×P1, 7×P2). |
 | 73 | Upgrade Node.js 20→25 | high | bug | Open | — | Dependabot PR #57 closed (major) |
 | 77 | Security Audit — Critical findings | critical | devops | In Progress | — | Parent. All 4 P0s done (PRs #82–#84), all 6 P1s done (PR #85). 6 P2s remaining (1 P2 was done in P1 batch). |

--- a/specs/workflows/CI-CD.md
+++ b/specs/workflows/CI-CD.md
@@ -34,7 +34,7 @@ Single unified workflow with two jobs. Triggers on every push (all branches) and
 | Checkout | Clones the repo |
 | Setup Docker Buildx | Enables advanced Docker builds |
 | Login to GHCR | Authenticates to GitHub Container Registry |
-| Build & push image | Multi-stage Docker build, pushes `latest` + `sha` tags |
+| Build & push image | Multi-stage Docker build, pushes `latest` + `sha` + `run_number` tags, passes `APP_VERSION` build arg |
 
 - **Gated on CI** — `needs: ci`, only runs if all CI checks pass
 - **Only on main push** — `if: github.ref == 'refs/heads/main' && github.event_name == 'push'`
@@ -374,6 +374,9 @@ By: username
 | `TELEGRAM_BOT_TOKEN` | Set | Deploy notifications | Telegram bot token from @BotFather |
 | `TELEGRAM_CHAT_ID` | Set | Deploy notifications | Telegram chat ID for notifications |
 
+| `STAGING_URL` | Needs setup | Staging smoke test | Full staging URL (`https://staging.artverse.idata.ro`) |
+| `PRODUCTION_URL` | Needs setup | Production smoke test | Full production URL (`https://artverse.idata.ro`) |
+
 DB passwords and session secrets are stored in `.env` files on the VPS (not in GitHub Secrets), since the docker-compose files read them locally.
 
 ---
@@ -466,6 +469,7 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
                │  Push to GHCR:           │
                │    :latest               │
                │    :<commit-sha>         │
+               │    :<run-number>         │
                └──────────┬───────────────┘
                           │
                           │ needs: docker job
@@ -477,6 +481,8 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
                │  docker pull <sha>       │
                │  docker compose up -d    │
                │  Health check (2 min)    │
+               │  Smoke test (external)   │
+               │  Git tag release-N       │
                │  📱 Telegram notify      │
                └──────────────────────────┘
 ```
@@ -497,6 +503,8 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
                │  docker compose up -d    │
                │  DB migrate (not push)   │
                │  Health check (2 min)    │
+               │  Smoke test (external)   │
+               │  Rollback (if: failure)  │
                │  📱 Telegram notify      │
                └──────────────────────────┘
 ```
@@ -538,6 +546,7 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
                     │  art-world-hub      │
                     │    :latest          │
                     │    :<sha>           │
+                    │    :<run-number>    │
                     └────────┬────────────┘
                              │ docker pull
                     ┌────────┴────────────┐
@@ -584,7 +593,7 @@ All third-party actions across all workflow files are **pinned to commit SHAs** 
 | `actions/setup-node` | `53b83947a5a98c8d113130e565377fae1a50d02f` |
 | `docker/setup-buildx-action` | `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` |
 | `docker/login-action` | `c94ce9fb468520275223c153574b00df6fe4bcc9` |
-| `docker/build-push-action` | `d08e5c354a6adb9ed34480a06d141179aa583294` |
+| `docker/build-push-action` | `d08e5c354a6adb9ed34480a06d141179aa583294` (+ `build-args: APP_VERSION`) |
 | `appleboy/scp-action` | `ff85246acaad7bdce478db94a363cd2bf7c90345` |
 | `appleboy/ssh-action` | `0ff4204d59e8e51228ff73bce53f80d53301dee2` |
 | `anthropics/claude-code-action` | `5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5` |
@@ -603,7 +612,7 @@ All workflow files now declare explicit `permissions:` blocks at the top level a
 
 | Workflow | Permissions |
 |----------|------------|
-| `ci.yml` | `contents: read`, `packages: write` (Docker job only) |
+| `ci.yml` | `contents: read` (CI), `packages: write` (Docker), `contents: write` (staging deploy — for git release tags) |
 | `deploy-production.yml` | `contents: read` |
 | `rollback-production.yml` | `contents: read` |
 | `doc-agent.yml` | `contents: read`, `pull-requests: write` (enforce), `issues: write` (audit) |
@@ -663,3 +672,4 @@ Commits and pushes directly to `main`. Skips issues labeled `docs-audit` (automa
 | 2026-03-11 | Updated Telegram notification format: added @racu8_bot header, repo name, environment URLs. Removed "View run" link. (Issue #26, PR #27) |
 | 2026-03-13 | Added Section 6: Security hardening — SHA-pinned actions, shell injection prevention, explicit permissions blocks, security scanning pipeline documentation. (Issue #77, PR #85) |
 | 2026-03-13 | Added Section 6.5: Issue Tracker Auto-Update workflow — auto-updates issue-tracker.md and creates bug docs on issue close. (Issue #89) |
+| 2026-03-13 | Release management (Issue #35): 3-tag Docker images (latest+sha+run_number), `/health` endpoint, APP_VERSION build arg, post-deploy smoke tests, production auto-rollback on failure, git release tags (`release-N`), CHANGELOG.md. Added `STAGING_URL` and `PRODUCTION_URL` to secrets inventory. |


### PR DESCRIPTION
## Summary
- **3-tag Docker images** (`latest`, `sha`, `run_number`) for rollback traceability
- **Health endpoint** (`GET /health`) with DB connectivity check and `APP_VERSION` env var
- **Post-deploy smoke tests** for staging and production (external HTTP check via `STAGING_URL`/`PRODUCTION_URL` secrets)
- **Auto-rollback** on production deploy failure (`if: failure()`)
- **Git release tags** (`release-N`) created on successful staging deploy
- **CHANGELOG.md** with Keep a Changelog format
- Updated all internal health checks from `/api/artists` to `/health`

## Required Setup
Add two GitHub repository secrets before merging:
- `STAGING_URL` = `https://staging.artverse.idata.ro`
- `PRODUCTION_URL` = `https://artverse.idata.ro`

## Files Changed
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | 3rd image tag, `APP_VERSION` build arg, smoke test, release tag, `contents: write` |
| `.github/workflows/deploy-production.yml` | Smoke test, rollback step (`if: failure()`), health check → `/health` |
| `.github/workflows/rollback-production.yml` | Health check → `/health` |
| `Dockerfile` | `ARG/ENV APP_VERSION` |
| `server/routes/health.ts` | New health endpoint |
| `server/index.ts` | Health router registration |
| `CHANGELOG.md` | New file |
| `specs/` | Feature spec, CI-CD spec update, issue tracker update |

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run check` — passes
- [x] `npm test` — 39/39 pass
- [x] `npm run build` — succeeds
- [x] `curl http://localhost:5000/health` returns `{"status":"ok","version":"unknown","timestamp":"..."}`
- [ ] After merge: verify `STAGING_URL` and `PRODUCTION_URL` secrets are set
- [ ] After merge: verify staging deploy creates `release-N` git tag
- [ ] After merge: verify Telegram notification includes release number

🤖 Generated with [Claude Code](https://claude.com/claude-code)