### PR TITLE
Fix postmortem issue references to use full markdown links

### DIFF
--- a/docs/postmortems/2026-03-13-issue-8-direct-push-to-main.md
+++ b/docs/postmortems/2026-03-13-issue-8-direct-push-to-main.md
@@ -204,12 +204,12 @@ N/A — no security incident.
 
 | # | Action Item | Type | Priority | Owner | Issue |
 |---|-------------|------|----------|-------|-------|
-| 1 | Enable GitHub branch protection on `main` requiring PR reviews and passing CI before merge — evaluate making repo public or upgrading to Pro | prevent | P1 | [project lead] | #100 |
-| 2 | Add pre-push git hook that runs `npm run check` and `npm test` before allowing push to any branch, with explicit block on direct pushes to `main` | prevent | P1 | [project lead] | #101 |
-| 3 | Add AI agent verification step: before any `git push`, agent must run `git branch --show-current` and abort if on `main` — reinforced in agent memory | prevent | P0 | [project lead] | #97 (done) |
-| 4 | Clean up `main` branch history — decide whether to squash the push+revert commits or leave as audit trail | repair | P2 | [project lead] | #97 |
-| 5 | Create proper PR from `feature/issue-8-admin-section` with code review and actual test cases for admin functionality | repair | P1 | [project lead] | #8 |
-| 6 | Document this incident as the first entry in the postmortem index at `docs/postmortems/README.md` | document | P2 | [project lead] | #102 |
+| 1 | Enable GitHub branch protection on `main` requiring PR reviews and passing CI before merge — evaluate making repo public or upgrading to Pro | prevent | P1 | [project lead] | [#100](https://github.com/ilv78/Art-World-Hub/issues/100) |
+| 2 | Add pre-push git hook that runs `npm run check` and `npm test` before allowing push to any branch, with explicit block on direct pushes to `main` | prevent | P1 | [project lead] | [#101](https://github.com/ilv78/Art-World-Hub/issues/101) |
+| 3 | Add AI agent verification step: before any `git push`, agent must run `git branch --show-current` and abort if on `main` — reinforced in agent memory | prevent | P0 | [project lead] | [#97](https://github.com/ilv78/Art-World-Hub/issues/97) (done) |
+| 4 | Clean up `main` branch history — decide whether to squash the push+revert commits or leave as audit trail | repair | P2 | [project lead] | [#97](https://github.com/ilv78/Art-World-Hub/issues/97) |
+| 5 | Create proper PR from `feature/issue-8-admin-section` with code review and actual test cases for admin functionality | repair | P1 | [project lead] | [#8](https://github.com/ilv78/Art-World-Hub/issues/8) |
+| 6 | Document this incident as the first entry in the postmortem index at `docs/postmortems/README.md` | document | P2 | [project lead] | [#102](https://github.com/ilv78/Art-World-Hub/issues/102) |
 
 ---
 

--- a/docs/postmortems/POSTMORTEM_TEMPLATE.md
+++ b/docs/postmortems/POSTMORTEM_TEMPLATE.md
@@ -197,7 +197,7 @@ _Minimum 3 items. Every item must have: description, type, priority, owner place
 
 | # | Action Item | Type | Priority | Owner | Issue |
 |---|-------------|------|----------|-------|-------|
-| 1 | [Specific, testable outcome: verb + object + success criterion] | prevent / mitigate / detect / repair / document | P0 / P1 / P2 | [role] | [GH-???] |
+| 1 | [Specific, testable outcome: verb + object + success criterion] | prevent / mitigate / detect / repair / document | P0 / P1 / P2 | [role] | [#N](https://github.com/ilv78/Art-World-Hub/issues/N) |
 | 2 | | | | | |
 | 3 | | | | | |
 
@@ -216,7 +216,7 @@ _Complete for security incidents. Mark N/A if not applicable._
 
 | # | Action Item | Type | Priority | Owner | Issue |
 |---|-------------|------|----------|-------|-------|
-| 1 | [e.g. Rotate all exposed credentials and revoke old tokens] | repair | P0 | [role] | [GH-???] |
+| 1 | [e.g. Rotate all exposed credentials and revoke old tokens] | repair | P0 | [role] | [#N](https://github.com/ilv78/Art-World-Hub/issues/N) |
 | 2 | | | | | |
 
 ---

--- a/docs/postmortems/POSTMORTEM_WORKFLOW.md
+++ b/docs/postmortems/POSTMORTEM_WORKFLOW.md
@@ -169,7 +169,9 @@ gh issue create --title "<action item title>" \
   --body "From postmortem: docs/postmortems/YYYY-MM-DD-slug.md — Action Item #N ..."
 ```
 
-After creating all issues, update the postmortem document to replace `[GH-???]` placeholders with the real issue numbers.
+After creating all issues, update the postmortem document to replace `[GH-???]` placeholders with **full markdown links** — not bare `#123` references. Postmortem documents are standalone artifacts that may be read outside of GitHub (locally, in editors, exported). Bare `#123` references are only clickable on GitHub, not in other contexts.
+
+**Format:** `[#123](https://github.com/ilv78/Art-World-Hub/issues/123)` — not `#123`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace bare `#N` references with `[#N](url)` full markdown links in the postmortem action items table
- Update `POSTMORTEM_WORKFLOW.md` Step 4b to require full URLs when replacing `[GH-???]` placeholders
- Update `POSTMORTEM_TEMPLATE.md` example rows to show full link format

Postmortem documents are standalone artifacts that may be read outside GitHub. Bare `#123` references only render as links on GitHub, not in local editors or exports.

## Test plan
- [x] All 6 action item links in the postmortem are now full markdown links
- [x] Workflow and template updated for future postmortems

🤖 Generated with [Claude Code](https://claude.com/claude-code)