### PR TITLE
fix: mobile adaptation for 3D galleries and classic view

### DIFF
--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   SidebarMenuItem,
   SidebarHeader,
   SidebarFooter,
+  useSidebar,
 } from "@/components/ui/sidebar";
 
 const menuItems = [
@@ -56,11 +57,13 @@ const menuItems = [
 export function AppSidebar() {
   const [location] = useLocation();
   const { user, isAuthenticated, logout, isLoggingOut } = useAuth();
+  const { isMobile, setOpenMobile } = useSidebar();
+  const closeMobileSidebar = () => { if (isMobile) setOpenMobile(false); };
 
   return (
     <Sidebar>
       <SidebarHeader className="p-4 border-b border-sidebar-border">
-        <Link href="/" className="flex items-center gap-3" data-testid="link-logo">
+        <Link href="/" className="flex items-center gap-3" data-testid="link-logo" onClick={closeMobileSidebar}>
           <div className="w-10 h-10 rounded-md bg-primary flex items-center justify-center">
             <span className="text-primary-foreground font-serif font-bold text-xl">A</span>
           </div>
@@ -82,7 +85,7 @@ export function AppSidebar() {
                     isActive={location === item.url}
                     data-testid={`link-nav-${item.title.toLowerCase().replace(/\s+/g, '-')}`}
                   >
-                    <Link href={item.url}>
+                    <Link href={item.url} onClick={closeMobileSidebar}>
                       <item.icon className="w-4 h-4" />
                       <span>{item.title}</span>
                     </Link>
@@ -95,7 +98,7 @@ export function AppSidebar() {
                     asChild
                     isActive={location === "/curator"}
                   >
-                    <Link href="/curator">
+                    <Link href="/curator" onClick={closeMobileSidebar}>
                       <Brush className="w-4 h-4" />
                       <span>Curator</span>
                     </Link>
@@ -109,7 +112,7 @@ export function AppSidebar() {
                     isActive={location === "/admin"}
                     data-testid="link-nav-admin"
                   >
-                    <Link href="/admin">
+                    <Link href="/admin" onClick={closeMobileSidebar}>
                       <Shield className="w-4 h-4" />
                       <span>Admin</span>
                     </Link>
@@ -136,7 +139,7 @@ export function AppSidebar() {
             </Button>
           </div>
         ) : (
-          <Link href="/auth">
+          <Link href="/auth" onClick={closeMobileSidebar}>
             <Button variant="outline" size="sm" className="w-full">
               <LogIn className="w-4 h-4 mr-2" />
               Sign in

--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { X, ShoppingCart, Move, Mouse, Keyboard, Maximize2, Minimize2, ZoomIn, Box, Map as MapIcon } from "lucide-react";
+import { X, ShoppingCart, Move, Mouse, Keyboard, Maximize2, Minimize2, ZoomIn, Box, Map as MapIcon, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Hand } from "lucide-react";
 import type { ArtworkWithArtist, MazeLayout, MazeCell } from "@shared/schema";
 import { useCartStore } from "@/lib/cart-store";
 import { formatPrice } from "@/lib/utils";
@@ -386,6 +386,10 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
   const playerPosRef = useRef({ x: 0, z: 0, rotation: 0 });
   const isPointerLockedRef = useRef(false);
   const selectedArtworkRef = useRef<ArtworkWithArtist | null>(null);
+
+  const isMobile = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+  const touchLookRef = useRef<{ lastX: number; lastY: number } | null>(null);
+  const mobileMoveRef = useRef<{ forward: boolean; backward: boolean; left: boolean; right: boolean }>({ forward: false, backward: false, left: false, right: false });
 
   const { addItem, items } = useCartStore();
   const { toast } = useToast();
@@ -1191,10 +1195,11 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
         const right = new THREE.Vector3(1, 0, 0).applyQuaternion(cam.quaternion);
         right.y = 0; right.normalize();
 
-        if (keysPressed.current.has("KeyW") || keysPressed.current.has("ArrowUp")) dir.add(forward);
-        if (keysPressed.current.has("KeyS") || keysPressed.current.has("ArrowDown")) dir.sub(forward);
-        if (keysPressed.current.has("KeyA") || keysPressed.current.has("ArrowLeft")) dir.sub(right);
-        if (keysPressed.current.has("KeyD") || keysPressed.current.has("ArrowRight")) dir.add(right);
+        const mm = mobileMoveRef.current;
+        if (keysPressed.current.has("KeyW") || keysPressed.current.has("ArrowUp") || mm.forward) dir.add(forward);
+        if (keysPressed.current.has("KeyS") || keysPressed.current.has("ArrowDown") || mm.backward) dir.sub(forward);
+        if (keysPressed.current.has("KeyA") || keysPressed.current.has("ArrowLeft") || mm.left) dir.sub(right);
+        if (keysPressed.current.has("KeyD") || keysPressed.current.has("ArrowRight") || mm.right) dir.add(right);
 
         if (dir.length() > 0) {
           dir.normalize().multiplyScalar(MOVE_SPEED);
@@ -1262,11 +1267,62 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
       setIsPointerLocked(locked);
     };
 
+    // Touch controls for mobile
+    const handleTouchStart = (e: TouchEvent) => {
+      if (!isPointerLockedRef.current || selectedArtworkRef.current) return;
+      if (e.touches.length === 1) {
+        touchLookRef.current = { lastX: e.touches[0].clientX, lastY: e.touches[0].clientY };
+      }
+    };
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!isPointerLockedRef.current || !cameraRef.current || !touchLookRef.current) return;
+      if (e.touches.length === 1) {
+        e.preventDefault();
+        const touch = e.touches[0];
+        const dx = touch.clientX - touchLookRef.current.lastX;
+        const dy = touch.clientY - touchLookRef.current.lastY;
+        touchLookRef.current = { lastX: touch.clientX, lastY: touch.clientY };
+        euler.current.setFromQuaternion(cameraRef.current.quaternion);
+        euler.current.y -= dx * LOOK_SPEED * 1.5;
+        euler.current.x -= dy * LOOK_SPEED * 1.5;
+        euler.current.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, euler.current.x));
+        cameraRef.current.quaternion.setFromEuler(euler.current);
+      }
+    };
+    const handleTouchEnd = () => { touchLookRef.current = null; };
+    const handleTouchTap = (e: TouchEvent) => {
+      if (!isPointerLockedRef.current || !cameraRef.current || !rendererRef.current) return;
+      if (e.changedTouches.length !== 1) return;
+      const touch = e.changedTouches[0];
+      const rect = rendererRef.current.domElement.getBoundingClientRect();
+      const x = ((touch.clientX - rect.left) / rect.width) * 2 - 1;
+      const y = -((touch.clientY - rect.top) / rect.height) * 2 + 1;
+      const raycaster = new THREE.Raycaster();
+      raycaster.setFromCamera(new THREE.Vector2(x, y), cameraRef.current);
+      const meshes = Array.from(artworkMeshesRef.current.values()).map(d => d.mesh);
+      const intersects = raycaster.intersectObjects(meshes);
+      if (intersects.length > 0) {
+        const hit = intersects[0].object;
+        const entries = Array.from(artworkMeshesRef.current.entries());
+        for (const [, data] of entries) {
+          if (data.mesh === hit) { setSelectedArtwork(data.artwork); break; }
+        }
+      }
+    };
+
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("pointerlockchange", handlePointerLockChange);
     document.addEventListener("click", handleClick);
+
+    const container = containerRef.current;
+    if (container) {
+      container.addEventListener("touchstart", handleTouchStart, { passive: false });
+      container.addEventListener("touchmove", handleTouchMove, { passive: false });
+      container.addEventListener("touchend", handleTouchEnd);
+      container.addEventListener("touchend", handleTouchTap);
+    }
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
@@ -1274,6 +1330,12 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("pointerlockchange", handlePointerLockChange);
       document.removeEventListener("click", handleClick);
+      if (container) {
+        container.removeEventListener("touchstart", handleTouchStart);
+        container.removeEventListener("touchmove", handleTouchMove);
+        container.removeEventListener("touchend", handleTouchEnd);
+        container.removeEventListener("touchend", handleTouchTap);
+      }
     };
   }, [handleClick]);
 
@@ -1294,8 +1356,14 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
   }, [isPointerLocked]);
 
   const requestPointerLock = () => {
-    if (containerRef.current && typeof containerRef.current.requestPointerLock === "function") {
+    if (isMobile) {
+      isPointerLockedRef.current = true;
+      setIsPointerLocked(true);
+    } else if (containerRef.current && typeof containerRef.current.requestPointerLock === "function") {
       containerRef.current.requestPointerLock();
+    } else {
+      isPointerLockedRef.current = true;
+      setIsPointerLocked(true);
     }
   };
 
@@ -1311,7 +1379,7 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
 
   if (webglError) {
     return (
-      <div className="relative w-full bg-gradient-to-b from-stone-900 to-black rounded-lg overflow-hidden flex items-center justify-center" style={{ height: "600px" }} data-testid="webgl-fallback">
+      <div className="relative w-full bg-gradient-to-b from-stone-900 to-black rounded-lg overflow-hidden flex items-center justify-center h-[60vh] min-h-[300px] max-h-[600px]" data-testid="webgl-fallback">
         <Card className="p-8 max-w-md text-center space-y-4">
           <Box className="w-16 h-16 mx-auto text-muted-foreground" />
           <h2 className="font-serif text-2xl font-bold">3D Gallery Unavailable</h2>
@@ -1322,43 +1390,62 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
   }
 
   return (
-    <div className="relative w-full rounded-lg overflow-hidden" style={{ height: "600px" }}>
+    <div className="relative w-full rounded-lg overflow-hidden h-[60vh] min-h-[300px] max-h-[600px]">
       <div ref={containerRef} className="absolute inset-0 cursor-crosshair" style={{ zIndex: 0 }} />
 
       {!isPointerLocked && !selectedArtwork && (
         <div className="absolute inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm" style={{ zIndex: 10 }}>
-          <Card className="p-8 max-w-md text-center space-y-6">
-            <h2 className="font-serif text-2xl font-bold">Museum Hallway</h2>
-            <p className="text-muted-foreground">
-              Walk through a hallway with individual artist rooms on each side.
+          <Card className="p-6 sm:p-8 max-w-md text-center space-y-4 sm:space-y-6 mx-4">
+            <h2 className="font-serif text-xl sm:text-2xl font-bold">Museum Hallway</h2>
+            <p className="text-muted-foreground text-sm sm:text-base">
+              {isMobile
+                ? "Explore artist rooms in a 3D hallway. Drag to look, use buttons to walk."
+                : "Walk through a hallway with individual artist rooms on each side."}
             </p>
-            <div className="grid grid-cols-3 gap-4 text-sm">
-              <div className="flex flex-col items-center gap-2">
-                <Keyboard className="w-8 h-8 text-primary" />
-                <span>WASD / Arrows</span>
-                <span className="text-muted-foreground text-xs">Move</span>
+            {!isMobile && (
+              <div className="grid grid-cols-3 gap-4 text-sm">
+                <div className="flex flex-col items-center gap-2">
+                  <Keyboard className="w-8 h-8 text-primary" />
+                  <span>WASD / Arrows</span>
+                  <span className="text-muted-foreground text-xs">Move</span>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <Mouse className="w-8 h-8 text-primary" />
+                  <span>Mouse</span>
+                  <span className="text-muted-foreground text-xs">Look around</span>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <ZoomIn className="w-8 h-8 text-primary" />
+                  <span>Click</span>
+                  <span className="text-muted-foreground text-xs">View artwork</span>
+                </div>
               </div>
-              <div className="flex flex-col items-center gap-2">
-                <Mouse className="w-8 h-8 text-primary" />
-                <span>Mouse</span>
-                <span className="text-muted-foreground text-xs">Look around</span>
+            )}
+            {isMobile && (
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="flex flex-col items-center gap-2">
+                  <Hand className="w-8 h-8 text-primary" />
+                  <span>Drag</span>
+                  <span className="text-muted-foreground text-xs">Look around</span>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <ZoomIn className="w-8 h-8 text-primary" />
+                  <span>Tap</span>
+                  <span className="text-muted-foreground text-xs">View artwork</span>
+                </div>
               </div>
-              <div className="flex flex-col items-center gap-2">
-                <ZoomIn className="w-8 h-8 text-primary" />
-                <span>Click</span>
-                <span className="text-muted-foreground text-xs">View artwork</span>
-              </div>
-            </div>
+            )}
             <Button size="lg" onClick={() => { requestPointerLock(); }} className="w-full" data-testid="button-enter-gallery">
               <Move className="w-4 h-4 mr-2" />
               Enter Museum
             </Button>
-            <p className="text-xs text-muted-foreground">Press Escape to release cursor</p>
+            {!isMobile && <p className="text-xs text-muted-foreground">Press Escape to release cursor</p>}
           </Card>
         </div>
       )}
 
-      {isPointerLocked && !selectedArtwork && (
+      {/* Desktop HUD */}
+      {isPointerLocked && !selectedArtwork && !isMobile && (
         <div style={{ zIndex: 5 }}>
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none">
             <div className="w-4 h-4 border-2 border-white/50 rounded-full" />
@@ -1366,6 +1453,38 @@ export function HallwayGallery3D({ artistRooms, curatorRooms }: HallwayGallery3D
           <div className="absolute bottom-4 left-4 text-white/70 text-sm space-y-1">
             <p>WASD to move | Mouse to look</p>
             <p>Click artwork to view | ESC to exit</p>
+          </div>
+        </div>
+      )}
+
+      {/* Mobile D-pad + exit */}
+      {isPointerLocked && !selectedArtwork && isMobile && (
+        <div style={{ zIndex: 10 }}>
+          <Button size="sm" variant="secondary" className="absolute top-3 left-3 opacity-80"
+            onClick={() => { isPointerLockedRef.current = false; setIsPointerLocked(false); mobileMoveRef.current = { forward: false, backward: false, left: false, right: false }; }}>
+            <X className="w-4 h-4 mr-1" /> Exit
+          </Button>
+          <div className="absolute bottom-6 left-6 select-none touch-none" style={{ zIndex: 15 }}>
+            <div className="grid grid-cols-3 gap-1" style={{ width: "132px" }}>
+              <div />
+              <button className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.forward = true; }} onTouchEnd={() => { mobileMoveRef.current.forward = false; }} onTouchCancel={() => { mobileMoveRef.current.forward = false; }}>
+                <ArrowUp className="w-5 h-5 text-white" /></button>
+              <div />
+              <button className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.left = true; }} onTouchEnd={() => { mobileMoveRef.current.left = false; }} onTouchCancel={() => { mobileMoveRef.current.left = false; }}>
+                <ArrowLeft className="w-5 h-5 text-white" /></button>
+              <button className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.backward = true; }} onTouchEnd={() => { mobileMoveRef.current.backward = false; }} onTouchCancel={() => { mobileMoveRef.current.backward = false; }}>
+                <ArrowDown className="w-5 h-5 text-white" /></button>
+              <button className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.right = true; }} onTouchEnd={() => { mobileMoveRef.current.right = false; }} onTouchCancel={() => { mobileMoveRef.current.right = false; }}>
+                <ArrowRight className="w-5 h-5 text-white" /></button>
+            </div>
+          </div>
+          <div className="absolute bottom-6 right-6 text-white/50 text-xs text-right">
+            <p>Drag to look</p>
+            <p>Tap artwork to view</p>
           </div>
         </div>
       )}

