### PR TITLE
fix: artwork click not working when same artwork in artist + curator room

### DIFF
--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -954,7 +954,10 @@ export function HallwayGallery3D({ artistRooms, curatorRooms, museumTemplate }: 
         artMesh.rotation.y = worldRotY;
         artMesh.translateZ(0.06);
         scene.add(artMesh);
-        artworkMeshesRef.current.set(artwork.id, { mesh: artMesh, artwork });
+        // Use a unique key per physical placement to avoid collisions when the
+        // same artwork appears in both an artist room and a curator room.
+        const meshKey = `${artwork.id}-${p.isLeft ? "L" : "R"}-${p.corridorZ}-${si}`;
+        artworkMeshesRef.current.set(meshKey, { mesh: artMesh, artwork });
 
         loadTextureWithCache(artwork.imageUrl).then(texture => {
           artMesh.material = new THREE.MeshStandardMaterial({ map: texture, roughness: 0.3 });


### PR DESCRIPTION
## Summary
- Fix artwork click handler in hallway gallery when the same artwork appears in both an artist room and a curator room
- Root cause: `artworkMeshesRef` Map used `artwork.id` as key — second `Map.set()` overwrote the first, so clicking the artwork in the first room found no mesh match
- Fix: use unique placement key (`artwork.id-side-position-slot`) so each physical mesh has its own entry

## Test plan
- [x] `npm test` — 54/54 pass
- [x] `npm run build` — success
- [x] `npm run dev` — app works, artworks clickable
- [x] Manual testing — LGTM
- [ ] CI passes

closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)