### PR TITLE
feat: upgrade react-resizable-panels from 2.x to 4.x

### DIFF
--- a/client/src/components/ui/resizable.tsx
+++ b/client/src/components/ui/resizable.tsx
@@ -8,8 +8,8 @@ import { cn } from "@/lib/utils"
 const ResizablePanelGroup = ({
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
-  <ResizablePrimitive.PanelGroup
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) => (
+  <ResizablePrimitive.Group
     className={cn(
       "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
       className
@@ -24,10 +24,10 @@ const ResizableHandle = ({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean
 }) => (
-  <ResizablePrimitive.PanelResizeHandle
+  <ResizablePrimitive.Separator
     className={cn(
       "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
       className
@@ -39,7 +39,7 @@ const ResizableHandle = ({
         <GripVertical className="h-2.5 w-2.5" />
       </div>
     )}
-  </ResizablePrimitive.PanelResizeHandle>
+  </ResizablePrimitive.Separator>
 )
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "react-hook-form": "^7.71.2",
         "react-icons": "^5.4.0",
         "react-markdown": "^10.1.0",
-        "react-resizable-panels": "^2.1.7",
+        "react-resizable-panels": "^4.7.5",
         "recharts": "^3.8.0",
         "resend": "^6.9.4",
         "tailwind-merge": "^2.6.0",
@@ -10838,13 +10838,13 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
-      "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.7.5.tgz",
+      "integrity": "sha512-ma22FpbUolymMK6xIwZOzzNxszi59kZdJiw805byxuGBrjAs8HngpQrrgEp5dj1OOV2jVFBCJxhVult6G+2KaQ==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-hook-form": "^7.71.2",
     "react-icons": "^5.4.0",
     "react-markdown": "^10.1.0",
-    "react-resizable-panels": "^2.1.7",
+    "react-resizable-panels": "^4.7.5",
     "recharts": "^3.8.0",
     "resend": "^6.9.4",
     "tailwind-merge": "^2.6.0",


### PR DESCRIPTION
## Summary
- Upgrade `react-resizable-panels` from 2.1.7 to 4.7.5
- Update Shadcn wrapper (`resizable.tsx`) for v4 API renames: `PanelGroup` → `Group`, `PanelResizeHandle` → `Separator`
- Wrapper components are not actively used in the app, so no visual changes

## Test plan
- [x] `npm run check` — zero type errors
- [x] `npm test` — 54/54 tests pass
- [x] `npm run build` — success
- [x] `npm run dev` — app works normally
- [x] Manual dev testing — LGTM
- [ ] CI passes

closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)