### PR TITLE
fix: add migration drift check and staging auto-migrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,19 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Check migration drift
+        run: |
+          # Count migration files before and after running generate
+          BEFORE=$(find migrations -name '*.sql' 2>/dev/null | wc -l)
+          npx drizzle-kit generate
+          AFTER=$(find migrations -name '*.sql' 2>/dev/null | wc -l)
+          if [ "$AFTER" -gt "$BEFORE" ]; then
+            echo "::error::Schema has changed but no migration was committed. Run 'npx drizzle-kit generate' locally and commit the result."
+            git diff --stat
+            exit 1
+          fi
+          echo "No migration drift detected"
+
       - name: Build
         run: npm run build
         env:
@@ -145,6 +158,9 @@ jobs:
             # Ensure upload subdirs exist on the Docker volume (new subdirs may be missing)
             docker compose run --rm --no-deps --user root --entrypoint sh app -c "mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars /app/logs && chown -R appuser:appgroup /app/uploads /app/logs"
             docker compose up -d --remove-orphans
+            # Run pending database migrations
+            echo "Running database migrations..."
+            docker compose exec -T app npx drizzle-kit migrate || echo "Warning: migration failed or no pending migrations"
             echo "Waiting for app to be healthy..."
             for i in $(seq 1 60); do
               if docker compose exec -T app node -e "fetch('http://localhost:5000/health').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,20 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: artverse_dev
+      POSTGRES_USER: artverse
+      POSTGRES_PASSWORD: devpassword
+    volumes:
+      - artverse_dev_data:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U artverse -d artverse_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  artverse_dev_data:


### PR DESCRIPTION
## Summary

- **CI migration drift check**: Counts migration files before/after `drizzle-kit generate` — fails the build if schema changed without a committed migration, catching drift before it reaches staging/production
- **Staging auto-migrate**: Adds `drizzle-kit migrate` step to staging deploy (matching what #167 added for production)
- **Local dev Postgres**: Adds `docker-compose.dev.yml` for running Postgres locally on port 5433

## Test plan

- [ ] CI pipeline passes — drift check should report "No migration drift detected" since migrations are up to date
- [ ] Verify drift check catches missing migrations: modify `shared/schema.ts` without generating a migration and confirm CI fails
- [ ] Staging deploy runs migrations without errors
- [ ] `docker compose -f docker-compose.dev.yml up` starts Postgres locally on 5433

🤖 Generated with [Claude Code](https://claude.com/claude-code)