### PR TITLE
release: v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ Deployment tags (`release-{run_number}`) are created automatically on every push
 
 ## [Unreleased]
 
-_Nothing yet — all recent work included in v2.2.1 below._
+_Nothing yet — all recent work included in v2.3.0 below._
+
+## [2.3.0] - 2026-03-18
+
+### Added
+- Role gallery curator ([#7](https://github.com/ilv78/Art-World-Hub/issues/7))
+
+### Fixed
+- Upgrade recharts from 2.x to 3.x ([#75](https://github.com/ilv78/Art-World-Hub/issues/75))
+- in the museum gallery correct names ([#32](https://github.com/ilv78/Art-World-Hub/issues/32))
 
 ## [2.2.1] - 2026-03-17
 


### PR DESCRIPTION
## Release v2.3.0

**Version:** 2.3.0
**Bump:** minor

### Changelog

### Added
- Role gallery curator ([#7](https://github.com/ilv78/Art-World-Hub/issues/7))

### Fixed
- Upgrade recharts from 2.x to 3.x ([#75](https://github.com/ilv78/Art-World-Hub/issues/75))
- in the museum gallery correct names ([#32](https://github.com/ilv78/Art-World-Hub/issues/32))

<!-- RELEASE_ISSUES: 75 32 7 -->
