### PR TITLE
Add pre-push hook to block direct pushes to main (closes #101)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Block direct pushes to main.
+# All changes to main must go through a pull request.
+# See: docs/postmortems/2026-03-13-issue-8-direct-push-to-main.md
+
+remote="$1"
+
+while read local_ref local_sha remote_ref remote_sha; do
+  if echo "$remote_ref" | grep -qE "refs/heads/main$"; then
+    echo ""
+    echo "ERROR: Direct push to 'main' is blocked."
+    echo ""
+    echo "  Use a feature branch and pull request instead:"
+    echo "    git checkout -b feature/issue-N-description"
+    echo "    git push -u origin feature/issue-N-description"
+    echo "    gh pr create"
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,7 @@
         "esbuild": "^0.25.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "husky": "^9.1.7",
         "postcss": "^8.5.8",
         "supertest": "^7.2.2",
         "tailwindcss": "^3.4.17",
@@ -9662,6 +9663,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "db:push": "drizzle-kit push",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "prepare": "husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -56,8 +57,8 @@
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
     "dotenv": "^17.3.1",
-    "drizzle-orm": "^0.39.3",
     "drizzle-kit": "^0.31.9",
+    "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
     "express": "^5.0.1",
@@ -117,6 +118,7 @@
     "esbuild": "^0.25.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "husky": "^9.1.7",
     "postcss": "^8.5.8",
     "supertest": "^7.2.2",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
## Summary
- Install Husky for git hook management (auto-installs on `npm install` via `prepare` script)
- Add pre-push hook that blocks any push to `main` with a clear error message
- Feature branch pushes are unaffected — no local check/test overhead

This is the client-side companion to branch protection (#100). Together they provide defense in depth: the hook gives immediate local feedback, branch protection enforces server-side.

## Test plan
- [x] Hook blocks push to main (tested via stdin simulation)
- [x] Hook allows push to feature branches (tested via stdin simulation)
- [x] TypeScript type check passes
- [x] 39/39 tests pass
- [x] Production build succeeds
- [ ] Verify `npm install` on fresh clone auto-installs the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)