### PR TITLE
fix: use RELEASE_PAT in issue tracker workflow

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Update issue tracker
         env:


### PR DESCRIPTION
## Summary
- Changed checkout token from `GITHUB_TOKEN` to `RELEASE_PAT` in the issue tracker auto-update workflow
- `GITHUB_TOKEN` cannot push directly to `main` when branch protection requires PRs and status checks
- `RELEASE_PAT` (admin PAT) can bypass branch protection for automated commits

Closes #136

## Test plan
- [ ] Close an issue after merging — verify the issue tracker workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)