### PR TITLE
docs: add versioning policy and backfill CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,80 @@
 
 All notable changes to ArtVerse will be documented in this file.
 
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-Releases are tagged as `release-{run_number}` in git and correspond to Docker image tags of the same number.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/). See `specs/workflows/VERSIONING.md` for the full versioning policy.
+
+Deployment tags (`release-{run_number}`) are created automatically on every push to main. Semantic version tags (`vX.Y.Z`) mark meaningful milestones.
 
 ## [Unreleased]
 
+_Nothing yet — all recent work included in v2.1.0 below._
+
+## [2.1.0] - 2026-03-14
+
 ### Added
-- Release management system: image tagging, health checks, smoke tests, git release tags
+- Email login: magic link signup (Resend) + email/password signin ([#6](https://github.com/ilv78/Art-World-Hub/issues/6))
+- Profile picture upload for artists ([#12](https://github.com/ilv78/Art-World-Hub/issues/12))
+- Release management system: Docker image tagging, health checks, smoke tests, git release tags ([#35](https://github.com/ilv78/Art-World-Hub/issues/35))
+- Security CI/CD pipeline: gitleaks, npm audit, Semgrep, hadolint, Trivy, custom checks ([#55](https://github.com/ilv78/Art-World-Hub/issues/55))
+- Auto-update issue tracker on issue closure ([#89](https://github.com/ilv78/Art-World-Hub/issues/89))
+- Pre-push hook to block direct pushes to main ([#101](https://github.com/ilv78/Art-World-Hub/issues/101))
+- Postmortem workflow and template ([#98](https://github.com/ilv78/Art-World-Hub/issues/98))
+- Documentation agent spec, backfill, and restructured specs directory ([#5](https://github.com/ilv78/Art-World-Hub/issues/5), [#40](https://github.com/ilv78/Art-World-Hub/issues/40), [#41](https://github.com/ilv78/Art-World-Hub/issues/41), [#42](https://github.com/ilv78/Art-World-Hub/issues/42))
+
+### Fixed
+- Magic link emails not being sent ([#34](https://github.com/ilv78/Art-World-Hub/issues/34))
+- Resend sender address — changed from sandbox to gallery@idata.ro ([#37](https://github.com/ilv78/Art-World-Hub/issues/37))
+
+### Security
+- Auth added to 9 unprotected write endpoints ([#78](https://github.com/ilv78/Art-World-Hub/issues/78))
+- Order endpoints locked down to prevent PII exposure ([#79](https://github.com/ilv78/Art-World-Hub/issues/79))
+- MCP server endpoint secured with authentication ([#80](https://github.com/ilv78/Art-World-Hub/issues/80))
+- SSRF vulnerability fixed in image proxy endpoint ([#81](https://github.com/ilv78/Art-World-Hub/issues/81))
+- P1 hardening: Helmet headers, email HTML escaping, Zod PATCH validation, magic byte upload validation, Actions SHA pinning, shell injection fixes ([#77](https://github.com/ilv78/Art-World-Hub/issues/77))
+
+### Changed
+- Refactored auth, email, and frontend code to consolidate duplications ([#53](https://github.com/ilv78/Art-World-Hub/issues/53))
+- Google OAuth moved from `/api/login` to `/api/login/google`
+- Resend email integration refactored to use `RESEND_API_KEY` env var
+
+## [2.0.0] - 2026-03-11
+
+### Added
+- Full CI/CD pipeline: lint, type check, tests, build, Docker image, staging deploy ([#20](https://github.com/ilv78/Art-World-Hub/issues/20))
+- Vitest test infrastructure with storage and route tests
+- PostgreSQL migrations with Drizzle Kit (dual-mode: push for staging, migrate for production)
+- Production deploy workflow with rollback capability
+- Rollback workflow (one-click)
+- Telegram notifications on deploy/rollback events
+- Architecture specification document
+- Development procedures and CI/CD spec
+
+### Fixed
+- Classic view gallery navigation arrows ([#9](https://github.com/ilv78/Art-World-Hub/issues/9))
+- Google OAuth login flow ([#11](https://github.com/ilv78/Art-World-Hub/issues/11))
+- Blog route SPA 404 errors ([#19](https://github.com/ilv78/Art-World-Hub/issues/19))
+- Missing artworks in gallery display ([#25](https://github.com/ilv78/Art-World-Hub/issues/25))
+- Museum gallery stale layout data ([#28](https://github.com/ilv78/Art-World-Hub/issues/28))
+
+### Changed
+- Color palette updated ([#1](https://github.com/ilv78/Art-World-Hub/issues/1))
+- Image storage refactored ([#3](https://github.com/ilv78/Art-World-Hub/issues/3))
+- Upload code deduplicated ([#17](https://github.com/ilv78/Art-World-Hub/issues/17))
+- Telegram notification format improved ([#26](https://github.com/ilv78/Art-World-Hub/issues/26))
+
+## [1.3.0] - 2026-02-24
+
+### Changed
+- Published app update
+
+## [1.2.1] - 2026-02-24
+
+### Added
+- Docker deployment
+- Google OIDC authentication
+- Safer user upsert logic
+
+## [1.2.0] - 2026-02-22
+
+### Added
+- Initial published application

--- a/specs/features/release-management/SPEC.md
+++ b/specs/features/release-management/SPEC.md
@@ -46,7 +46,11 @@ On successful staging deploy, the CI creates a git tag `release-{run_number}` po
 
 ### 6. CHANGELOG.md
 
-Root-level changelog following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. `[Unreleased]` section updated per feature branch; moved to dated release section before merging to main.
+Root-level changelog following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. `[Unreleased]` section updated per feature branch; moved to dated release section when declaring a new version.
+
+### 7. Versioning Policy
+
+Semantic versioning (`vX.Y.Z`) for milestone releases, separate from deployment tags (`release-{N}`). Full policy documented in `specs/workflows/VERSIONING.md`.
 
 ## Required Secrets
 

--- a/specs/workflows/VERSIONING.md
+++ b/specs/workflows/VERSIONING.md
@@ -1,0 +1,73 @@
+# Versioning & Release Policy
+
+## Version Scheme
+
+ArtVerse uses [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+
+| Bump | When | Examples |
+|------|------|----------|
+| **PATCH** (v2.0.→**1**) | Bug fixes, dependency patches, docs-only changes | CSS fix, typo fix, dep bump with no behavior change |
+| **MINOR** (v2.**1**.0) | New features, enhancements, non-breaking schema changes | Email login, profile picture upload, new admin panel |
+| **MAJOR** (v**3**.0.0) | Breaking API changes, breaking schema migrations, major rewrites | New auth system replacing old one, API v2 |
+
+## When to Declare a Release
+
+A **versioned release** (git tag `vX.Y.Z` + GitHub Release) is declared when a meaningful set of changes has been **deployed to production and confirmed healthy**. Specifically:
+
+### Trigger a release when:
+
+1. **A user-facing feature ships to production** — e.g., new login method, new admin panel, new gallery template. This is a MINOR bump.
+2. **A batch of bug/security fixes ships to production** — e.g., all P0 security findings fixed and deployed. This is a PATCH bump.
+3. **A breaking change ships to production** — anything that changes API contracts, requires data migration with downtime, or fundamentally changes existing behavior. This is a MAJOR bump.
+
+### Do NOT create a release for:
+
+- Every individual PR merge to main (that's what `release-{run_number}` tags are for)
+- Documentation-only changes (specs, postmortems, README updates)
+- CI/CD pipeline changes that don't affect the deployed application
+- Dependency bumps that don't change application behavior
+
+### Batching guideline
+
+It's fine to batch multiple features/fixes into a single release. A natural rhythm:
+- After a feature branch + its follow-up fixes are all deployed and stable
+- After a security hardening sprint completes
+- Weekly, if there's been a steady stream of small changes
+
+## Release Checklist
+
+When you're ready to declare a release:
+
+1. **Verify production is healthy** — check `https://artverse.idata.ro/health`
+2. **Update `CHANGELOG.md`**:
+   - Move items from `[Unreleased]` into a new `[X.Y.Z] - YYYY-MM-DD` section
+   - Group changes under: Added, Changed, Fixed, Security, Removed (as applicable)
+3. **Commit the CHANGELOG update** to main (via PR)
+4. **Create the git tag and GitHub Release**:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes "See CHANGELOG.md for details"
+   ```
+5. **Update `specs/issue-tracker.md`** revision log noting the release
+
+## Relationship to Deployment Tags
+
+ArtVerse has two tagging systems that serve different purposes:
+
+| Tag | Purpose | Created by | Example |
+|-----|---------|------------|---------|
+| `release-{N}` | Deployment identifier (every push to main) | CI automatically | `release-222` |
+| `vX.Y.Z` | Semantic version (milestone marker) | Developer manually | `v2.1.0` |
+
+Both are useful. `release-{N}` tags enable fast rollback to any deployment. `vX.Y.Z` tags mark meaningful milestones for communication and tracking.
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| v1.2.0 | 2026-02-22 | Initial published application |
+| v1.2.1 | 2026-02-24 | Docker deploy + Google OIDC auth |
+| v1.3.0 | 2026-02-24 | Published app update |
+| v2.0.0 | 2026-03-11 | Full CI/CD pipeline (11 steps), testing, migrations, rollback, Telegram notifications |
+| v2.1.0 | 2026-03-14 | Email login, security hardening (P0+P1), profile pictures, release management, postmortem workflow |


### PR DESCRIPTION
## Summary
- Add `specs/workflows/VERSIONING.md` — defines when to bump MAJOR/MINOR/PATCH, batching guidelines, and release checklist
- Backfill `CHANGELOG.md` with full v2.0.0 and v2.1.0 sections covering all work shipped since March 11
- Update release management spec to reference the versioning policy

## Test plan
- [ ] Verify CHANGELOG entries match completed issues in `specs/issue-tracker.md`
- [ ] Verify versioning policy is consistent with existing release tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)