--- a/client/src/components/maze-gallery-3d.tsx
+++ b/client/src/components/maze-gallery-3d.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { X, ShoppingCart, Info, Move, Mouse, Keyboard, Maximize2, Minimize2, ZoomIn, ZoomOut, Box, Map as MapIcon, MapPin, Palette, Image as ImageIcon, ExternalLink } from "lucide-react";
+import { X, ShoppingCart, Info, Move, Mouse, Keyboard, Maximize2, Minimize2, ZoomIn, ZoomOut, Box, Map as MapIcon, MapPin, Palette, Image as ImageIcon, ExternalLink, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Hand } from "lucide-react";
 import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import type { ArtworkWithArtist, Artist, MazeLayout, MazeCell } from "@shared/schema";
@@ -117,6 +117,11 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
   const isPointerLockedRef = useRef(false);
   const selectedArtworkRef = useRef<ArtworkWithArtist | null>(null);
   const artworkCollisionZones = useRef<{ x: number; z: number; normalX: number; normalZ: number }[]>([]);
+
+  // Mobile support
+  const isMobile = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+  const touchLookRef = useRef<{ lastX: number; lastY: number } | null>(null);
+  const mobileMoveRef = useRef<{ forward: boolean; backward: boolean; left: boolean; right: boolean }>({ forward: false, backward: false, left: false, right: false });
   
   const { addItem, items } = useCartStore();
   const { toast } = useToast();
