### PR TITLE
fix: copy .npmrc into Docker deps stage for npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:25-bookworm-slim AS deps
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 
 FROM node:25-bookworm-slim AS build


### PR DESCRIPTION
## Summary
- Copy `.npmrc` alongside `package.json` and `package-lock.json` in the Docker deps stage
- Required for `npm ci` to resolve the optional esbuild peer dep conflict from `rolldown-vite`

## Test plan
- [ ] CI Docker build passes (was failing after #208 merge)

refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)