### PR TITLE
refactor: code review cleanup — formatPrice, ensureArtistProfile, SQL session cleanup

### DIFF
--- a/client/src/components/artwork-card.tsx
+++ b/client/src/components/artwork-card.tsx
@@ -5,6 +5,7 @@ import { ShoppingCart, Eye } from "lucide-react";
 import type { ArtworkWithArtist } from "@shared/schema";
 import { useCartStore } from "@/lib/cart-store";
 import { useToast } from "@/hooks/use-toast";
+import { formatPrice } from "@/lib/utils";
 
 interface ArtworkCardProps {
   artwork: ArtworkWithArtist;
@@ -96,7 +97,7 @@ export function ArtworkCard({ artwork, onViewDetails, showAddToCart = true }: Ar
             </Badge>
             {artwork.isForSale && (
               <span className="font-semibold text-primary" data-testid={`text-price-${artwork.id}`}>
-                {parseInt(artwork.price).toLocaleString()} &euro;
+                {formatPrice(artwork.price)}
               </span>
             )}
           </div>

--- a/client/src/components/artwork-detail-dialog.tsx
+++ b/client/src/components/artwork-detail-dialog.tsx
@@ -13,6 +13,7 @@ import { ShoppingCart, Calendar, Ruler, Palette, MapPin } from "lucide-react";
 import type { ArtworkWithArtist } from "@shared/schema";
 import { useCartStore } from "@/lib/cart-store";
 import { useToast } from "@/hooks/use-toast";
+import { formatPrice } from "@/lib/utils";
 
 interface ArtworkDetailDialogProps {
   artwork: ArtworkWithArtist | null;
@@ -127,7 +128,7 @@ export function ArtworkDetailDialog({
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-muted-foreground">Price</span>
                   <span className="text-2xl font-bold text-primary" data-testid="text-detail-price">
-                    {parseInt(artwork.price).toLocaleString()} &euro;
+                    {formatPrice(artwork.price)}
                   </span>
                 </div>
               )}

--- a/client/src/components/cart-sheet.tsx
+++ b/client/src/components/cart-sheet.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useCartStore } from "@/lib/cart-store";
+import { formatPrice } from "@/lib/utils";
 import { useState } from "react";
 import { CheckoutDialog } from "./checkout-dialog";
 
@@ -81,7 +82,7 @@ export function CartSheet() {
                           by {item.artwork.artist.name}
                         </p>
                         <p className="text-sm font-semibold text-primary mt-1">
-                          {parseInt(item.artwork.price).toLocaleString()} &euro;
+                          {formatPrice(item.artwork.price)}
                         </p>
                       </div>
                       <Button
@@ -101,7 +102,7 @@ export function CartSheet() {
                 <Separator />
                 <div className="flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Subtotal</span>
-                  <span className="font-semibold">{total.toLocaleString()} &euro;</span>
+                  <span className="font-semibold">{formatPrice(total)}</span>
                 </div>
                 <div className="flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Shipping</span>
@@ -111,7 +112,7 @@ export function CartSheet() {
                 <div className="flex justify-between items-center">
                   <span className="font-semibold">Total</span>
                   <span className="text-xl font-bold text-primary" data-testid="text-cart-total">
-                    {total.toLocaleString()} &euro;
+                    {formatPrice(total)}
                   </span>
                 </div>
                 <SheetFooter className="gap-2 sm:gap-2">

--- a/client/src/components/checkout-dialog.tsx
+++ b/client/src/components/checkout-dialog.tsx
@@ -25,6 +25,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import type { ArtworkWithArtist } from "@shared/schema";
 import { CheckCircle, Loader2 } from "lucide-react";
+import { formatPrice } from "@/lib/utils";
 
 interface CartItem {
   artwork: ArtworkWithArtist;
@@ -124,7 +125,7 @@ export function CheckoutDialog({
               <DialogTitle className="font-serif text-xl">Checkout</DialogTitle>
               <DialogDescription>
                 Complete your order for {items.length} item
-                {items.length > 1 ? "s" : ""} - Total: {total.toLocaleString()} &euro;
+                {items.length > 1 ? "s" : ""} - Total: {formatPrice(total)}
               </DialogDescription>
             </DialogHeader>
 

--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { X, ShoppingCart, Move, Mouse, Keyboard, Maximize2, Minimize2, ZoomIn, Box, Map as MapIcon } from "lucide-react";
 import type { ArtworkWithArtist, MazeLayout, MazeCell } from "@shared/schema";
 import { useCartStore } from "@/lib/cart-store";
+import { formatPrice } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 
 interface ArtistRoom {
@@ -1131,7 +1132,7 @@ export function HallwayGallery3D({ artistRooms }: HallwayGallery3DProps) {
             <div className="pt-2 border-t space-y-2">
               <div>
                 {selectedArtwork.isForSale && (
-                  <p className="text-lg font-bold text-primary">{parseInt(selectedArtwork.price).toLocaleString()} &euro;</p>
+                  <p className="text-lg font-bold text-primary">{formatPrice(selectedArtwork.price)}</p>
                 )}
                 {selectedArtwork.dimensions && <p className="text-xs text-muted-foreground">{selectedArtwork.dimensions}</p>}
               </div>

--- a/client/src/components/maze-gallery-3d.tsx
+++ b/client/src/components/maze-gallery-3d.tsx
@@ -11,6 +11,7 @@ import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import type { ArtworkWithArtist, Artist, MazeLayout, MazeCell } from "@shared/schema";
 import { useCartStore } from "@/lib/cart-store";
+import { formatPrice } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 
 interface MazeGallery3DProps {
@@ -1161,7 +1162,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
               <div>
                 {selectedArtwork.isForSale && (
                   <p className="text-lg font-bold text-primary">
-                    {parseInt(selectedArtwork.price).toLocaleString()} &euro;
+                    {formatPrice(selectedArtwork.price)}
                   </p>
                 )}
                 {selectedArtwork.dimensions && (

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatPrice(amount: string | number): string {
+  return `${parseInt(String(amount)).toLocaleString()} \u20AC`;
+}

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { AlertTriangle, Shield, Trash2, Users, Palette, Image, Calendar, BookOpen } from "lucide-react";
+import { formatPrice } from "@/lib/utils";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -416,7 +417,7 @@ export default function AdminPage() {
                         <TableCell className="font-medium">{aw.title}</TableCell>
                         <TableCell>{aw.artist.name}</TableCell>
                         <TableCell>{aw.medium}</TableCell>
-                        <TableCell>${parseInt(aw.price).toLocaleString()}</TableCell>
+                        <TableCell>{formatPrice(aw.price)}</TableCell>
                         <TableCell>
                           <Badge variant={aw.isForSale ? "default" : "secondary"}>
                             {aw.isForSale ? "Yes" : "No"}

--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
+import { formatPrice } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -717,7 +718,7 @@ export default function ArtistDashboard() {
                   <CardContent className="p-4">
                     <h3 className="font-semibold truncate">{artwork.title}</h3>
                     {artwork.isForSale && (
-                      <p className="text-sm text-muted-foreground">{parseInt(artwork.price).toLocaleString()} &euro;</p>
+                      <p className="text-sm text-muted-foreground">{formatPrice(artwork.price)}</p>
                     )}
                   </CardContent>
                   <CardFooter className="p-4 pt-0 gap-2">

--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { SiInstagram, SiX, SiFacebook, SiYoutube, SiTiktok, SiLinkedin, SiBehance, SiDribbble, SiDeviantart, SiPinterest } from "react-icons/si";
 import { useCartStore } from "@/lib/cart-store";
+import { formatPrice } from "@/lib/utils";
 import { MazeGallery3D } from "@/components/maze-gallery-3d";
 import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
 import type { Artist, ArtworkWithArtist, BlogPostWithArtist, MazeLayout } from "@shared/schema";
@@ -254,7 +255,7 @@ export default function ArtistProfile() {
                         <h3 className="font-semibold">{artwork.title}</h3>
                         <div className="flex items-center justify-between mt-2">
                           {artwork.isForSale && (
-                            <span className="text-lg font-bold text-primary">{parseInt(artwork.price).toLocaleString()} &euro;</span>
+                            <span className="text-lg font-bold text-primary">{formatPrice(artwork.price)}</span>
                           )}
                           {artwork.year && (
                             <span className="text-sm text-muted-foreground">{artwork.year}</span>

--- a/client/src/pages/auctions.tsx
+++ b/client/src/pages/auctions.tsx
@@ -32,6 +32,7 @@ import { formatDistanceToNow, format, isPast, isFuture } from "date-fns";
 import type { AuctionWithArtwork, Bid } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { formatPrice } from "@/lib/utils";
 
 const bidSchema = z.object({
   bidderName: z.string().min(2, "Name must be at least 2 characters"),
@@ -101,7 +102,7 @@ function AuctionCard({
               {status === "active" ? "Current Bid" : status === "upcoming" ? "Starting Price" : "Final Bid"}
             </span>
             <span className="font-bold text-primary" data-testid={`text-bid-${auction.id}`}>
-              {currentBid.toLocaleString()} &euro;
+              {formatPrice(currentBid)}
             </span>
           </div>
           {status === "active" && (
@@ -201,7 +202,7 @@ export default function Auctions() {
 
     if (data.amount < currentBid + minIncrement) {
       form.setError("amount", {
-        message: `Minimum bid is ${(currentBid + minIncrement).toLocaleString()} \u20AC`,
+        message: `Minimum bid is ${formatPrice(currentBid + minIncrement)}`,
       });
       return;
     }
@@ -268,12 +269,11 @@ export default function Auctions() {
             </div>
             <div>
               <p className="text-2xl font-bold">
-                {auctions
+                {formatPrice(auctions
                   ?.reduce(
                     (sum, a) => sum + parseFloat(a.currentBid || a.startingPrice),
                     0
-                  )
-                  .toLocaleString() || "0"} &euro;
+                  ) ?? 0)}
               </p>
               <p className="text-sm text-muted-foreground">Total Value</p>
             </div>
@@ -379,14 +379,12 @@ export default function Auctions() {
                     <div>
                       <p className="text-sm text-muted-foreground">Current Bid</p>
                       <p className="text-2xl font-bold text-primary">
-                        {parseFloat(
-                          selectedAuction.currentBid || selectedAuction.startingPrice
-                        ).toLocaleString()} &euro;
+                        {formatPrice(selectedAuction.currentBid || selectedAuction.startingPrice)}
                       </p>
                     </div>
                     <div>
                       <p className="text-xs text-muted-foreground">
-                        Minimum increment: {parseFloat(selectedAuction.minimumIncrement).toLocaleString()} &euro;
+                        Minimum increment: {formatPrice(selectedAuction.minimumIncrement)}
                       </p>
                     </div>
                   </div>
@@ -485,7 +483,7 @@ export default function Auctions() {
                               <span>{bid.bidderName}</span>
                             </div>
                             <span className="font-medium">
-                              {parseFloat(bid.amount).toLocaleString()} &euro;
+                              {formatPrice(bid.amount)}
                             </span>
                           </div>
                         ))}

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import type { ArtworkWithArtist } from "@shared/schema";
 import { useCartStore } from "@/lib/cart-store";
+import { formatPrice } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import { HallwayGallery3D } from "@/components/hallway-gallery-3d";
 
@@ -312,7 +313,7 @@ export default function Gallery() {
                           <div className="flex items-center justify-between gap-2 mb-4">
                             <span className="text-sm text-muted-foreground">Price</span>
                             <span className="text-2xl font-bold text-primary">
-                              {parseInt(currentArtwork.price).toLocaleString()} &euro;
+                              {formatPrice(currentArtwork.price)}
                             </span>
                           </div>
                         )}

--- a/client/src/pages/store.tsx
+++ b/client/src/pages/store.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/select";
 import { Search, SlidersHorizontal, Grid3X3, LayoutList, X } from "lucide-react";
 import { ArtworkCard } from "@/components/artwork-card";
+import { formatPrice } from "@/lib/utils";
 import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
 import type { ArtworkWithArtist } from "@shared/schema";
 
@@ -248,7 +249,7 @@ export default function Store() {
               </div>
               <div className="text-right flex-shrink-0">
                 <p className="font-bold text-primary text-lg">
-                  {parseInt(artwork.price).toLocaleString()} &euro;
+                  {formatPrice(artwork.price)}
                 </p>
                 <Badge variant="outline" className="mt-2">
                   {artwork.medium}

--- a/server/__tests__/helpers/mock-storage.ts
+++ b/server/__tests__/helpers/mock-storage.ts
@@ -7,6 +7,7 @@ export function createMockStorage(): IStorage {
     getArtists: vi.fn().mockResolvedValue([]),
     getArtist: vi.fn().mockResolvedValue(undefined),
     getArtistByUserId: vi.fn().mockResolvedValue(undefined),
+    ensureArtistProfile: vi.fn().mockResolvedValue({ id: "artist-1", name: "Test Artist" }),
     createArtist: vi.fn().mockResolvedValue({}),
     updateArtist: vi.fn().mockResolvedValue(undefined),
 

--- a/server/__tests__/helpers/test-app.ts
+++ b/server/__tests__/helpers/test-app.ts
@@ -8,6 +8,7 @@ const { mockStorage } = vi.hoisted(() => {
     getArtists: fn().mockResolvedValue([]),
     getArtist: fn().mockResolvedValue(undefined),
     getArtistByUserId: fn().mockResolvedValue(undefined),
+    ensureArtistProfile: fn().mockResolvedValue({ id: "artist-1", name: "Test Artist" }),
     createArtist: fn().mockResolvedValue({}),
     updateArtist: fn().mockResolvedValue(undefined),
     getArtworks: fn().mockResolvedValue([]),

--- a/server/replit_integrations/auth/replitAuth.ts
+++ b/server/replit_integrations/auth/replitAuth.ts
@@ -122,19 +122,11 @@ async function upsertUser(claims: any) {
     profileImageUrl: claims["picture"] ?? claims["profile_image_url"],
   });
 
-  // Auto-create artist profile if none exists
-  const existingArtist = await storage.getArtistByUserId(user.id);
-  if (!existingArtist) {
-    const firstName = claims["given_name"] ?? claims["first_name"] ?? "";
-    const lastName = claims["family_name"] ?? claims["last_name"] ?? "";
-    const displayName = `${firstName} ${lastName}`.trim() || "New Artist";
-    await storage.createArtist({
-      name: displayName,
-      bio: "Welcome to my gallery! I'm a new artist on ArtVerse.",
-      userId: user.id,
-      email: claims["email"] || undefined,
-    });
-  }
+  await storage.ensureArtistProfile(user.id, {
+    firstName: claims["given_name"] ?? claims["first_name"],
+    lastName: claims["family_name"] ?? claims["last_name"],
+    email: claims["email"],
+  });
 }
 
 // Build the origin (protocol + host + port) for callback URLs
@@ -248,17 +240,11 @@ export async function setupAuth(app: Express) {
         emailVerified: true,
       });
 
-      // Auto-create artist profile if none exists
-      const existingArtist = await storage.getArtistByUserId(user.id);
-      if (!existingArtist) {
-        const displayName = [user.firstName, user.lastName].filter(Boolean).join(" ") || "New Artist";
-        await storage.createArtist({
-          name: displayName,
-          bio: "Welcome to my gallery! I'm a new artist on ArtVerse.",
-          userId: user.id,
-          email: user.email || undefined,
-        });
-      }
+      await storage.ensureArtistProfile(user.id, {
+        firstName: user.firstName || undefined,
+        lastName: user.lastName || undefined,
+        email: user.email || undefined,
+      });
 
       req.login(buildSessionUser(user), (err) => {
         if (err) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,6 +16,10 @@ import crypto from "crypto";
 import { logger, logFilePath } from "./logger";
 import readline from "readline";
 
+function formatPrice(amount: string | number): string {
+  return `${parseInt(String(amount)).toLocaleString()} \u20AC`;
+}
+
 function escapeHtml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
@@ -55,7 +59,7 @@ async function sendOrderNotificationEmail(
           <tr><td style="padding: 8px 0; color: #666;">Artwork:</td><td style="padding: 8px 0; font-weight: bold;">${escapeHtml(artwork.title)}</td></tr>
           <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${escapeHtml(artwork.medium)}</td></tr>
           ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${escapeHtml(artwork.dimensions)}</td></tr>` : ""}
-          <tr><td style="padding: 8px 0; color: #666;">Price:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()} &euro;</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Price:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${formatPrice(order.totalAmount)}</td></tr>
         </table>
       </div>
 
@@ -112,7 +116,7 @@ async function sendBuyerConfirmationEmail(
           <tr><td style="padding: 8px 0; color: #666;">Artist:</td><td style="padding: 8px 0;">${escapeHtml(artist.name)}</td></tr>
           <tr><td style="padding: 8px 0; color: #666;">Medium:</td><td style="padding: 8px 0;">${escapeHtml(artwork.medium)}</td></tr>
           ${artwork.dimensions ? `<tr><td style="padding: 8px 0; color: #666;">Dimensions:</td><td style="padding: 8px 0;">${escapeHtml(artwork.dimensions)}</td></tr>` : ""}
-          <tr><td style="padding: 8px 0; color: #666;">Total:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${parseInt(order.totalAmount).toLocaleString()} &euro;</td></tr>
+          <tr><td style="padding: 8px 0; color: #666;">Total:</td><td style="padding: 8px 0; font-weight: bold; color: #F97316;">${formatPrice(order.totalAmount)}</td></tr>
         </table>
       </div>
 
@@ -310,19 +314,11 @@ export async function registerRoutes(
     try {
       const userId = req.user?.claims?.sub;
       const claims = req.user?.claims;
-      let artist = await storage.getArtistByUserId(userId);
-      if (!artist) {
-        const firstName = claims?.first_name || "";
-        const lastName = claims?.last_name || "";
-        const displayName = `${firstName} ${lastName}`.trim() || "New Artist";
-        const email = claims?.email || "";
-        artist = await storage.createArtist({
-          name: displayName,
-          bio: "Welcome to my gallery! I'm a new artist on ArtVerse.",
-          userId,
-          email: email || undefined,
-        });
-      }
+      const artist = await storage.ensureArtistProfile(userId, {
+        firstName: claims?.first_name,
+        lastName: claims?.last_name,
+        email: claims?.email,
+      });
       res.json(artist);
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch artist profile" });
@@ -1040,24 +1036,22 @@ export async function registerRoutes(
     }
   });
 
-  // Version & changelog (public)
+  // Version & changelog (public) — cached at startup since content only changes on redeploy
+  let cachedChangelog: string | null = null;
+  let cachedVersion = "unknown";
+  try {
+    cachedChangelog = fs.readFileSync(path.resolve(process.cwd(), "CHANGELOG.md"), "utf-8");
+    const match = cachedChangelog.match(/^## \[(\d+\.\d+\.\d+)\]/m);
+    cachedVersion = match ? `v${match[1]}` : "unknown";
+  } catch { /* CHANGELOG.md not present */ }
+
   app.get("/api/version", (_req, res) => {
-    try {
-      const changelog = fs.readFileSync(path.resolve(process.cwd(), "CHANGELOG.md"), "utf-8");
-      const match = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m);
-      res.json({ version: match ? `v${match[1]}` : "unknown" });
-    } catch {
-      res.json({ version: "unknown" });
-    }
+    res.json({ version: cachedVersion });
   });
 
   app.get("/api/changelog", (_req, res) => {
-    try {
-      const changelog = fs.readFileSync(path.resolve(process.cwd(), "CHANGELOG.md"), "utf-8");
-      res.type("text/plain").send(changelog);
-    } catch {
-      res.status(404).json({ error: "Changelog not found" });
-    }
+    if (!cachedChangelog) return res.status(404).json({ error: "Changelog not found" });
+    res.type("text/plain").send(cachedChangelog);
   });
 
   return httpServer;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -26,7 +26,8 @@ export interface IStorage {
   getArtist(id: string): Promise<Artist | undefined>;
   getArtistByUserId(userId: string): Promise<Artist | undefined>;
   createArtist(artist: InsertArtist): Promise<Artist>;
-  
+  ensureArtistProfile(userId: string, opts: { firstName?: string; lastName?: string; email?: string }): Promise<Artist>;
+
   // Artworks
   getArtworks(): Promise<ArtworkWithArtist[]>;
   getArtwork(id: string): Promise<ArtworkWithArtist | undefined>;
@@ -102,6 +103,18 @@ export class DatabaseStorage implements IStorage {
   async createArtist(insertArtist: InsertArtist): Promise<Artist> {
     const [artist] = await db.insert(artists).values(insertArtist).returning();
     return artist;
+  }
+
+  async ensureArtistProfile(userId: string, opts: { firstName?: string; lastName?: string; email?: string }): Promise<Artist> {
+    const existing = await this.getArtistByUserId(userId);
+    if (existing) return existing;
+    const displayName = [opts.firstName, opts.lastName].filter(Boolean).join(" ") || "New Artist";
+    return this.createArtist({
+      name: displayName,
+      bio: "Welcome to my gallery! I'm a new artist on ArtVerse.",
+      userId,
+      email: opts.email || undefined,
+    });
   }
 
   // Artworks
@@ -416,9 +429,7 @@ export class DatabaseStorage implements IStorage {
 
     // Delete all related data in dependency order
     const artistArtworks = await db.select({ id: artworks.id }).from(artworks).where(eq(artworks.artistId, id));
-    for (const aw of artistArtworks) {
-      await this.deleteArtwork(aw.id);
-    }
+    await Promise.all(artistArtworks.map(aw => this.deleteArtwork(aw.id)));
     // Delete blog posts by this artist
     await db.delete(blogPosts).where(eq(blogPosts.artistId, id));
     // Delete the artist
@@ -432,14 +443,10 @@ export class DatabaseStorage implements IStorage {
   }
 
   async deleteUser(id: string): Promise<boolean> {
-    // Delete user sessions (connect-pg-simple stores userId in sess JSON)
-    const allSessions = await db.select().from(sessions);
-    for (const s of allSessions) {
-      const sess = s.sess as any;
-      if (sess?.passport?.user?.claims?.sub === id) {
-        await db.delete(sessions).where(eq(sessions.sid, s.sid));
-      }
-    }
+    // Delete user sessions using JSONB query (connect-pg-simple stores userId in sess JSON)
+    await db.delete(sessions).where(
+      sql`${sessions.sess}->'passport'->'user'->'claims'->>'sub' = ${id}`
+    );
     // Delete the user record
     const result = await db.delete(users).where(eq(users.id, id)).returning();
     return result.length > 0;


### PR DESCRIPTION
## Summary

Code quality cleanup from `/simplify` review. No new features — all behavioral changes are bug fixes.

### Changes
1. **`formatPrice()` utility** — extracted to `client/src/lib/utils.ts` and `server/routes.ts`, replacing 14+ inline `parseInt(x).toLocaleString() + " €"` instances. **Fixes bug:** admin artworks table showed `$` instead of `€`.
2. **`ensureArtistProfile()`** — extracted to `server/storage.ts`, deduplicating artist auto-creation from 3 places (Google OAuth, email verify, `/api/artists/me`)
3. **`deleteUser()` SQL optimization** — replaced full table scan + JS iteration + N+1 deletes with a single JSONB SQL query: `DELETE FROM sessions WHERE sess->'passport'->'user'->'claims'->>'sub' = $1`
4. **CHANGELOG.md caching** — read once at startup instead of `readFileSync` on every `/api/version` and `/api/changelog` request
5. **Concurrent artwork deletions** — `deleteArtist` now uses `Promise.all` instead of sequential loop
6. Test mocks updated for new `ensureArtistProfile` and `deleteUser` methods

## Test plan
- [x] All 52 tests pass
- [x] Production build succeeds
- [x] Price formatting consistent across all pages (€, no $)

🤖 Generated with [Claude Code](https://claude.com/claude-code)