@@ -781,17 +786,18 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
         right.y = 0;
         right.normalize();
 
-        // Apply movement based on keys
-        if (keysPressed.current.has("KeyW") || keysPressed.current.has("ArrowUp")) {
+        // Apply movement based on keys + mobile D-pad
+        const mm = mobileMoveRef.current;
+        if (keysPressed.current.has("KeyW") || keysPressed.current.has("ArrowUp") || mm.forward) {
           direction.add(forward);
         }
-        if (keysPressed.current.has("KeyS") || keysPressed.current.has("ArrowDown")) {
+        if (keysPressed.current.has("KeyS") || keysPressed.current.has("ArrowDown") || mm.backward) {
           direction.sub(forward);
         }
-        if (keysPressed.current.has("KeyA") || keysPressed.current.has("ArrowLeft")) {
+        if (keysPressed.current.has("KeyA") || keysPressed.current.has("ArrowLeft") || mm.left) {
           direction.sub(right);
         }
-        if (keysPressed.current.has("KeyD") || keysPressed.current.has("ArrowRight")) {
+        if (keysPressed.current.has("KeyD") || keysPressed.current.has("ArrowRight") || mm.right) {
           direction.add(right);
         }
 
@@ -838,10 +844,10 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
     };
   }, [layout, artworks, whiteRoom, CELL_SIZE, createMaze, placeArtworks, setupLighting, checkCollision]);
 
-  // Pointer lock and controls
+  // Pointer lock and controls (desktop + mobile touch)
   useEffect(() => {
     const movementKeys = new Set(["KeyW", "KeyA", "KeyS", "KeyD", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
-    
+
     const handleKeyDown = (e: KeyboardEvent) => {
       if (selectedArtworkRef.current) return;
       if (movementKeys.has(e.code) && isPointerLockedRef.current) {
@@ -873,11 +879,72 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
       setIsPointerLocked(locked);
     };
 
+    // Touch controls for mobile
+    const handleTouchStart = (e: TouchEvent) => {
+      if (!isPointerLockedRef.current || selectedArtworkRef.current) return;
+      if (e.touches.length === 1) {
+        touchLookRef.current = { lastX: e.touches[0].clientX, lastY: e.touches[0].clientY };
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!isPointerLockedRef.current || !cameraRef.current || !touchLookRef.current) return;
+      if (e.touches.length === 1) {
+        e.preventDefault();
+        const touch = e.touches[0];
+        const dx = touch.clientX - touchLookRef.current.lastX;
+        const dy = touch.clientY - touchLookRef.current.lastY;
+        touchLookRef.current = { lastX: touch.clientX, lastY: touch.clientY };
+
+        euler.current.setFromQuaternion(cameraRef.current.quaternion);
+        euler.current.y -= dx * LOOK_SPEED * 1.5;
+        euler.current.x -= dy * LOOK_SPEED * 1.5;
+        euler.current.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, euler.current.x));
+        cameraRef.current.quaternion.setFromEuler(euler.current);
+      }
+    };
+
+    const handleTouchEnd = () => {
+      touchLookRef.current = null;
+    };
+
+    // Tap on artwork — raycast from touch position
+    const handleTouchTap = (e: TouchEvent) => {
+      if (!isPointerLockedRef.current || !cameraRef.current || !rendererRef.current) return;
+      if (e.changedTouches.length !== 1) return;
+      const touch = e.changedTouches[0];
+      const rect = rendererRef.current.domElement.getBoundingClientRect();
+      const x = ((touch.clientX - rect.left) / rect.width) * 2 - 1;
+      const y = -((touch.clientY - rect.top) / rect.height) * 2 + 1;
+      const raycaster = new THREE.Raycaster();
+      raycaster.setFromCamera(new THREE.Vector2(x, y), cameraRef.current);
+      const meshes = Array.from(artworkMeshesRef.current.values()).map(d => d.mesh);
+      const intersects = raycaster.intersectObjects(meshes);
+      if (intersects.length > 0) {
+        const hit = intersects[0].object;
+        const entries = Array.from(artworkMeshesRef.current.entries());
+        for (const [, data] of entries) {
+          if (data.mesh === hit) {
+            setSelectedArtwork(data.artwork);
+            break;
+          }
+        }
+      }
+    };
+
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("pointerlockchange", handlePointerLockChange);
     document.addEventListener("click", handleClick);
+
+    const container = containerRef.current;
+    if (container) {
+      container.addEventListener("touchstart", handleTouchStart, { passive: false });
+      container.addEventListener("touchmove", handleTouchMove, { passive: false });
+      container.addEventListener("touchend", handleTouchEnd);
+      container.addEventListener("touchend", handleTouchTap);
+    }
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
@@ -885,6 +952,12 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("pointerlockchange", handlePointerLockChange);
       document.removeEventListener("click", handleClick);
+      if (container) {
+        container.removeEventListener("touchstart", handleTouchStart);
+        container.removeEventListener("touchmove", handleTouchMove);
+        container.removeEventListener("touchend", handleTouchEnd);
+        container.removeEventListener("touchend", handleTouchTap);
+      }
     };
   }, [handleClick]);
 
@@ -908,11 +981,17 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
   }, [isPointerLocked]);
 
   const requestPointerLock = () => {
-    if (containerRef.current && typeof containerRef.current.requestPointerLock === 'function') {
+    if (isMobile) {
+      // Mobile: skip pointer lock, just enter gallery mode
+      isPointerLockedRef.current = true;
+      setIsPointerLocked(true);
+      setShowControls(false);
+    } else if (containerRef.current && typeof containerRef.current.requestPointerLock === 'function') {
       containerRef.current.requestPointerLock();
       setShowControls(false);
     } else {
       setShowControls(false);
+      isPointerLockedRef.current = true;
       setIsPointerLocked(true);
     }
   };
@@ -930,7 +1009,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
   // Fallback UI when WebGL is not available
   if (webglError) {
     return (
-      <div className="relative w-full bg-gradient-to-b from-stone-900 to-black rounded-lg overflow-hidden flex items-center justify-center" style={{ height: "600px" }} data-testid="webgl-fallback">
+      <div className="relative w-full bg-gradient-to-b from-stone-900 to-black rounded-lg overflow-hidden flex items-center justify-center h-[60vh] min-h-[300px] max-h-[600px]" data-testid="webgl-fallback">
         <Card className="p-8 max-w-md text-center space-y-4">
           <Box className="w-16 h-16 mx-auto text-muted-foreground" />
           <h2 className="font-serif text-2xl font-bold">3D Gallery Unavailable</h2>
@@ -944,38 +1023,57 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
   }
 
   return (
-    <div className="relative w-full rounded-lg overflow-hidden" style={{ height: "600px" }}>
+    <div className="relative w-full rounded-lg overflow-hidden h-[60vh] min-h-[300px] max-h-[600px]">
       <div ref={containerRef} className="absolute inset-0 cursor-crosshair" style={{ zIndex: 0 }} />
 
       {/* Controls overlay */}
       {!isPointerLocked && !selectedArtwork && !showArtistDialog && (
         <div className="absolute inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm" style={{ zIndex: 10 }}>
-          <Card className="p-8 max-w-md text-center space-y-6">
-            <h2 className="font-serif text-2xl font-bold">Virtual Gallery</h2>
-            <p className="text-muted-foreground">
-              Walk through a 3D art gallery. Click anywhere to start exploring.
+          <Card className="p-6 sm:p-8 max-w-md text-center space-y-4 sm:space-y-6 mx-4">
+            <h2 className="font-serif text-xl sm:text-2xl font-bold">Virtual Gallery</h2>
+            <p className="text-muted-foreground text-sm sm:text-base">
+              {isMobile
+                ? "Explore a 3D art gallery. Drag to look around, use buttons to move."
+                : "Walk through a 3D art gallery. Click anywhere to start exploring."}
             </p>
-            
-            <div className="grid grid-cols-3 gap-4 text-sm">
-              <div className="flex flex-col items-center gap-2">
-                <Keyboard className="w-8 h-8 text-primary" />
-                <span>WASD / Arrows</span>
-                <span className="text-muted-foreground text-xs">Move</span>
-              </div>
-              <div className="flex flex-col items-center gap-2">
-                <Mouse className="w-8 h-8 text-primary" />
-                <span>Mouse</span>
-                <span className="text-muted-foreground text-xs">Look around</span>
-              </div>
-              <div className="flex flex-col items-center gap-2">
-                <ZoomIn className="w-8 h-8 text-primary" />
-                <span>Click</span>
-                <span className="text-muted-foreground text-xs">View artwork</span>
-              </div>
-            </div>
 
-            <Button 
-              size="lg" 
+            {!isMobile && (
+              <div className="grid grid-cols-3 gap-4 text-sm">
+                <div className="flex flex-col items-center gap-2">
+                  <Keyboard className="w-8 h-8 text-primary" />
+                  <span>WASD / Arrows</span>
+                  <span className="text-muted-foreground text-xs">Move</span>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <Mouse className="w-8 h-8 text-primary" />
+                  <span>Mouse</span>
+                  <span className="text-muted-foreground text-xs">Look around</span>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <ZoomIn className="w-8 h-8 text-primary" />
+                  <span>Click</span>
+                  <span className="text-muted-foreground text-xs">View artwork</span>
+                </div>
+              </div>
+            )}
+
+            {isMobile && (
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="flex flex-col items-center gap-2">
+                  <Hand className="w-8 h-8 text-primary" />
+                  <span>Drag</span>
+                  <span className="text-muted-foreground text-xs">Look around</span>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <ZoomIn className="w-8 h-8 text-primary" />
+                  <span>Tap</span>
+                  <span className="text-muted-foreground text-xs">View artwork</span>
+                </div>
+              </div>
+            )}
+
+            <Button
+              size="lg"
               onClick={requestPointerLock}
               className="w-full"
               data-testid="button-enter-gallery"
@@ -984,25 +1082,77 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
               Enter Gallery
             </Button>
 
-            <p className="text-xs text-muted-foreground">
-              Press ESC to exit walking mode
-            </p>
+            {!isMobile && (
+              <p className="text-xs text-muted-foreground">
+                Press ESC to exit walking mode
+              </p>
+            )}
           </Card>
         </div>
       )}
 
-      {/* HUD */}
-      {isPointerLocked && (
+      {/* HUD — desktop */}
+      {isPointerLocked && !isMobile && (
         <div style={{ zIndex: 5 }}>
-          {/* Crosshair */}
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none">
             <div className="w-4 h-4 border-2 border-white/50 rounded-full" />
           </div>
-
-          {/* Mini instructions */}
           <div className="absolute bottom-4 left-4 text-white/70 text-sm space-y-1">
             <p>WASD to move | Mouse to look</p>
             <p>Click artwork to view | ESC to pause</p>
+          </div>
+        </div>
+      )}
+
+      {/* Mobile D-pad + exit button */}
+      {isPointerLocked && isMobile && (
+        <div style={{ zIndex: 10 }}>
+          {/* Exit button */}
+          <Button
+            size="sm"
+            variant="secondary"
+            className="absolute top-3 left-3 opacity-80"
+            onClick={() => { isPointerLockedRef.current = false; setIsPointerLocked(false); mobileMoveRef.current = { forward: false, backward: false, left: false, right: false }; }}
+          >
+            <X className="w-4 h-4 mr-1" /> Exit
+          </Button>
+
+          {/* D-pad */}
+          <div className="absolute bottom-6 left-6 select-none touch-none" style={{ zIndex: 15 }}>
+            <div className="grid grid-cols-3 gap-1" style={{ width: "132px" }}>
+              <div />
+              <button
+                className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.forward = true; }}
+                onTouchEnd={() => { mobileMoveRef.current.forward = false; }}
+                onTouchCancel={() => { mobileMoveRef.current.forward = false; }}
+              ><ArrowUp className="w-5 h-5 text-white" /></button>
+              <div />
+              <button
+                className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.left = true; }}
+                onTouchEnd={() => { mobileMoveRef.current.left = false; }}
+                onTouchCancel={() => { mobileMoveRef.current.left = false; }}
+              ><ArrowLeft className="w-5 h-5 text-white" /></button>
+              <button
+                className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.backward = true; }}
+                onTouchEnd={() => { mobileMoveRef.current.backward = false; }}
+                onTouchCancel={() => { mobileMoveRef.current.backward = false; }}
+              ><ArrowDown className="w-5 h-5 text-white" /></button>
+              <button
+                className="w-11 h-11 rounded-lg bg-white/20 active:bg-white/40 flex items-center justify-center backdrop-blur-sm"
+                onTouchStart={() => { mobileMoveRef.current.right = true; }}
+                onTouchEnd={() => { mobileMoveRef.current.right = false; }}
+                onTouchCancel={() => { mobileMoveRef.current.right = false; }}
+              ><ArrowRight className="w-5 h-5 text-white" /></button>
+            </div>
+          </div>
+
+          {/* Look hint */}
+          <div className="absolute bottom-6 right-6 text-white/50 text-xs text-right">
+            <p>Drag to look</p>
+            <p>Tap artwork to view</p>
           </div>
         </div>
       )}

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -32,7 +32,8 @@ interface ArtistRoom {
 }
 
 export default function Gallery() {
-  const [viewMode, setViewMode] = useState<ViewMode>("3d");
+  const isMobile = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+  const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? "classic" : "3d");
   const [currentIndex, setCurrentIndex] = useState(0);
   const [zoom, setZoom] = useState(1);
   const [showInfo, setShowInfo] = useState(false);
