### PR TITLE
chore: upgrade Node.js from 20 to 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 25
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 25
           cache: npm
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-bookworm-slim AS deps
+FROM node:25-bookworm-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-FROM node:20-bookworm-slim AS build
+FROM node:25-bookworm-slim AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NODE_ENV=production
 RUN npm run build
 
-FROM node:20-bookworm-slim AS run
+FROM node:25-bookworm-slim AS run
 WORKDIR /app
 ENV NODE_ENV=production
 ARG APP_VERSION=dev


### PR DESCRIPTION
## Summary
- Upgrade Node.js from 20 to 25 across Dockerfile (all 3 stages) and CI workflows (ci.yml, security.yml)
- Docker build verified locally with `node:25-bookworm-slim`
- All tests pass (54/54), type check clean, production build succeeds

Closes #73

## Test plan
- [ ] CI pipeline passes with Node 25
- [ ] Docker image builds and starts correctly
- [ ] Staging deployment works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)