### PR TITLE
hotfix: fix seed FK violation crashing staging

### DIFF
--- a/server/seed.ts
+++ b/server/seed.ts
@@ -1,5 +1,5 @@
 import { db } from "./db";
-import { artists, artworks, auctions, bids, orders, exhibitions, exhibitionArtworks, blogPosts } from "@shared/schema";
+import { artists, artworks, auctions, bids, orders, exhibitions, exhibitionArtworks, blogPosts, curatorGalleryArtworks, curatorGalleries } from "@shared/schema";
 import { sql, eq } from "drizzle-orm";
 import { seedLogger as logger } from "./logger";
 
@@ -304,6 +304,8 @@ export async function seedDatabase() {
 
     if (existingArtists.length > 0 && !hasCorrectData) {
       logger.info("Stale seed data detected, clearing and reseeding");
+      await db.delete(curatorGalleryArtworks);
+      await db.delete(curatorGalleries);
       await db.delete(exhibitionArtworks);
       await db.delete(bids);
       await db.delete(auctions);


### PR DESCRIPTION
## Summary

- Staging is **down** — app crashes on startup during seed reseed
- Seed cleanup deletes `artworks` before `curator_gallery_artworks`, violating FK constraint
- Adds `curator_gallery_artworks` and `curator_galleries` deletion before `artworks` in the reseed cleanup

## Root cause

The seed detects stale data and tries to clear+reseed, but the deletion order didn't account for curator gallery tables added in v2.3.0. Artworks referenced by curator galleries can't be deleted first.

## Test plan

- [ ] CI passes
- [ ] Staging deploy succeeds and app is healthy
- [ ] Seed reseed works without FK errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)