### PR TITLE
feat: migrate Zod v3 → v4 (closes #198)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "dotenv": "^17.3.1",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.39.3",
-        "drizzle-zod": "^0.7.0",
+        "drizzle-zod": "^0.8.3",
         "embla-carousel-react": "^8.6.0",
         "express": "^5.0.1",
         "express-rate-limit": "^8.3.1",
@@ -87,7 +87,7 @@
         "vaul": "^1.1.2",
         "wouter": "^3.9.0",
         "ws": "^8.20.0",
-        "zod": "^3.24.2",
+        "zod": "^4.3.6",
         "zod-validation-error": "^3.4.0",
         "zustand": "^5.0.12"
       },
@@ -6762,13 +6762,13 @@
       }
     },
     "node_modules/drizzle-zod": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/drizzle-zod/-/drizzle-zod-0.7.1.tgz",
-      "integrity": "sha512-nZzALOdz44/AL2U005UlmMqaQ1qe5JfanvLujiTHiiT8+vZJTBFhj3pY4Vk+L6UWyKFfNmLhk602Hn4kCTynKQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/drizzle-zod/-/drizzle-zod-0.8.3.tgz",
+      "integrity": "sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "drizzle-orm": ">=0.36.0",
-        "zod": ">=3.0.0"
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -13741,9 +13741,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dotenv": "^17.3.1",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.39.3",
-    "drizzle-zod": "^0.7.0",
+    "drizzle-zod": "^0.8.3",
     "embla-carousel-react": "^8.6.0",
     "express": "^5.0.1",
     "express-rate-limit": "^8.3.1",
@@ -94,7 +94,7 @@
     "vaul": "^1.1.2",
     "wouter": "^3.9.0",
     "ws": "^8.20.0",
-    "zod": "^3.24.2",
+    "zod": "^4.3.6",
     "zod-validation-error": "^3.4.0",
     "zustand": "^5.0.12"
   },

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -486,7 +486,7 @@ export function createMcpServer(): McpServer {
       country: z.string().optional().describe("Country"),
       specialization: z.string().optional().describe("Art specialization"),
       email: z.string().email().optional().describe("Contact email"),
-      socialLinks: z.record(z.string()).optional().describe("Social media links as key-value pairs (e.g. { instagram: 'url', website: 'url' })"),
+      socialLinks: z.record(z.string(), z.string()).optional().describe("Social media links as key-value pairs (e.g. { instagram: 'url', website: 'url' })"),
     },
     async (args) => {
       try {

--- a/server/replit_integrations/auth/replitAuth.ts
+++ b/server/replit_integrations/auth/replitAuth.ts
@@ -217,7 +217,7 @@ export async function setupAuth(app: Express) {
       res.json({ message: "Check your email for a verification link." });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ message: error.errors[0].message });
+        return res.status(400).json({ message: error.issues[0].message });
       }
       logger.error({ err: error }, "Signup error");
       res.status(500).json({ message: "Failed to send verification email" });
@@ -285,7 +285,7 @@ export async function setupAuth(app: Express) {
       res.json({ message: "Password set successfully" });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ message: error.errors[0].message });
+        return res.status(400).json({ message: error.issues[0].message });
       }
       logger.error({ err: error }, "Set password error");
       res.status(500).json({ message: "Failed to set password" });
@@ -298,7 +298,7 @@ export async function setupAuth(app: Express) {
       loginSchema.parse(req.body);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ message: error.errors[0].message });
+        return res.status(400).json({ message: error.issues[0].message });
       }
     }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -522,7 +522,7 @@ export async function registerRoutes(
       res.status(201).json(bid);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: error.errors[0].message });
+        return res.status(400).json({ error: error.issues[0].message });
       }
       res.status(500).json({ error: "Failed to place bid" });
     }
@@ -599,7 +599,7 @@ export async function registerRoutes(
       res.status(201).json(order);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: error.errors[0].message });
+        return res.status(400).json({ error: error.issues[0].message });
       }
       res.status(500).json({ error: "Failed to create order" });
     }
@@ -723,7 +723,7 @@ export async function registerRoutes(
       res.status(201).json(post);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: error.errors[0].message });
+        return res.status(400).json({ error: error.issues[0].message });
       }
       res.status(500).json({ error: "Failed to create blog post" });
     }
@@ -788,7 +788,7 @@ export async function registerRoutes(
       res.json(artist);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: error.errors[0].message });
+        return res.status(400).json({ error: error.issues[0].message });
       }
       res.status(500).json({ error: "Failed to update artist" });
     }
@@ -812,7 +812,7 @@ export async function registerRoutes(
       res.status(201).json(artwork);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: error.errors[0].message });
+        return res.status(400).json({ error: error.issues[0].message });
       }
       res.status(500).json({ error: "Failed to create artwork" });
     }

--- a/specs/architecture/OVERVIEW.md
+++ b/specs/architecture/OVERVIEW.md
@@ -446,7 +446,7 @@ npx vitest run <file>       # Single file
 | openid-client | 6.8 | OIDC protocol |
 | bcryptjs | 3.0 | Password hashing |
 | Resend | 4.0 | Transactional email |
-| Zod | 3.24 | Schema validation |
+| Zod | 4.3 | Schema validation |
 | @modelcontextprotocol/sdk | 1.26 | MCP server |
 | esbuild | 0.25 | Server bundler |
 | Vitest | 3.2 | Test framework |


### PR DESCRIPTION
## Summary

- Upgrade `zod` from 3.24.2 to **4.3.6** (6–14x faster parsing, 57% smaller bundle)
- Upgrade `drizzle-zod` from 0.7.0 to **0.8.3** (Zod v4 compatibility)
- Fix `z.record()` in `server/mcp.ts` — v4 requires both key and value schemas
- Fix `ZodError.errors` → `ZodError.issues` in `server/routes.ts` and `replitAuth.ts` (v4 API rename)
- Update version in `specs/architecture/OVERVIEW.md`

## Test plan

- [x] `npm run check` — zero type errors
- [x] `npm test` — 54/54 tests pass
- [x] `npm run build` — production build succeeds
- [x] Dev server manual testing — pages load, images render, API validation works
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)