### PR TITLE
chore: remove unused zod-validation-error dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,6 @@
         "wouter": "^3.9.0",
         "ws": "^8.20.0",
         "zod": "^4.3.6",
-        "zod-validation-error": "^3.4.0",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -13756,18 +13755,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
-      }
-    },
-    "node_modules/zod-validation-error": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
-      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.24.4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "wouter": "^3.9.0",
     "ws": "^8.20.0",
     "zod": "^4.3.6",
-    "zod-validation-error": "^3.4.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/script/build.ts
+++ b/script/build.ts
@@ -33,7 +33,6 @@ const allowlist = [
   "ws",
   "xlsx",
   "zod",
-  "zod-validation-error",
 ];
 
 async function buildAll() {


### PR DESCRIPTION
## Summary

- Remove `zod-validation-error` from `package.json` — never imported anywhere in the codebase
- Remove from esbuild bundle allowlist in `script/build.ts`

Found during `/simplify` review of the Zod v4 migration (#224).

## Test plan

- [x] `npm run check` — zero type errors
- [x] `npm test` — 54/54 tests pass
- [x] `npm run build` — production build succeeds
- [x] Dev server manual testing — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)