### PR TITLE
feat: curator profile editor and role-based dashboard navigation

### DIFF
--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -47,11 +47,6 @@ const menuItems = [
     url: "/blog",
     icon: BookOpen,
   },
-  {
-    title: "Artist Dashboard",
-    url: "/dashboard",
-    icon: LayoutDashboard,
-  },
 ];
 
 export function AppSidebar() {
@@ -92,15 +87,30 @@ export function AppSidebar() {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
-              {isAuthenticated && (user?.role === "curator" || user?.role === "admin") && (
+              {isAuthenticated && user?.role === "user" && (
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={location === "/dashboard"}
+                    data-testid="link-nav-artist-dashboard"
+                  >
+                    <Link href="/dashboard" onClick={closeMobileSidebar}>
+                      <LayoutDashboard className="w-4 h-4" />
+                      <span>Artist Dashboard</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              )}
+              {isAuthenticated && user?.role === "curator" && (
                 <SidebarMenuItem>
                   <SidebarMenuButton
                     asChild
                     isActive={location === "/curator"}
+                    data-testid="link-nav-curator-dashboard"
                   >
                     <Link href="/curator" onClick={closeMobileSidebar}>
                       <Brush className="w-4 h-4" />
-                      <span>Curator</span>
+                      <span>Curator Dashboard</span>
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
@@ -110,11 +120,11 @@ export function AppSidebar() {
                   <SidebarMenuButton
                     asChild
                     isActive={location === "/admin"}
-                    data-testid="link-nav-admin"
+                    data-testid="link-nav-admin-dashboard"
                   >
                     <Link href="/admin" onClick={closeMobileSidebar}>
                       <Shield className="w-4 h-4" />
-                      <span>Admin</span>
+                      <span>Admin Dashboard</span>
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/client/src/pages/curator-dashboard.tsx
+++ b/client/src/pages/curator-dashboard.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/use-auth";
-import { Plus, Trash2, Save, Loader2, Image as ImageIcon, GripVertical, LogIn } from "lucide-react";
+import { Plus, Trash2, Save, Loader2, Image as ImageIcon, GripVertical, LogIn, Pencil } from "lucide-react";
 import type { CuratorGalleryWithArtworks, ArtworkWithArtist } from "@shared/schema";
 
 export default function CuratorDashboard() {
@@ -41,6 +41,28 @@ export default function CuratorDashboard() {
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [newDescription, setNewDescription] = useState("");
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [profileFirstName, setProfileFirstName] = useState("");
+  const [profileLastName, setProfileLastName] = useState("");
+
+  useEffect(() => {
+    if (user) {
+      setProfileFirstName(user.firstName || "");
+      setProfileLastName(user.lastName || "");
+    }
+  }, [user]);
+
+  const profileMutation = useMutation({
+    mutationFn: async (data: { firstName: string; lastName: string }) => {
+      const res = await apiRequest("PATCH", "/api/curator/profile", data);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/auth/user"] });
+      setEditingProfile(false);
+      toast({ title: "Profile updated" });
+    },
+  });
 
   const isCurator = isAuthenticated && (user?.role === "curator" || user?.role === "admin");
 
@@ -112,6 +134,7 @@ export default function CuratorDashboard() {
           <DialogTrigger asChild>
             <Button><Plus className="w-4 h-4 mr-2" />New Gallery</Button>
           </DialogTrigger>
+
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Create Gallery</DialogTitle>
@@ -139,6 +162,50 @@ export default function CuratorDashboard() {
           </DialogContent>
         </Dialog>
       </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+          <CardTitle className="text-lg">Profile</CardTitle>
+          {!editingProfile && (
+            <Button variant="ghost" size="sm" onClick={() => setEditingProfile(true)}>
+              <Pencil className="w-4 h-4 mr-1" />Edit
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {editingProfile ? (
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="profile-first">First name</Label>
+                <Input id="profile-first" value={profileFirstName} onChange={e => setProfileFirstName(e.target.value)} className="w-48" />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="profile-last">Last name</Label>
+                <Input id="profile-last" value={profileLastName} onChange={e => setProfileLastName(e.target.value)} className="w-48" />
+              </div>
+              <Button
+                size="sm"
+                onClick={() => profileMutation.mutate({ firstName: profileFirstName, lastName: profileLastName })}
+                disabled={profileMutation.isPending}
+              >
+                {profileMutation.isPending && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                <Save className="w-4 h-4 mr-1" />Save
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => {
+                setProfileFirstName(user?.firstName || "");
+                setProfileLastName(user?.lastName || "");
+                setEditingProfile(false);
+              }}>Cancel</Button>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {user?.firstName || user?.lastName
+                ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim()
+                : <span className="italic">No name set — click Edit to add your display name</span>}
+            </p>
+          )}
+        </CardContent>
+      </Card>
 
       {isLoading ? (
         <div className="grid gap-4">

--- a/server/__tests__/helpers/mock-storage.ts
+++ b/server/__tests__/helpers/mock-storage.ts
@@ -67,6 +67,9 @@ export function createMockStorage(): IStorage {
     regenerateCuratorGalleryLayout: vi.fn().mockResolvedValue({ width: 3, height: 3, cells: [], spawnPoint: { x: 1, z: 1 } }),
     getAllExhibitionReadyArtworks: vi.fn().mockResolvedValue([]),
 
+    // User profile
+    updateUserProfile: vi.fn().mockResolvedValue(undefined),
+
     // Admin
     getUsers: vi.fn().mockResolvedValue([]),
     updateUserRole: vi.fn().mockResolvedValue(undefined),

--- a/server/__tests__/helpers/test-app.ts
+++ b/server/__tests__/helpers/test-app.ts
@@ -41,6 +41,7 @@ const { mockStorage } = vi.hoisted(() => {
     deleteBlogPost: fn().mockResolvedValue(false),
     getExhibitionReadyArtworks: fn().mockResolvedValue([]),
     regenerateArtistGallery: fn().mockResolvedValue({ width: 3, height: 3, cells: [], spawnPoint: { x: 1, z: 1 } }),
+    updateUserProfile: fn().mockResolvedValue(undefined),
     getUsers: fn().mockResolvedValue([]),
     updateUserRole: fn().mockResolvedValue(undefined),
     deleteArtist: fn().mockResolvedValue(false),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -914,6 +914,27 @@ export async function registerRoutes(
     }
   });
 
+  // Curator: update own profile (name)
+  app.patch("/api/curator/profile", isCurator, async (req: any, res) => {
+    try {
+      const userId = req.user?.claims?.sub;
+      const { firstName, lastName } = req.body;
+      if (typeof firstName !== "string" && typeof lastName !== "string") {
+        return res.status(400).json({ error: "Provide firstName or lastName" });
+      }
+      const data: { firstName?: string; lastName?: string } = {};
+      if (typeof firstName === "string") data.firstName = firstName.trim();
+      if (typeof lastName === "string") data.lastName = lastName.trim();
+      const user = await storage.updateUserProfile(userId, data);
+      if (!user) return res.status(404).json({ error: "User not found" });
+      const { password: _, ...safeUser } = user;
+      res.json(safeUser);
+    } catch (error) {
+      logger.error({ err: error }, "Update curator profile error");
+      res.status(500).json({ error: "Failed to update profile" });
+    }
+  });
+
   // Curator: available artworks
   app.get("/api/curator/artworks/available", isCurator, async (_req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -90,6 +90,9 @@ export interface IStorage {
   regenerateCuratorGalleryLayout(galleryId: string): Promise<MazeLayout>;
   getAllExhibitionReadyArtworks(): Promise<ArtworkWithArtist[]>;
 
+  // User profile
+  updateUserProfile(userId: string, data: { firstName?: string; lastName?: string }): Promise<User | undefined>;
+
   // Admin
   getUsers(): Promise<User[]>;
   updateUserRole(userId: string, role: UserRole): Promise<User | undefined>;
@@ -429,6 +432,15 @@ export class DatabaseStorage implements IStorage {
   // Admin
   async getUsers(): Promise<User[]> {
     return db.select().from(users).orderBy(desc(users.createdAt));
+  }
+
+  async updateUserProfile(userId: string, data: { firstName?: string; lastName?: string }): Promise<User | undefined> {
+    const [user] = await db
+      .update(users)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(users.id, userId))
+      .returning();
+    return user;
   }
 
   async updateUserRole(userId: string, role: UserRole): Promise<User | undefined> {


### PR DESCRIPTION
## Summary
- **Role-based sidebar navigation**: each role sees only their dashboard link — Artist Dashboard (user), Curator Dashboard (curator), Admin Dashboard (admin)
- **Curator profile editor**: new Profile card at top of Curator Dashboard with inline first/last name editing
- **New API endpoint**: `PATCH /api/curator/profile` (curator-protected) to update display name

Closes [#164](https://github.com/ilv78/Art-World-Hub/issues/164)

## Test plan
- [ ] Log in as `user` role → sidebar shows "Artist Dashboard" only
- [ ] Log in as `curator` role → sidebar shows "Curator Dashboard" only (no "Artist Dashboard")
- [ ] Log in as `admin` role → sidebar shows "Admin Dashboard" only (no others)
- [ ] On Curator Dashboard, click Profile Edit → change name → Save → verify name updates in sidebar footer
- [ ] Verify unauthenticated users see no dashboard links

🤖 Generated with [Claude Code](https://claude.com/claude-code)