### PR TITLE
fix: sync users and artists lifecycle

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -126,9 +126,26 @@ export default function AdminPage() {
     },
   });
 
+  const deleteUserMutation = useMutation({
+    mutationFn: (id: string) => apiFetch(`/api/admin/users/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/artists"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/artworks"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/artists"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/artworks"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/gallery/hallway"] });
+      toast({ title: "User deleted" });
+    },
+    onError: (err: Error) => {
+      toast({ title: "Failed to delete user", description: err.message, variant: "destructive" });
+    },
+  });
+
   const deleteArtistMutation = useMutation({
     mutationFn: (id: string) => apiFetch(`/api/admin/artists/${id}`, { method: "DELETE" }),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
       queryClient.invalidateQueries({ queryKey: ["/api/admin/artists"] });
       queryClient.invalidateQueries({ queryKey: ["/api/admin/artworks"] });
       queryClient.invalidateQueries({ queryKey: ["/api/artists"] });
@@ -264,6 +281,7 @@ export default function AdminPage() {
                       <TableHead>Role</TableHead>
                       <TableHead>Verified</TableHead>
                       <TableHead>Created</TableHead>
+                      <TableHead>Actions</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -294,6 +312,31 @@ export default function AdminPage() {
                         </TableCell>
                         <TableCell className="text-sm text-muted-foreground">
                           {u.createdAt ? new Date(u.createdAt).toLocaleDateString() : "—"}
+                        </TableCell>
+                        <TableCell>
+                          {u.id !== user.id && (
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <Button variant="destructive" size="sm">
+                                  <Trash2 className="w-4 h-4" />
+                                </Button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>Delete User</AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    This will permanently delete {u.email || "this user"} and their associated artist profile, artworks, blog posts, and all related data.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                  <AlertDialogAction onClick={() => deleteUserMutation.mutate(u.id)}>
+                                    Delete
+                                  </AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/server/__tests__/helpers/mock-storage.ts
+++ b/server/__tests__/helpers/mock-storage.ts
@@ -58,6 +58,7 @@ export function createMockStorage(): IStorage {
     getUsers: vi.fn().mockResolvedValue([]),
     updateUserRole: vi.fn().mockResolvedValue(undefined),
     deleteArtist: vi.fn().mockResolvedValue(false),
+    deleteUser: vi.fn().mockResolvedValue(false),
     deleteExhibition: vi.fn().mockResolvedValue(false),
     getAllBlogPosts: vi.fn().mockResolvedValue([]),
   };

--- a/server/__tests__/helpers/test-app.ts
+++ b/server/__tests__/helpers/test-app.ts
@@ -43,6 +43,7 @@ const { mockStorage } = vi.hoisted(() => {
     getUsers: fn().mockResolvedValue([]),
     updateUserRole: fn().mockResolvedValue(undefined),
     deleteArtist: fn().mockResolvedValue(false),
+    deleteUser: fn().mockResolvedValue(false),
     deleteExhibition: fn().mockResolvedValue(false),
     getAllBlogPosts: fn().mockResolvedValue([]),
   };

--- a/server/replit_integrations/auth/replitAuth.ts
+++ b/server/replit_integrations/auth/replitAuth.ts
@@ -11,6 +11,7 @@ import type { Express, RequestHandler } from "express";
 import memoize from "memoizee";
 import connectPg from "connect-pg-simple";
 import { authStorage } from "./storage";
+import { storage } from "../../storage";
 import { sendMagicLinkEmail } from "../../email";
 import { z } from "zod";
 import type { User, UserRole } from "@shared/models/auth";
@@ -113,13 +114,27 @@ function updateUserSession(
 
 async function upsertUser(claims: any) {
   // Google OIDC claims: sub, email, given_name, family_name, picture
-  await authStorage.upsertUser({
+  const user = await authStorage.upsertUser({
     id: claims["sub"],
     email: claims["email"],
     firstName: claims["given_name"] ?? claims["first_name"],
     lastName: claims["family_name"] ?? claims["last_name"],
     profileImageUrl: claims["picture"] ?? claims["profile_image_url"],
   });
+
+  // Auto-create artist profile if none exists
+  const existingArtist = await storage.getArtistByUserId(user.id);
+  if (!existingArtist) {
+    const firstName = claims["given_name"] ?? claims["first_name"] ?? "";
+    const lastName = claims["family_name"] ?? claims["last_name"] ?? "";
+    const displayName = `${firstName} ${lastName}`.trim() || "New Artist";
+    await storage.createArtist({
+      name: displayName,
+      bio: "Welcome to my gallery! I'm a new artist on ArtVerse.",
+      userId: user.id,
+      email: claims["email"] || undefined,
+    });
+  }
 }
 
 // Build the origin (protocol + host + port) for callback URLs
@@ -232,6 +247,18 @@ export async function setupAuth(app: Express) {
         email: link.email,
         emailVerified: true,
       });
+
+      // Auto-create artist profile if none exists
+      const existingArtist = await storage.getArtistByUserId(user.id);
+      if (!existingArtist) {
+        const displayName = [user.firstName, user.lastName].filter(Boolean).join(" ") || "New Artist";
+        await storage.createArtist({
+          name: displayName,
+          bio: "Welcome to my gallery! I'm a new artist on ArtVerse.",
+          userId: user.id,
+          email: user.email || undefined,
+        });
+      }
 
       req.login(buildSessionUser(user), (err) => {
         if (err) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -874,6 +874,28 @@ export async function registerRoutes(
     }
   });
 
+  app.delete("/api/admin/users/:id", isAdmin, async (req: any, res) => {
+    try {
+      // Prevent admin from deleting themselves
+      if (req.params.id === req.user?.claims?.sub) {
+        return res.status(400).json({ error: "Cannot delete your own account" });
+      }
+      // Also delete the artist linked to this user, if any
+      const artist = await storage.getArtistByUserId(req.params.id);
+      if (artist) {
+        await storage.deleteArtist(artist.id);
+      } else {
+        const deleted = await storage.deleteUser(req.params.id);
+        if (!deleted) {
+          return res.status(404).json({ error: "User not found" });
+        }
+      }
+      res.status(204).send();
+    } catch (error) {
+      res.status(500).json({ error: "Failed to delete user" });
+    }
+  });
+
   app.get("/api/admin/artists", isAdmin, async (req: any, res) => {
     try {
       const artists = await storage.getArtists();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,6 +16,7 @@ import {
   artists, artworks, auctions, bids, orders, exhibitions, exhibitionArtworks, blogPosts
 } from "@shared/schema";
 import { type User, type UserRole, users } from "@shared/models/auth";
+import { sessions } from "@shared/models/auth";
 import { db } from "./db";
 import { eq, desc, asc, and, sql } from "drizzle-orm";
 
@@ -77,6 +78,7 @@ export interface IStorage {
   getUsers(): Promise<User[]>;
   updateUserRole(userId: string, role: UserRole): Promise<User | undefined>;
   deleteArtist(id: string): Promise<boolean>;
+  deleteUser(id: string): Promise<boolean>;
   deleteExhibition(id: string): Promise<boolean>;
   getAllBlogPosts(): Promise<BlogPostWithArtist[]>;
 }
@@ -408,6 +410,10 @@ export class DatabaseStorage implements IStorage {
   }
 
   async deleteArtist(id: string): Promise<boolean> {
+    // Look up the artist to find the linked user before deletion
+    const [artist] = await db.select().from(artists).where(eq(artists.id, id));
+    if (!artist) return false;
+
     // Delete all related data in dependency order
     const artistArtworks = await db.select({ id: artworks.id }).from(artworks).where(eq(artworks.artistId, id));
     for (const aw of artistArtworks) {
@@ -416,7 +422,26 @@ export class DatabaseStorage implements IStorage {
     // Delete blog posts by this artist
     await db.delete(blogPosts).where(eq(blogPosts.artistId, id));
     // Delete the artist
-    const result = await db.delete(artists).where(eq(artists.id, id)).returning();
+    await db.delete(artists).where(eq(artists.id, id));
+
+    // Cascade: delete the associated user (and their sessions)
+    if (artist.userId) {
+      await this.deleteUser(artist.userId);
+    }
+    return true;
+  }
+
+  async deleteUser(id: string): Promise<boolean> {
+    // Delete user sessions (connect-pg-simple stores userId in sess JSON)
+    const allSessions = await db.select().from(sessions);
+    for (const s of allSessions) {
+      const sess = s.sess as any;
+      if (sess?.passport?.user?.claims?.sub === id) {
+        await db.delete(sessions).where(eq(sessions.sid, s.sid));
+      }
+    }
+    // Delete the user record
+    const result = await db.delete(users).where(eq(users.id, id)).returning();
     return result.length > 0;
   }
 


### PR DESCRIPTION
## Summary
- **Cascade artist deletion** → also deletes the linked user record and their sessions
- **Admin delete user endpoint** (`DELETE /api/admin/users/:id`) — cascades to artist + all content if linked
- **Admin UI delete button** on Users tab with confirmation dialog (cannot delete yourself)
- **Auto-create artist on signup** — moved from lazy creation (first dashboard visit) to immediate creation during email verification and Google OAuth flows, preventing future orphaned users
- Updated test mocks with new `deleteUser` method

Closes #122

## Test plan
- [x] All 52 tests pass
- [x] Production build succeeds
- [x] Admin Users tab shows delete button for all users except self
- [x] Deleting a user cascades to artist + all content
- [x] Deleting an artist cascades to the linked user
- [x] Cannot delete your own admin account
- [ ] New signup creates artist profile immediately (testable on staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)