### PR TITLE
Add logging tests and staging smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,28 @@ jobs:
           fi
           echo "Health check passed — staging deployment verified"
 
+      - name: Smoke test — logging infrastructure
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: staging
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd ~/app
+            echo "Checking log file exists..."
+            docker compose exec -T app test -f /app/logs/app.log || { echo "FAIL: /app/logs/app.log not found"; exit 1; }
+            echo "Checking log file has entries..."
+            LOG_LINES=$(docker compose exec -T app wc -l < /app/logs/app.log)
+            if [ "$LOG_LINES" -lt 1 ]; then
+              echo "FAIL: log file is empty"
+              exit 1
+            fi
+            echo "Checking logs are valid JSON..."
+            docker compose exec -T app tail -1 /app/logs/app.log | python3 -c "import sys,json; json.load(sys.stdin)" || { echo "FAIL: last log line is not valid JSON"; exit 1; }
+            echo "Checking startup log entries..."
+            docker compose exec -T app grep -c '"msg":"Server listening"' /app/logs/app.log > /dev/null || { echo "FAIL: no Server listening entry"; exit 1; }
+            echo "Logging smoke test passed — $LOG_LINES log entries, valid JSON"
+
       - name: Tag release in git
         if: success()
         run: |

--- a/server/__tests__/helpers/test-app.ts
+++ b/server/__tests__/helpers/test-app.ts
@@ -82,6 +82,28 @@ vi.mock("../../storage", () => ({
   generateWhiteRoomLayout: vi.fn(),
 }));
 
+// Mock logger — no-op logger + testable logFilePath
+const { testLogDir } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const tmpdir = require("os").tmpdir();
+  return { testLogDir: `${tmpdir}/artverse-test-logs-${process.pid}` };
+});
+
+vi.mock("../../logger", () => {
+  const noopLogger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+    fatal: vi.fn(), trace: vi.fn(), child: vi.fn().mockReturnThis(),
+  };
+  return {
+    logger: noopLogger,
+    authLogger: noopLogger,
+    mcpLogger: noopLogger,
+    seedLogger: noopLogger,
+    logFilePath: `${testLogDir}/app.log`,
+    LOG_DIR: testLogDir,
+  };
+});
+
 import express from "express";
 import { createServer } from "http";
 import { registerRoutes } from "../../routes";

--- a/server/__tests__/logger.test.ts
+++ b/server/__tests__/logger.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import pino from "pino";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const testLogDir = path.join(os.tmpdir(), `artverse-logger-test-${process.pid}`);
+const testLogFile = path.join(testLogDir, "test.log");
+
+describe("Logger output format", () => {
+  let logger: pino.Logger;
+
+  beforeAll(() => {
+    fs.mkdirSync(testLogDir, { recursive: true });
+    logger = pino(
+      {
+        level: "trace",
+        timestamp: pino.stdTimeFunctions.isoTime,
+      },
+      pino.destination({ dest: testLogFile, sync: true, mkdir: true }),
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(testLogDir, { recursive: true, force: true });
+  });
+
+  it("writes valid NDJSON to the log file", () => {
+    logger.info("test message");
+    logger.flush();
+
+    const content = fs.readFileSync(testLogFile, "utf-8").trim();
+    const lines = content.split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.msg).toBe("test message");
+    expect(entry.level).toBe(30); // pino info = 30
+  });
+
+  it("includes ISO timestamp", () => {
+    logger.info("timestamp test");
+    logger.flush();
+
+    const lines = fs.readFileSync(testLogFile, "utf-8").trim().split("\n");
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("child logger includes module field", () => {
+    const child = logger.child({ module: "auth" });
+    child.warn("auth warning");
+    logger.flush();
+
+    const lines = fs.readFileSync(testLogFile, "utf-8").trim().split("\n");
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.module).toBe("auth");
+    expect(entry.level).toBe(40); // pino warn = 40
+  });
+
+  it("error level includes error object", () => {
+    logger.error({ err: new Error("test error") }, "something failed");
+    logger.flush();
+
+    const lines = fs.readFileSync(testLogFile, "utf-8").trim().split("\n");
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.level).toBe(50); // pino error = 50
+    expect(entry.msg).toBe("something failed");
+    expect(entry.err.message).toBe("test error");
+    expect(entry.err.type).toBe("Error");
+  });
+
+  it("supports structured context fields", () => {
+    logger.info({ port: 5000, host: "0.0.0.0" }, "Server listening");
+    logger.flush();
+
+    const lines = fs.readFileSync(testLogFile, "utf-8").trim().split("\n");
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.port).toBe(5000);
+    expect(entry.host).toBe("0.0.0.0");
+  });
+});

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 import type express from "express";
 import type { IStorage } from "../storage";
 import { createTestApp, mockStorage } from "./helpers/test-app";
