### PR TITLE
fix: upgrade flatted to patch high-severity vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9565,9 +9565,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- Upgrades `flatted` to patch Prototype Pollution via `parse()` (GHSA-rf6f-7fwh-wjgh)
- Only change: `package-lock.json` version bump
- CI Dependency Audit (npm audit) should now pass, unblocking the Gate check on all PRs

## Test plan

- [ ] `npm audit` reports 0 vulnerabilities
- [ ] All tests pass
- [ ] CI Gate check passes (no more audit failure)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)