@@ -85,6 +86,9 @@ export default function Gallery() {
     }
   };
 
+  // Swipe tracking for mobile classic view
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (viewMode !== "classic") return;
@@ -93,8 +97,29 @@ export default function Gallery() {
       if (e.key === "i") setShowInfo((prev) => !prev);
       if (e.key === "Escape") setShowInfo(false);
     };
+    const handleTouchStart = (e: TouchEvent) => {
+      if (viewMode !== "classic") return;
+      touchStartRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    };
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (viewMode !== "classic" || !touchStartRef.current) return;
+      const dx = e.changedTouches[0].clientX - touchStartRef.current.x;
+      const dy = e.changedTouches[0].clientY - touchStartRef.current.y;
+      touchStartRef.current = null;
+      // Only horizontal swipes (minimum 50px, not too vertical)
+      if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+        if (dx < 0) handleNext();
+        else handlePrevious();
+      }
+    };
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("touchstart", handleTouchStart, { passive: true });
+    window.addEventListener("touchend", handleTouchEnd, { passive: true });
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
   }, [galleryArtworks.length, viewMode]);
 
   const isLoading = artworksLoading || hallwayLoading;
@@ -191,7 +216,7 @@ export default function Gallery() {
             <div className="absolute top-0 left-1/2 -translate-x-1/2 w-1/2 h-32 bg-gradient-to-b from-yellow-100/30 to-transparent dark:from-yellow-100/10 blur-xl" />
           </div>
 
-          <div className="relative flex-1 flex items-center justify-center gap-4 p-8">
+          <div className="relative flex-1 flex items-center justify-center gap-2 sm:gap-4 p-4 sm:p-8">
             <Button
               variant="secondary"
               size="icon"
@@ -209,10 +234,10 @@ export default function Gallery() {
               <img
                 src={currentArtwork.imageUrl}
                 alt={currentArtwork.title}
-                className="max-w-lg max-h-[60vh] object-contain shadow-2xl rounded-sm"
+                className="max-w-[70vw] sm:max-w-lg max-h-[50vh] sm:max-h-[60vh] object-contain shadow-2xl rounded-sm"
                 data-testid="img-current-artwork"
               />
-              <div className="absolute bottom-0 left-full ml-2 z-20 w-48 p-2 bg-white/90 dark:bg-stone-800/90 backdrop-blur-sm shadow-lg rounded-sm text-left">
+              <div className="absolute -bottom-12 left-0 right-0 sm:bottom-0 sm:left-full sm:right-auto sm:ml-2 z-20 w-auto sm:w-48 p-2 bg-white/90 dark:bg-stone-800/90 backdrop-blur-sm shadow-lg rounded-sm text-left">
                 <h3 className="font-serif font-bold text-sm truncate" data-testid="text-artwork-title">
                   {currentArtwork.title}
                 </h3>
@@ -220,7 +245,7 @@ export default function Gallery() {
                   {currentArtwork.artist.name}
                   {currentArtwork.year && `, ${currentArtwork.year}`}
                 </p>
-                <p className="text-xs text-muted-foreground mt-1">{currentArtwork.medium}</p>
+                <p className="text-xs text-muted-foreground mt-1 hidden sm:block">{currentArtwork.medium}</p>
               </div>
             </div>
 

--- a/specs/bugs/BUG-0172-mobile-adaptation.md
+++ b/specs/bugs/BUG-0172-mobile-adaptation.md
@@ -1,0 +1,38 @@
+# BUG-0172: Mobile Adaptation
+
+**Status:** Fixed
+**Priority:** Critical
+**Issue:** #172
+
+## Problem
+
+1. **3D maze gallery not visible on mobile** — Pointer Lock API doesn't exist on mobile devices, so the gallery was permanently stuck on the "Click to Enter" overlay. No touch controls existed.
+2. **2D/Classic view not functional on mobile** — Navigation was keyboard-only (arrow keys), artwork info label overflowed off-screen on narrow viewports.
+
+## Root Causes
+
+- `requestPointerLock()` is a desktop-only API; mobile browsers don't support it
+- No touch event handlers (`touchstart`, `touchmove`, `touchend`) in 3D components
+- Fixed `600px` container height caused layout issues on small viewports
+- Classic view relied entirely on keyboard for navigation (no swipe)
+- Artwork info label positioned with `left-full` (off-screen on mobile)
+
+## Fix
+
+### 3D Galleries (`maze-gallery-3d.tsx` + `hallway-gallery-3d.tsx`)
+
+- **Mobile detection**: `"ontouchstart" in window || navigator.maxTouchPoints > 0`
+- **Touch-to-look**: Single-finger drag rotates camera (using `touchstart`/`touchmove`/`touchend`)
+- **On-screen D-pad**: 4-button directional pad in bottom-left corner for movement
+- **Tap-to-select**: Touch raycasting to select artworks
+- **Bypass pointer lock on mobile**: Gallery enters directly without pointer lock
+- **Exit button**: Mobile gets an explicit "Exit" button (no ESC key on mobile)
+- **Responsive container**: Changed from `style={{ height: "600px" }}` to `h-[60vh] min-h-[300px] max-h-[600px]`
+- **Mobile-adapted entry overlay**: Simpler instructions (Drag/Tap instead of WASD/Mouse/Click)
+
+### Classic View (`gallery.tsx`)
+
+- **Swipe navigation**: Horizontal swipe (>50px, more horizontal than vertical) navigates between artworks
+- **Responsive image sizing**: `max-w-[70vw] sm:max-w-lg max-h-[50vh] sm:max-h-[60vh]`
+- **Responsive info label**: Positioned below artwork on mobile, beside it on desktop
+- **Reduced padding**: `p-4 sm:p-8` and `gap-2 sm:gap-4` for smaller screens


### PR DESCRIPTION
## Summary

- **3D galleries (maze + hallway)**: Touch-to-look (drag), on-screen D-pad for movement, tap-to-select artworks, bypass pointer lock on mobile, responsive container (`h-[60vh]` instead of fixed `600px`)
- **Classic/2D view**: Swipe left/right to navigate artworks, responsive image sizing and label positioning, defaults to 2D on mobile
- **Sidebar**: Auto-closes on mobile after any link is clicked

## Test plan

- [ ] Open on mobile (or Chrome DevTools device mode) — gallery should default to Classic view
- [ ] Classic view: swipe left/right navigates between artworks, artwork label visible below image
- [ ] Switch to 3D Museum tab — entry overlay shows mobile instructions (Drag/Tap)
- [ ] Enter 3D gallery — D-pad buttons appear in bottom-left, drag to look around works
- [ ] Tap on artwork in 3D to open detail dialog
- [ ] Exit button in top-left exits 3D mode
- [ ] Sidebar menu: clicking any link closes the sidebar overlay on mobile
- [ ] Desktop: no behavior changes — pointer lock, WASD, mouse all work as before

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)