+import fs from "fs";
+import path from "path";
+import os from "os";
 
 let app: express.Express;
 
@@ -462,5 +465,91 @@ describe("PATCH /api/artworks/:id", () => {
       .send({ title: "Hacked" });
 
     expect(res.status).toBe(403);
+  });
+});
+
+// ----- Admin logs endpoint -----
+
+describe("GET /api/admin/logs", () => {
+  // The logger mock in test-app.ts sets logFilePath to a temp dir.
+  // We write test NDJSON there before hitting the endpoint.
+  const logDir = path.join(os.tmpdir(), `artverse-test-logs-${process.pid}`);
+  const logFile = path.join(logDir, "app.log");
+
+  const testEntries = [
+    { level: 30, time: "2026-03-15T10:00:00.000Z", module: "seed", msg: "Database seeded" },
+    { level: 30, time: "2026-03-15T10:01:00.000Z", module: "mcp", msg: "MCP registered" },
+    { level: 40, time: "2026-03-15T10:02:00.000Z", module: "auth", msg: "Token expired" },
+    { level: 50, time: "2026-03-15T10:03:00.000Z", module: "auth", msg: "Login failed", err: { message: "bad password" } },
+    { level: 30, time: "2026-03-15T10:04:00.000Z", req: { method: "GET", url: "/api/artists" }, res: { statusCode: 200 }, responseTime: 15, msg: "request completed" },
+  ];
+
+  beforeAll(() => {
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(logFile, testEntries.map((e) => JSON.stringify(e)).join("\n") + "\n");
+  });
+
+  afterAll(() => {
+    fs.rmSync(logDir, { recursive: true, force: true });
+  });
+
+  it("returns all log entries with default params", async () => {
+    const res = await request(app).get("/api/admin/logs");
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(5);
+    expect(res.body.total).toBe(5);
+  });
+
+  it("filters by log level", async () => {
+    const res = await request(app).get("/api/admin/logs?level=warn");
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(2);
+    expect(res.body.entries.every((e: any) => e.level >= 40)).toBe(true);
+  });
+
+  it("filters by module", async () => {
+    const res = await request(app).get("/api/admin/logs?module=auth");
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(2);
+    expect(res.body.entries.every((e: any) => e.module === "auth")).toBe(true);
+  });
+
+  it("filters by text search", async () => {
+    const res = await request(app).get("/api/admin/logs?search=artists");
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(1);
+    expect(res.body.entries[0].req.url).toBe("/api/artists");
+  });
+
+  it("filters by since timestamp", async () => {
+    const res = await request(app).get("/api/admin/logs?since=2026-03-15T10:03:00.000Z");
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(2);
+  });
+
+  it("respects limit parameter", async () => {
+    const res = await request(app).get("/api/admin/logs?limit=2");
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(2);
+    expect(res.body.total).toBe(5);
+  });
+
+  it("combines filters", async () => {
+    const res = await request(app).get("/api/admin/logs?level=error&module=auth");
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(1);
+    expect(res.body.entries[0].msg).toBe("Login failed");
+  });
+
+  it("returns empty when log file does not exist", async () => {
+    const tmpPath = logFile + ".bak";
+    fs.renameSync(logFile, tmpPath);
+    try {
+      const res = await request(app).get("/api/admin/logs");
+      expect(res.status).toBe(200);
+      expect(res.body.entries).toHaveLength(0);
+    } finally {
+      fs.renameSync(tmpPath, logFile);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add 5 logger unit tests verifying JSON format, ISO timestamps, child loggers, error serialization
- Add 8 admin logs endpoint tests covering all filter parameters (level, module, search, since, limit, combined)
- Add staging deploy smoke test that verifies logs are working after every deploy

Follow-up to [#39](https://github.com/ilv78/Art-World-Hub/issues/39) logging infrastructure.

## Test coverage added
| Test | What it verifies |
|------|-----------------|
| Logger: NDJSON output | Log file contains valid JSON lines |
| Logger: ISO timestamp | `time` field is ISO 8601 |
| Logger: child module | Child logger adds `module` field |
| Logger: error object | `err` includes message + type |
| Logger: structured context | Extra fields (port, host) are included |
| Admin logs: default | Returns all entries |
| Admin logs: level filter | Only entries >= specified level |
| Admin logs: module filter | Only entries with matching module |
| Admin logs: search filter | Text search across log lines |
| Admin logs: since filter | Only entries after timestamp |
| Admin logs: limit | Returns tail of N entries |
| Admin logs: combined | Multiple filters work together |
| Admin logs: missing file | Returns empty array gracefully |
| **Staging smoke test** | After deploy: log file exists, has entries, valid JSON, contains startup message |

## Test plan
- [x] `npm test` — 52/52 tests pass (39 existing + 13 new)
- [x] `npm run lint` — 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)