### PR TITLE
fix: prices as integers in EUR, hide when not for sale

### DIFF
--- a/client/src/components/artwork-card.tsx
+++ b/client/src/components/artwork-card.tsx
@@ -94,9 +94,11 @@ export function ArtworkCard({ artwork, onViewDetails, showAddToCart = true }: Ar
             <Badge variant="outline" className="text-xs">
               {artwork.medium}
             </Badge>
-            <span className="font-semibold text-primary" data-testid={`text-price-${artwork.id}`}>
-              {parseInt(artwork.price).toLocaleString()}
-            </span>
+            {artwork.isForSale && (
+              <span className="font-semibold text-primary" data-testid={`text-price-${artwork.id}`}>
+                {parseInt(artwork.price).toLocaleString()} &euro;
+              </span>
+            )}
           </div>
         </div>
       </CardContent>

--- a/client/src/components/artwork-detail-dialog.tsx
+++ b/client/src/components/artwork-detail-dialog.tsx
@@ -123,12 +123,14 @@ export function ArtworkDetailDialog({
             <Separator className="my-4" />
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">Price</span>
-                <span className="text-2xl font-bold text-primary" data-testid="text-detail-price">
-                  {parseInt(artwork.price).toLocaleString()}
-                </span>
-              </div>
+              {artwork.isForSale && (
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">Price</span>
+                  <span className="text-2xl font-bold text-primary" data-testid="text-detail-price">
+                    {parseInt(artwork.price).toLocaleString()} &euro;
+                  </span>
+                </div>
+              )}
 
               {artwork.isForSale ? (
                 <Button

--- a/client/src/components/cart-sheet.tsx
+++ b/client/src/components/cart-sheet.tsx
@@ -81,7 +81,7 @@ export function CartSheet() {
                           by {item.artwork.artist.name}
                         </p>
                         <p className="text-sm font-semibold text-primary mt-1">
-                          {parseInt(item.artwork.price).toLocaleString()}
+                          {parseInt(item.artwork.price).toLocaleString()} &euro;
                         </p>
                       </div>
                       <Button
@@ -101,7 +101,7 @@ export function CartSheet() {
                 <Separator />
                 <div className="flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Subtotal</span>
-                  <span className="font-semibold">{total.toLocaleString()}</span>
+                  <span className="font-semibold">{total.toLocaleString()} &euro;</span>
                 </div>
                 <div className="flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Shipping</span>
@@ -111,7 +111,7 @@ export function CartSheet() {
                 <div className="flex justify-between items-center">
                   <span className="font-semibold">Total</span>
                   <span className="text-xl font-bold text-primary" data-testid="text-cart-total">
-                    ${total.toLocaleString()}
+                    {total.toLocaleString()} &euro;
                   </span>
                 </div>
                 <SheetFooter className="gap-2 sm:gap-2">

--- a/client/src/components/checkout-dialog.tsx
+++ b/client/src/components/checkout-dialog.tsx
@@ -124,7 +124,7 @@ export function CheckoutDialog({
               <DialogTitle className="font-serif text-xl">Checkout</DialogTitle>
               <DialogDescription>
                 Complete your order for {items.length} item
-                {items.length > 1 ? "s" : ""} - Total: ${total.toLocaleString()}
+                {items.length > 1 ? "s" : ""} - Total: {total.toLocaleString()} &euro;
               </DialogDescription>
             </DialogHeader>
 

--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -1130,7 +1130,9 @@ export function HallwayGallery3D({ artistRooms }: HallwayGallery3DProps) {
             <p className="text-xs text-muted-foreground flex-1">{selectedArtwork.description}</p>
             <div className="pt-2 border-t space-y-2">
               <div>
-                <p className="text-lg font-bold text-primary">{parseInt(selectedArtwork.price).toLocaleString()}</p>
+                {selectedArtwork.isForSale && (
+                  <p className="text-lg font-bold text-primary">{parseInt(selectedArtwork.price).toLocaleString()} &euro;</p>
+                )}
                 {selectedArtwork.dimensions && <p className="text-xs text-muted-foreground">{selectedArtwork.dimensions}</p>}
               </div>
               {selectedArtwork.isForSale && (

--- a/client/src/components/maze-gallery-3d.tsx
+++ b/client/src/components/maze-gallery-3d.tsx
@@ -1159,9 +1159,11 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
 
             <div className="pt-2 border-t space-y-2">
               <div>
-                <p className="text-lg font-bold text-primary">
-                  {parseInt(selectedArtwork.price).toLocaleString()}
-                </p>
+                {selectedArtwork.isForSale && (
+                  <p className="text-lg font-bold text-primary">
+                    {parseInt(selectedArtwork.price).toLocaleString()} &euro;
+                  </p>
+                )}
                 {selectedArtwork.dimensions && (
                   <p className="text-xs text-muted-foreground">{selectedArtwork.dimensions}</p>
                 )}

--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -592,7 +592,7 @@ export default function ArtistDashboard() {
                         id="price"
                         value={artworkForm.price}
                         onChange={(e) => setArtworkForm({ ...artworkForm, price: e.target.value })}
-                        placeholder="$1,000"
+                        placeholder="1000"
                         data-testid="input-artwork-price"
                       />
                     </div>
@@ -716,7 +716,9 @@ export default function ArtistDashboard() {
                   </div>
                   <CardContent className="p-4">
                     <h3 className="font-semibold truncate">{artwork.title}</h3>
-                    <p className="text-sm text-muted-foreground">{artwork.price}</p>
+                    {artwork.isForSale && (
+                      <p className="text-sm text-muted-foreground">{parseInt(artwork.price).toLocaleString()} &euro;</p>
+                    )}
                   </CardContent>
                   <CardFooter className="p-4 pt-0 gap-2">
                     <Button 

--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -253,7 +253,9 @@ export default function ArtistProfile() {
                       <CardContent className="p-4">
                         <h3 className="font-semibold">{artwork.title}</h3>
                         <div className="flex items-center justify-between mt-2">
-                          <span className="text-lg font-bold text-primary">{parseInt(artwork.price).toLocaleString()}</span>
+                          {artwork.isForSale && (
+                            <span className="text-lg font-bold text-primary">{parseInt(artwork.price).toLocaleString()} &euro;</span>
+                          )}
                           {artwork.year && (
                             <span className="text-sm text-muted-foreground">{artwork.year}</span>
                           )}

--- a/client/src/pages/auctions.tsx
+++ b/client/src/pages/auctions.tsx
@@ -101,7 +101,7 @@ function AuctionCard({
               {status === "active" ? "Current Bid" : status === "upcoming" ? "Starting Price" : "Final Bid"}
             </span>
             <span className="font-bold text-primary" data-testid={`text-bid-${auction.id}`}>
-              ${currentBid.toLocaleString()}
+              {currentBid.toLocaleString()} &euro;
             </span>
           </div>
           {status === "active" && (
@@ -201,7 +201,7 @@ export default function Auctions() {
 
     if (data.amount < currentBid + minIncrement) {
       form.setError("amount", {
-        message: `Minimum bid is $${(currentBid + minIncrement).toLocaleString()}`,
+        message: `Minimum bid is ${(currentBid + minIncrement).toLocaleString()} \u20AC`,
       });
       return;
     }
@@ -268,13 +268,12 @@ export default function Auctions() {
             </div>
             <div>
               <p className="text-2xl font-bold">
-                $
                 {auctions
                   ?.reduce(
                     (sum, a) => sum + parseFloat(a.currentBid || a.startingPrice),
                     0
                   )
-                  .toLocaleString() || "0"}
+                  .toLocaleString() || "0"} &euro;
               </p>
               <p className="text-sm text-muted-foreground">Total Value</p>
             </div>
@@ -380,16 +379,14 @@ export default function Auctions() {
                     <div>
                       <p className="text-sm text-muted-foreground">Current Bid</p>
                       <p className="text-2xl font-bold text-primary">
-                        $
                         {parseFloat(
                           selectedAuction.currentBid || selectedAuction.startingPrice
-                        ).toLocaleString()}
+                        ).toLocaleString()} &euro;
                       </p>
                     </div>
                     <div>
                       <p className="text-xs text-muted-foreground">
-                        Minimum increment: $
-                        {parseFloat(selectedAuction.minimumIncrement).toLocaleString()}
+                        Minimum increment: {parseFloat(selectedAuction.minimumIncrement).toLocaleString()} &euro;
                       </p>
                     </div>
                   </div>
@@ -420,11 +417,11 @@ export default function Auctions() {
                       name="amount"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Your Bid ($)</FormLabel>
+                          <FormLabel>Your Bid (&euro;)</FormLabel>
                           <FormControl>
                             <Input
                               type="number"
-                              step="0.01"
+                              step="1"
                               {...field}
                               data-testid="input-bid-amount"
                             />
@@ -488,7 +485,7 @@ export default function Auctions() {
                               <span>{bid.bidderName}</span>
                             </div>
                             <span className="font-medium">
-                              ${parseFloat(bid.amount).toLocaleString()}
+                              {parseFloat(bid.amount).toLocaleString()} &euro;
                             </span>
                           </div>
                         ))}

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -308,12 +308,14 @@ export default function Gallery() {
                     </div>
                     <Card>
                       <CardContent className="p-4">
-                        <div className="flex items-center justify-between gap-2 mb-4">
-                          <span className="text-sm text-muted-foreground">Price</span>
-                          <span className="text-2xl font-bold text-primary">
-                            {parseInt(currentArtwork.price).toLocaleString()}
-                          </span>
-                        </div>
+                        {currentArtwork.isForSale && (
+                          <div className="flex items-center justify-between gap-2 mb-4">
+                            <span className="text-sm text-muted-foreground">Price</span>
+                            <span className="text-2xl font-bold text-primary">
+                              {parseInt(currentArtwork.price).toLocaleString()} &euro;
+                            </span>
+                          </div>
+                        )}
                         {currentArtwork.isForSale ? (
                           <Button className="w-full" onClick={handleAddToCart} disabled={isInCart} data-testid="button-gallery-add-cart">
                             <ShoppingCart className="h-4 w-4 mr-2" />

--- a/client/src/pages/store.tsx
+++ b/client/src/pages/store.tsx
@@ -248,7 +248,7 @@ export default function Store() {
               </div>
               <div className="text-right flex-shrink-0">
                 <p className="font-bold text-primary text-lg">
-                  {parseInt(artwork.price).toLocaleString()}
+                  {parseInt(artwork.price).toLocaleString()} &euro;
                 </p>
                 <Badge variant="outline" className="mt-2">
                   {artwork.medium}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,7 +55,7 @@ async function sendOrderNotificationEmail(
           <tr><td style="padding: 8px 0; color: #666;">Artwork:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(artwork.title)}</td></tr>
           <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${escapeHtml(artwork.medium)}</td></tr>
           ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${escapeHtml(artwork.dimensions)}</td></tr>` : ""}
-          <tr><td style="padding: 8px 0; color: #666;">Price:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Price:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()} &euro;</td></tr>
         </table>
       </div>
 
@@ -112,7 +112,7 @@ async function sendBuyerConfirmationEmail(
           <tr><td style="padding: 8px 0; color: #666;">Artist:</td><td style="padding: 8px 0;">${escapeHtml(artist.name)}</td></tr>
           <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${escapeHtml(artwork.medium)}</td></tr>
           ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${escapeHtml(artwork.dimensions)}</td></tr>` : ""}
-          <tr><td style="padding: 8px 0; color: #666;">Total:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()}</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Total:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()} &euro;</td></tr>
         </table>
       </div>
 


### PR DESCRIPTION
## Summary
- Changed all currency references from USD ($) to EUR (€) across the entire platform
- Display prices as integers (no decimals) — fixed artist dashboard which showed raw decimal string
- Hide price when artwork is not for sale (`isForSale=false`) in all views: artwork cards, detail dialog, gallery, artist profile, artist dashboard, 3D hallway and maze galleries
- Updated bid input step from 0.01 to 1 for integer bids
- Updated price input placeholder from "$1,000" to "1000"

Closes #130

### Files changed (12)
- `client/src/components/artwork-card.tsx` — EUR + hide price
- `client/src/components/artwork-detail-dialog.tsx` — EUR + hide price
- `client/src/components/cart-sheet.tsx` — EUR on item prices, subtotal, total
- `client/src/components/checkout-dialog.tsx` — $ → EUR
- `client/src/components/hallway-gallery-3d.tsx` — EUR + hide price
- `client/src/components/maze-gallery-3d.tsx` — EUR + hide price
- `client/src/pages/store.tsx` — EUR in list view
- `client/src/pages/gallery.tsx` — EUR + hide price
- `client/src/pages/artist-profile.tsx` — EUR + hide price
- `client/src/pages/artist-dashboard.tsx` — EUR + hide price + fix raw decimal + placeholder
- `client/src/pages/auctions.tsx` — all $ → EUR + integer bid step
- `server/routes.ts` — EUR in order notification emails

## Test plan
- [x] All 52 tests pass
- [x] Production build succeeds
- [x] Store: prices show as integers with €
- [x] Gallery: price hidden when not for sale
- [x] Artist Dashboard: integer prices with €, no raw decimals
- [x] Auctions: all $ replaced with €
- [x] Cart/Checkout: EUR throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)