### PR TITLE
fix: copy .npmrc into Docker run stage for npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 ARG APP_VERSION=dev
 ENV APP_VERSION=$APP_VERSION
-COPY --from=build /app/package.json /app/package-lock.json ./
+COPY --from=build /app/package.json /app/package-lock.json /app/.npmrc ./
 RUN npm ci --omit=dev --ignore-scripts
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/shared ./shared


### PR DESCRIPTION
## Summary
- Also copy `.npmrc` in the `run` stage (line 20) — the `deps` stage was fixed in #210 but the `run` stage's `npm ci --omit=dev` also needs it

## Test plan
- [ ] CI Docker build passes (staging deploy unblocked)

refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)