### PR TITLE
fix: PR-based release flow for branch protection

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,0 +1,111 @@
+name: Release Finalize
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  finalize:
+    name: Finalize Release
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release metadata
+        id: meta
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Extract tag from PR title (format: "release: vX.Y.Z")
+          TAG="${PR_TITLE#release: }"
+          VERSION="${TAG#v}"
+
+          # Validate tag format
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Invalid tag format: $TAG (expected vX.Y.Z)"
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Release tag: ${TAG}"
+
+          # Extract issue numbers from PR body (hidden comment)
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep '<!-- RELEASE_ISSUES:' | sed 's/.*<!-- RELEASE_ISSUES: //' | sed 's/ -->.*//')
+          echo "issue_numbers=${ISSUE_NUMBERS}" >> "$GITHUB_OUTPUT"
+          echo "Issues: ${ISSUE_NUMBERS}"
+
+          # Extract changelog body from CHANGELOG.md for this version
+          CHANGELOG_BODY=$(awk -v ver="$VERSION" '
+            /^## \[/ && index($0, "[" ver "]") > 0 {found=1; next}
+            /^## \[/ && found {exit}
+            found {print}
+          ' CHANGELOG.md)
+
+          {
+            echo "changelog_body<<CHANGELOG_EOF"
+            echo "$CHANGELOG_BODY"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          CHANGELOG_BODY: ${{ steps.meta.outputs.changelog_body }}
+        run: |
+          printf '%s\n' "$CHANGELOG_BODY" | gh release create "$TAG" --title "$TAG" --notes-file -
+
+      - name: 'Remove "release: next" labels'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBERS: ${{ steps.meta.outputs.issue_numbers }}
+        run: |
+          for num in $ISSUE_NUMBERS; do
+            echo "Removing 'release: next' label from #$num"
+            gh issue edit "$num" --remove-label "release: next" || true
+          done
+
+      - name: Notify Telegram
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RELEASE_STATUS: ${{ job.status }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          TRIGGERED_BY: ${{ github.actor }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
+          if [ "$RELEASE_STATUS" = "success" ]; then EMOJI="🏷️"; else EMOJI="❌"; fi
+          curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            -d parse_mode="HTML" \
+            -d text="@racu8_bot
+          ${EMOJI} <b>New release: ${TAG}</b> [${REPO_NAME}]
+          By: ${TRIGGERED_BY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,16 @@ on:
 
 permissions:
   contents: write
-  issues: write
+  pull-requests: write
 
 jobs:
-  release:
-    name: Create Release
+  prepare:
+    name: Prepare Release PR
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
-      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -45,80 +45,60 @@ jobs:
         if: steps.prep.outputs.skip == 'true'
         run: echo "No issues to release — exiting."
 
+      - name: Create release branch and PR
+        if: steps.prep.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.prep.outputs.tag }}
+          VERSION: ${{ steps.prep.outputs.version }}
+          BUMP_TYPE: ${{ steps.prep.outputs.bump_type }}
+          CHANGELOG_BODY: ${{ steps.prep.outputs.changelog_body }}
+          ISSUE_NUMBERS: ${{ steps.prep.outputs.issue_numbers }}
+        run: |
+          BRANCH="release/${TAG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "release: ${TAG}"
+          git push origin "$BRANCH"
+
+          # Build PR body safely using printf (no shell expansion issues)
+          {
+            printf '## Release %s\n\n' "$TAG"
+            printf '**Version:** %s\n' "$VERSION"
+            printf '**Bump:** %s\n\n' "$BUMP_TYPE"
+            printf '### Changelog\n\n'
+            printf '%s\n\n' "$CHANGELOG_BODY"
+            printf '<!-- RELEASE_ISSUES: %s -->\n' "$ISSUE_NUMBERS"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --title "release: ${TAG}" \
+            --body-file /tmp/pr-body.md \
+            --label "autorelease" \
+            --base main \
+            --head "$BRANCH"
+
       - name: Job summary
         if: steps.prep.outputs.skip != 'true'
         env:
-          VERSION: ${{ steps.prep.outputs.version }}
           TAG: ${{ steps.prep.outputs.tag }}
+          VERSION: ${{ steps.prep.outputs.version }}
           BUMP_TYPE: ${{ steps.prep.outputs.bump_type }}
           CHANGELOG_BODY: ${{ steps.prep.outputs.changelog_body }}
           ISSUE_NUMBERS: ${{ steps.prep.outputs.issue_numbers }}
         run: |
           {
-            echo "## Release $TAG"
+            echo "## Release PR created: ${TAG}"
             echo ""
-            echo "**Version:** $VERSION"
-            echo "**Bump:** $BUMP_TYPE"
-            echo "**Issues:** $ISSUE_NUMBERS"
+            echo "**Version:** ${VERSION}"
+            echo "**Bump:** ${BUMP_TYPE}"
+            echo "**Issues:** ${ISSUE_NUMBERS}"
+            echo ""
+            echo "Merge the PR to finalize the release (tag + GitHub Release created automatically)."
             echo ""
             echo "### Changelog"
             echo ""
-            echo "$CHANGELOG_BODY"
+            echo "${CHANGELOG_BODY}"
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Commit CHANGELOG
-        if: steps.prep.outputs.skip != 'true'
-        env:
-          TAG: ${{ steps.prep.outputs.tag }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "release: $TAG"
-
-      - name: Push commit and tag
-        if: steps.prep.outputs.skip != 'true'
-        env:
-          TAG: ${{ steps.prep.outputs.tag }}
-        run: |
-          git tag "$TAG"
-          git push origin main "$TAG"
-
-      - name: Create GitHub Release
-        if: steps.prep.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.prep.outputs.tag }}
-          CHANGELOG_BODY: ${{ steps.prep.outputs.changelog_body }}
-        run: |
-          printf '%s\n' "$CHANGELOG_BODY" | gh release create "$TAG" --title "$TAG" --notes-file -
-
-      - name: 'Remove "release: next" labels'
-        if: steps.prep.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBERS: ${{ steps.prep.outputs.issue_numbers }}
-        run: |
-          for num in $ISSUE_NUMBERS; do
-            echo "Removing 'release: next' label from #$num"
-            gh issue edit "$num" --remove-label "release: next" || true
-          done
-
-      - name: Notify Telegram
-        if: always() && steps.prep.outputs.skip != 'true'
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          RELEASE_STATUS: ${{ job.status }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          TAG: ${{ steps.prep.outputs.tag }}
-          TRIGGERED_BY: ${{ github.actor }}
-        run: |
-          if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
-          if [ "$RELEASE_STATUS" = "success" ]; then EMOJI="🏷️"; else EMOJI="❌"; fi
-          curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            -d chat_id="${TELEGRAM_CHAT_ID}" \
-            -d parse_mode="HTML" \
-            -d text="@racu8_bot
-          ${EMOJI} <b>New release: ${TAG}</b> [${REPO_NAME}]
-          By: ${TRIGGERED_BY}"

--- a/specs/features/release-management/SPEC.md
+++ b/specs/features/release-management/SPEC.md
@@ -54,14 +54,17 @@ Semantic versioning (`vX.Y.Z`) for milestone releases, separate from deployment 
 
 ### 8. Automated Release Workflow
 
-**Workflow:** `.github/workflows/release.yml` (manual dispatch)
+**Prepare:** `.github/workflows/release.yml` (manual dispatch → creates PR)
+**Finalize:** `.github/workflows/release-finalize.yml` (runs on PR merge with `autorelease` label)
 **Script:** `.github/scripts/prepare-release.sh`
 
-Label-driven release automation:
+Two-phase label-driven release automation:
 1. Developer labels closed issues with `release: next`
-2. Trigger workflow via GitHub Actions UI (with optional bump override)
+2. Trigger "Release" workflow via GitHub Actions UI (with optional bump override)
 3. Script collects labeled issues, detects version bump, generates CHANGELOG entries
-4. Workflow commits CHANGELOG, creates git tag + GitHub Release, removes labels
+4. Workflow creates a release PR (`release/vX.Y.Z` branch, `autorelease` label)
+5. Developer reviews and merges the PR (CI validates the CHANGELOG update)
+6. On merge, `release-finalize.yml` creates git tag + GitHub Release, removes labels, sends Telegram notification
 
 **Version bump detection:**
 - Any issue with `feature` or `enhancement` label → MINOR bump

--- a/specs/workflows/CI-CD.md
+++ b/specs/workflows/CI-CD.md
@@ -652,11 +652,14 @@ Commits and pushes directly to `main`. Skips issues labeled `docs-audit` (automa
 
 ### 6.6 Automated Release Workflow
 
-`.github/workflows/release.yml` provides label-driven versioned releases (`vX.Y.Z`). Developer labels closed issues with `release: next`, then triggers the workflow via manual dispatch. The workflow auto-detects the version bump (MINOR for features/enhancements, PATCH for fixes), updates `CHANGELOG.md`, creates a git tag + GitHub Release, removes labels, and sends a Telegram notification.
+Two-phase label-driven versioned releases (`vX.Y.Z`):
+
+1. **Prepare** (`.github/workflows/release.yml`, manual dispatch): Developer labels closed issues with `release: next`, triggers the workflow. Script auto-detects the version bump (MINOR for features/enhancements, PATCH for fixes), updates `CHANGELOG.md`, and creates a release PR with the `autorelease` label.
+2. **Finalize** (`.github/workflows/release-finalize.yml`, automatic on PR merge): When the release PR is merged, creates the git tag + GitHub Release, removes `release: next` labels from issues, and sends a Telegram notification.
 
 **Script:** `.github/scripts/prepare-release.sh`
 
-Does NOT trigger production deploy — that remains a separate manual step via `deploy-production.yml`.
+Changes go through a PR, so CI validates the CHANGELOG update before it reaches main. Does NOT trigger production deploy — that remains a separate manual step via `deploy-production.yml`.
 
 ---
 

--- a/specs/workflows/VERSIONING.md
+++ b/specs/workflows/VERSIONING.md
@@ -42,15 +42,15 @@ It's fine to batch multiple features/fixes into a single release. A natural rhyt
 2. **Run the workflow** — GitHub Actions → "Release" → Run workflow
    - Leave bump override empty for auto-detect (MINOR if any `feature`/`enhancement`, else PATCH)
    - Select `minor` or `major` to override
-3. The workflow automatically:
-   - Detects version bump from issue labels
-   - Categorizes issues into CHANGELOG groups (Added, Fixed, Security, Changed)
-   - Updates `CHANGELOG.md`
-   - Creates git tag and GitHub Release
+3. The workflow creates a **release PR** (branch `release/vX.Y.Z`) with the updated `CHANGELOG.md`
+4. **Review and merge** the PR — CI runs normally, ensuring the CHANGELOG update passes all checks
+5. On merge, `release-finalize.yml` automatically:
+   - Creates git tag `vX.Y.Z` and GitHub Release
    - Removes `release: next` labels from processed issues
    - Sends Telegram notification
 
-**Workflow:** `.github/workflows/release.yml`
+**Prepare:** `.github/workflows/release.yml` (manual dispatch → creates PR)
+**Finalize:** `.github/workflows/release-finalize.yml` (runs on PR merge with `autorelease` label)
 **Script:** `.github/scripts/prepare-release.sh`
 
 ### Manual (fallback)


### PR DESCRIPTION
## Summary
- Split release workflow into two phases to respect branch protection rules
- `release.yml` (manual dispatch): prepares CHANGELOG, creates a release PR with `autorelease` label
- `release-finalize.yml` (on PR merge): creates git tag + GitHub Release, removes `release: next` labels, sends Telegram notification
- Cleaned up stale `v2.1.0` tag from failed direct-push attempt
- Updated VERSIONING.md, release-management SPEC, and CI-CD spec to reflect PR-based flow

Fixes the branch protection error from run 23076725004 where direct push to main was rejected.

## Test plan
- [ ] Label 1-2 closed issues with `release: next`
- [ ] Run the "Release" workflow — verify it creates a PR with `autorelease` label and correct CHANGELOG
- [ ] Review and merge the release PR
- [ ] Verify `release-finalize.yml` runs: git tag created, GitHub Release created, labels removed, Telegram sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)