### PR TITLE
fix: allow CHANGELOG.md through .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ uploads/
 dist/
 *.key
 *.md
+!CHANGELOG.md
 !package.json
 !package-lock.json
 .github/


### PR DESCRIPTION
## Summary
- Added `!CHANGELOG.md` exception to `.dockerignore` — the `*.md` rule was excluding it from the Docker build context, causing the `COPY --from=build /app/CHANGELOG.md ./` step to fail

Follow-up fix for #121 (the previous PR added the COPY but missed the .dockerignore exclusion)

## Test plan
- [ ] Docker build succeeds on CI
- [ ] Version and changelog page work on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)