### PR TITLE
docs: logging feature spec and CI-CD spec update

### DIFF
--- a/specs/features/logging/SPEC.md
+++ b/specs/features/logging/SPEC.md
@@ -1,0 +1,211 @@
+# Logging Infrastructure
+
+**Status:** Active
+**Issue:** [#39](https://github.com/ilv78/Art-World-Hub/issues/39)
+**PRs:** [#124](https://github.com/ilv78/Art-World-Hub/pull/124), [#125](https://github.com/ilv78/Art-World-Hub/pull/125), [#126](https://github.com/ilv78/Art-World-Hub/pull/126)
+**Last Updated:** 2026-03-15
+
+---
+
+## Overview
+
+Structured JSON logging using [pino](https://github.com/pinojs/pino), replacing all `console.log/error/warn` calls. Logs are written to both stdout (for Docker) and a persistent file (for querying via admin API and MCP).
+
+---
+
+## Architecture
+
+### Logger Module (`server/logger.ts`)
+
+```
+                    pino (root logger)
+                    ├── stdout (JSON in production, pretty in dev)
+                    └── /app/logs/app.log (JSON, persistent via Docker volume)
+                         │
+               ┌─────────┼──────────┐
+               ▼         ▼          ▼
+          authLogger  mcpLogger  seedLogger
+          (child)     (child)    (child)
+```
+
+- **Root logger** — `pino` with ISO timestamps and `pino.multistream` for dual output
+- **Child loggers** — each adds a `module` field (e.g., `"module": "auth"`) for filtering
+- **pino-http middleware** — automatic request/response logging on `/api/*` routes with method, URL, status code, and response time
+- **No worker threads** — uses `pino.multistream()` (not `pino.transport()`) for esbuild bundle compatibility
+
+### Log Entry Format (NDJSON)
+
+Each line in the log file is a standalone JSON object:
+
+```json
+{"level":30,"time":"2026-03-15T20:08:17.270Z","pid":1,"hostname":"ee44cff1c89a","module":"mcp","msg":"MCP server registered at /mcp"}
+{"level":30,"time":"2026-03-15T20:08:39.323Z","pid":1,"hostname":"ee44cff1c89a","req":{"method":"GET","url":"/api/artists"},"res":{"statusCode":200},"responseTime":7,"msg":"request completed"}
+{"level":50,"time":"2026-03-15T21:00:00.000Z","pid":1,"hostname":"ee44cff1c89a","module":"auth","err":{"message":"bad password","type":"Error"},"msg":"Login failed"}
+```
+
+### Pino Log Levels
+
+| Level | Value | Usage |
+|-------|-------|-------|
+| `fatal` | 60 | Process-ending errors |
+| `error` | 50 | Operation failures (auth, email, DB) |
+| `warn` | 40 | Degraded state (Resend not configured, OIDC disabled) |
+| `info` | 30 | Normal operations (startup, requests, seeding) |
+| `debug` | 20 | Detailed diagnostics (off by default) |
+| `trace` | 10 | Very verbose (off by default) |
+
+---
+
+## Configuration
+
+| Env Variable | Default | Description |
+|-------------|---------|-------------|
+| `LOG_LEVEL` | `info` | Minimum log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`) |
+| `LOG_DIR` | `./logs` | Directory for log files |
+
+---
+
+## Access Methods
+
+### 1. Admin API — `GET /api/admin/logs`
+
+Requires admin role (RBAC). Returns filtered log entries from the log file.
+
+**Query parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `limit` | number | Max entries to return (default 200, max 2000) |
+| `level` | string | Minimum level: `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
+| `module` | string | Filter by module: `auth`, `mcp`, `seed` |
+| `search` | string | Case-insensitive text search across log lines |
+| `since` | string | ISO timestamp — only entries after this time |
+
+**Response:**
+```json
+{
+  "entries": [ { "level": 50, "time": "...", "msg": "..." }, ... ],
+  "total": 42
+}
+```
+
+**Examples:**
+- `/api/admin/logs` — last 200 entries
+- `/api/admin/logs?level=error` — errors and fatals only
+- `/api/admin/logs?module=auth&since=2026-03-15T10:00:00Z` — auth entries since 10am
+- `/api/admin/logs?search=artists&limit=10` — entries mentioning "artists"
+
+### 2. MCP Tool — `get_logs`
+
+Same filtering capabilities as the admin API, accessible to Claude via the MCP server.
+
+**Parameters:** `limit`, `level`, `module`, `search`, `since` (same as API above).
+
+### 3. SSH (direct file access)
+
+```bash
+# View last 20 entries (pretty-printed)
+ssh staging@artverse.idata.ro "cd ~/app && docker compose exec -T app tail -20 /app/logs/app.log" | python3 -m json.tool
+
+# Docker stdout logs
+ssh staging@artverse.idata.ro "cd ~/app && docker compose logs --tail=20 app"
+```
+
+### 4. Local development
+
+Logs are pretty-printed to stdout via `pino-pretty` (devDependency) and written as JSON to `logs/app.log`.
+
+```bash
+# View log file
+cat logs/app.log | npx pino-pretty
+
+# Filter errors
+grep '"level":50' logs/app.log | npx pino-pretty
+```
+
+---
+
+## Docker Setup
+
+### Volumes
+
+All three docker-compose files (`docker-compose.yml`, `deploy/staging/docker-compose.yml`, `deploy/production/docker-compose.yml`) mount a `logs` volume:
+
+```yaml
+volumes:
+  - logs:/app/logs
+```
+
+### Directory creation
+
+The Dockerfile creates `/app/logs` during build. Deploy workflows also ensure the directory exists and has correct ownership:
+
+```bash
+mkdir -p /app/logs && chown -R appuser:appgroup /app/logs
+```
+
+---
+
+## Testing
+
+### Unit Tests (`server/__tests__/logger.test.ts`)
+
+5 tests verifying pino output format:
+
+| Test | What it verifies |
+|------|-----------------|
+| NDJSON output | Log file contains valid JSON lines |
+| ISO timestamp | `time` field is ISO 8601 format |
+| Child module field | Child logger adds `module` field |
+| Error serialization | `err` includes `message` and `type` |
+| Structured context | Extra fields (port, host) are included |
+
+### Admin Logs Endpoint Tests (`server/__tests__/routes.test.ts`)
+
+8 tests covering the `GET /api/admin/logs` endpoint:
+
+| Test | What it verifies |
+|------|-----------------|
+| Default params | Returns all entries |
+| Level filter | Only entries >= specified level |
+| Module filter | Only entries with matching module |
+| Search filter | Text search across log lines |
+| Since filter | Only entries after timestamp |
+| Limit | Returns tail of N entries |
+| Combined filters | Multiple filters work together |
+| Missing file | Returns empty array gracefully |
+
+### Staging Smoke Test (CI/CD)
+
+After every staging deploy, the CI pipeline SSHes into the VPS and verifies:
+
+1. `/app/logs/app.log` exists in the container
+2. File has at least 1 entry
+3. Last line is valid JSON (parsed with `python3 -c "import json; json.load()"`)
+4. File contains `"Server listening"` startup entry
+
+**Location:** `.github/workflows/ci.yml` → `Deploy to Staging` job → `Smoke test — logging infrastructure` step
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `server/logger.ts` | Pino logger configuration, child loggers, exports |
+| `server/index.ts` | pino-http middleware setup |
+| `server/routes.ts` | `GET /api/admin/logs` endpoint |
+| `server/mcp.ts` | `get_logs` MCP tool |
+| `server/__tests__/logger.test.ts` | Logger unit tests |
+| `server/__tests__/routes.test.ts` | Admin logs endpoint tests |
+| `.github/workflows/ci.yml` | Staging logging smoke test |
+
+---
+
+## Revision Log
+
+| Date | Change |
+|------|--------|
+| 2026-03-15 | Initial implementation — pino structured logging, admin API, MCP tool, Docker volumes ([#124](https://github.com/ilv78/Art-World-Hub/pull/124)) |
+| 2026-03-15 | Fix: switched from `pino.transport()` to `pino.multistream()` for esbuild compatibility ([#125](https://github.com/ilv78/Art-World-Hub/pull/125)) |
+| 2026-03-15 | Added unit tests, endpoint tests, and staging smoke test ([#126](https://github.com/ilv78/Art-World-Hub/pull/126)) |

--- a/specs/workflows/CI-CD.md
+++ b/specs/workflows/CI-CD.md
@@ -22,7 +22,7 @@ Single unified workflow with two jobs. Triggers on every push (all branches) and
 | Install dependencies | `npm ci` |
 | Lint | `npm run lint` (ESLint 9 + TypeScript + React hooks) |
 | Type check | `npm run check` (tsc with 6GB heap) |
-| Run tests | `npm test` (Vitest, 32 tests) |
+| Run tests | `npm test` (Vitest, 52 tests — routes, storage, logger) |
 | Build | `npm run build` (Vite client + esbuild server) |
 
 - Uses a PostgreSQL 16 Alpine service container (needed for the build to succeed)
@@ -452,7 +452,7 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
                │  └────────┬───────────┘  │
                │           ▼              │
                │  ┌────────────────────┐  │
-               │  │  npm test          │  │  ← Vitest (32 tests)
+               │  │  npm test          │  │  ← Vitest (52 tests)
                │  └────────┬───────────┘  │
                │           ▼              │
                │  ┌────────────────────┐  │
@@ -482,6 +482,7 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
                │  docker compose up -d    │
                │  Health check (2 min)    │
                │  Smoke test (external)   │
+               │  Smoke test (logging)    │  ← Verifies log file exists, valid JSON
                │  Git tag release-N       │
                │  📱 Telegram notify      │
                └──────────────────────────┘
@@ -685,3 +686,4 @@ Changes go through a PR, so CI validates the CHANGELOG update before it reaches 
 | 2026-03-13 | Added Section 6.5: Issue Tracker Auto-Update workflow — auto-updates issue-tracker.md and creates bug docs on issue close. (Issue #89) |
 | 2026-03-13 | Release management (Issue #35): 3-tag Docker images (latest+sha+run_number), `/health` endpoint, APP_VERSION build arg, post-deploy smoke tests, production auto-rollback on failure, git release tags (`release-N`), CHANGELOG.md. Added `STAGING_URL` and `PRODUCTION_URL` to secrets inventory. |
 | 2026-03-14 | Added Section 6.6: Automated Release Workflow — label-driven versioned releases via `release.yml` + `prepare-release.sh`. Auto-detects PATCH/MINOR bump, updates CHANGELOG, creates git tag + GitHub Release, removes labels, Telegram notification. (Issue #110) |
+| 2026-03-15 | Added logging smoke test to staging deploy — verifies log file exists, has entries, valid JSON, and contains startup message. Updated test count from 32 to 52. (Issue [#39](https://github.com/ilv78/Art-World-Hub/issues/39)) |


### PR DESCRIPTION
## Summary
- Create `specs/features/logging/SPEC.md` — full feature spec covering architecture, configuration, access methods (admin API, MCP tool, SSH, local dev), Docker volume setup, and test coverage
- Update `specs/workflows/CI-CD.md` — test count 32→52, logging smoke test in pipeline diagram, revision log entry

Closes [#39](https://github.com/ilv78/Art-World-Hub/issues/39)

## Test plan
- [ ] CI passes
- [ ] Documentation Agent passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)