### PR TITLE
feat: preview environment for redesign/v3 branch (closes #235)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    branches: [main]
+    branches: [main, redesign/v3]
 
 permissions:
   contents: read
@@ -81,7 +81,7 @@ jobs:
   changes:
     name: Detect Code Changes
     needs: ci
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/redesign/v3') && github.event_name == 'push'
     runs-on: ubuntu-latest
 
     permissions:
@@ -107,7 +107,7 @@ jobs:
   build-image:
     name: Build & Push Docker Image
     needs: [ci, changes]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.changes.outputs.code == 'true'
+    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/redesign/v3') && github.event_name == 'push' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     permissions:
@@ -186,6 +186,7 @@ jobs:
   deploy-staging:
     name: Deploy to Staging
     needs: scan-image
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     permissions:
@@ -299,4 +300,98 @@ jobs:
           Staging address: https://staging.artverse.idata.ro
           Tag: <code>${DEPLOY_SHA}</code>
           Release: <code>release-${RUN_NUMBER}</code>
+          By: ${TRIGGERED_BY}"
+
+  deploy-preview:
+    name: Deploy to Preview
+    needs: scan-image
+    if: github.ref == 'refs/heads/redesign/v3'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Sync docker-compose to VPS
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: preview
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: deploy/preview/docker-compose.yml
+          target: ~/app/
+          strip_components: 2
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: preview
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: DEPLOY_SHA
+          script: |
+            cd ~/app
+            docker pull ghcr.io/ilv78/art-world-hub:$DEPLOY_SHA
+            sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$DEPLOY_SHA/" .env || echo "IMAGE_TAG=$DEPLOY_SHA" >> .env
+            # Ensure upload subdirs exist on the Docker volume (new subdirs may be missing)
+            docker compose run --rm --no-deps --user root --entrypoint sh app -c "mkdir -p /app/uploads/artworks /app/uploads/blog-covers /app/uploads/avatars /app/logs && chown -R appuser:appgroup /app/uploads /app/logs"
+            docker compose up -d --remove-orphans
+            # Run pending database migrations (push mode, like staging)
+            echo "Running database schema push..."
+            docker compose exec -T app npx drizzle-kit push --force || echo "Warning: schema push failed"
+            echo "Waiting for app to be healthy..."
+            for i in $(seq 1 60); do
+              if docker compose exec -T app node -e "fetch('http://localhost:5000/health').then(r => { if (!r.ok) process.exit(1) })" 2>/dev/null; then
+                echo "Preview is healthy after ${i}s"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "Health check failed"
+            docker compose logs --tail=50 app
+            exit 1
+
+      - name: Smoke test — health check
+        env:
+          PREVIEW_URL: ${{ secrets.PREVIEW_URL }}
+        run: |
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "PREVIEW_URL secret not set, skipping external smoke test"
+            exit 0
+          fi
+          echo "Waiting for container to boot..."
+          sleep 15
+          HEALTH_URL="${PREVIEW_URL}/health"
+          HTTP_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "$HEALTH_URL")
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "Health check failed — HTTP $HTTP_STATUS"
+            exit 1
+          fi
+          echo "Health check passed — preview deployment verified"
+
+      - name: Notify Telegram
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          DEPLOY_STATUS: ${{ job.status }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          DEPLOY_SHA: ${{ github.sha }}
+          TRIGGERED_BY: ${{ github.actor }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ]; then exit 0; fi
+          if [ "$DEPLOY_STATUS" = "success" ]; then EMOJI="✅"; else EMOJI="❌"; fi
+          curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            -d parse_mode="HTML" \
+            -d text="@racu8_bot
+          ${EMOJI} <b>Preview deployment: ${DEPLOY_STATUS}</b> [${REPO_NAME}]
+          Preview address: https://preview.artverse.idata.ro
+          Branch: redesign/v3
+          Tag: <code>${DEPLOY_SHA}</code>
           By: ${TRIGGERED_BY}"

--- a/deploy/nginx/preview.artverse.idata.ro.conf
+++ b/deploy/nginx/preview.artverse.idata.ro.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name preview.artverse.idata.ro;
+
+    access_log /home/preview/app/access.log;
+    error_log /home/preview/app/error.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:5004;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+}

--- a/deploy/preview/.env.example
+++ b/deploy/preview/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_PASSWORD=change-me-preview-db-password
+SESSION_SECRET=change-me-preview-session-secret
+IMAGE_TAG=latest

--- a/deploy/preview/docker-compose.yml
+++ b/deploy/preview/docker-compose.yml
@@ -1,0 +1,46 @@
+name: artverse-preview
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: artverse_preview
+      POSTGRES_USER: artverse
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - 127.0.0.1:5436:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U artverse -d artverse_preview"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  app:
+    image: ghcr.io/ilv78/art-world-hub:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: 5000
+      DATABASE_URL: postgresql://artverse:${POSTGRES_PASSWORD}@db:5432/artverse_preview
+      SESSION_SECRET: ${SESSION_SECRET}
+      OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-}
+    ports:
+      - 127.0.0.1:5004:5000
+    volumes:
+      - uploads:/app/uploads
+      - logs:/app/logs
+
+volumes:
+  pgdata:
+  uploads:
+  logs:

--- a/deploy/server-setup.sh
+++ b/deploy/server-setup.sh
@@ -23,8 +23,16 @@ else
   echo "Created user 'production'"
 fi
 
+echo "=== Creating preview user ==="
+if id "preview" &>/dev/null; then
+  echo "User 'preview' already exists, skipping"
+else
+  useradd -m -s /bin/bash preview
+  echo "Created user 'preview'"
+fi
+
 echo "=== Setting up SSH keys ==="
-for user in staging production; do
+for user in staging production preview; do
   home_dir=$(eval echo "~$user")
   mkdir -p "$home_dir/.ssh"
 
@@ -44,10 +52,11 @@ done
 echo "=== Adding users to docker group ==="
 usermod -aG docker staging
 usermod -aG docker production
-echo "Both users can now run Docker commands"
+usermod -aG docker preview
+echo "All users can now run Docker commands"
 
 echo "=== Creating app directories ==="
-for user in staging production; do
+for user in staging production preview; do
   home_dir=$(eval echo "~$user")
   mkdir -p "$home_dir/app"
   chown -R "$user:$user" "$home_dir/app"
@@ -58,14 +67,16 @@ echo "=== Logging into GHCR (needed once for image pulls) ==="
 echo "After this script, run the following for each user:"
 echo "  su - staging -c 'docker login ghcr.io -u ilv78'"
 echo "  su - production -c 'docker login ghcr.io -u ilv78'"
+echo "  su - preview -c 'docker login ghcr.io -u ilv78'"
 echo "(Use a GitHub Personal Access Token with read:packages scope as the password)"
 
 echo ""
 echo "=== Setup complete ==="
 echo "Staging home:    /home/staging/app"
 echo "Production home: /home/production/app"
+echo "Preview home:    /home/preview/app"
 echo ""
 echo "Next steps:"
 echo "1. Log both users into GHCR (see above)"
-echo "2. Set up DNS A records for artverse.idata.ro and staging.artverse.idata.ro"
+echo "2. Set up DNS A records for artverse.idata.ro, staging.artverse.idata.ro, and preview.artverse.idata.ro"
 echo "3. Copy Nginx configs and run certbot for SSL"

--- a/specs/workflows/CI-CD.md
+++ b/specs/workflows/CI-CD.md
@@ -134,6 +134,7 @@ Feature Branch                   main
 | **Local** | Development | `npm run dev` / `docker compose up` | Local PostgreSQL (port 5433) | `localhost:5000` |
 | **CI** | Validation | Push / PR | Ephemeral service container | N/A |
 | **Staging** | Pre-production testing | Auto on merge to `main` | Dedicated staging DB | `staging.artverse.<domain>` |
+| **Preview** | v3 redesign testing | Auto on push to `redesign/v3` | Dedicated preview DB | `preview.artverse.<domain>` |
 | **Production** | Live site | Manual approval / git tag | Dedicated production DB | `artverse.<domain>` |
 
 ---
@@ -394,6 +395,7 @@ By: username
 | `TELEGRAM_CHAT_ID` | Set | Deploy notifications | Telegram chat ID for notifications |
 
 | `STAGING_URL` | Needs setup | Staging smoke test | Full staging URL (`https://staging.artverse.idata.ro`) |
+| `PREVIEW_URL` | Needs setup | Preview smoke test | Full preview URL (`https://preview.artverse.idata.ro`) |
 | `PRODUCTION_URL` | Needs setup | Production smoke test | Full production URL (`https://artverse.idata.ro`) |
 
 DB passwords and session secrets are stored in `.env` files on the VPS (not in GitHub Secrets), since the docker-compose files read them locally.
@@ -582,18 +584,18 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
                     ┌────────┴────────────┐
                     │                     │
                     ▼                     ▼
-     ┌──────────────────────┐  ┌──────────────────────┐
-     │  STAGING             │  │  PRODUCTION           │
-     │  staging user        │  │  production user      │
-     │                      │  │                       │
-     │  App    → :5003      │  │  App    → :5002       │
-     │  DB     → :5435      │  │  DB     → :5434       │
-     │                      │  │                       │
-     │  DB mode: push       │  │  DB mode: migrate     │
-     │  Auto-deploy on main │  │  Manual deploy        │
-     └──────────┬───────────┘  └──────────┬────────────┘
-                │                         │
-                └────────┬────────────────┘
+     ┌──────────────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
+     │  STAGING             │  │  PREVIEW              │  │  PRODUCTION           │
+     │  staging user        │  │  preview user         │  │  production user      │
+     │                      │  │                       │  │                       │
+     │  App    → :5003      │  │  App    → :5004       │  │  App    → :5002       │
+     │  DB     → :5435      │  │  DB     → :5436       │  │  DB     → :5434       │
+     │                      │  │                       │  │                       │
+     │  DB mode: push       │  │  DB mode: push        │  │  DB mode: migrate     │
+     │  Auto-deploy on main │  │  Auto on redesign/v3  │  │  Manual deploy        │
+     └──────────┬───────────┘  └──────────┬────────────┘  └──────────┬────────────┘
+                │                         │                          │
+                └────────┬────────────────┴──────────────────────────┘
                          │ localhost only
                          ▼
               ┌──────────────────────┐
@@ -601,6 +603,9 @@ DB passwords and session secrets are stored in `.env` files on the VPS (not in G
               │                      │
               │  staging.artverse.   │
               │  idata.ro → :5003   │
+              │                      │
+              │  preview.artverse.   │
+              │  idata.ro → :5004   │
               │                      │
               │  artverse.           │
               │  idata.ro → :5002   │
@@ -718,3 +723,4 @@ Changes go through a PR, so CI validates the CHANGELOG update before it reaches 
 | 2026-03-14 | Added Section 6.6: Automated Release Workflow — label-driven versioned releases via `release.yml` + `prepare-release.sh`. Auto-detects PATCH/MINOR bump, updates CHANGELOG, creates git tag + GitHub Release, removes labels, Telegram notification. (Issue #110) |
 | 2026-03-15 | Added logging smoke test to staging deploy — verifies log file exists, has entries, valid JSON, and contains startup message. Updated test count from 32 to 52. (Issue [#39](https://github.com/ilv78/Art-World-Hub/issues/39)) |
 | 2026-03-23 | Skip Docker build and staging deploy for docs-only changes — added `changes` job with `dorny/paths-filter` to detect non-docs file changes. `build-image` and `deploy-staging` are skipped when only `specs/`, `docs/`, `**/*.md`, or `.github/ISSUE_TEMPLATE/` files changed. Updated pipeline diagram and job descriptions. (Issue [#206](https://github.com/ilv78/Art-World-Hub/issues/206)) |
+| 2026-03-24 | Added preview environment for `redesign/v3` branch — new `deploy-preview` job in ci.yml, `deploy/preview/docker-compose.yml` (port 5004/5436), nginx config for `preview.artverse.idata.ro`, updated server-setup.sh with preview user. CI pipeline now builds Docker images and deploys on both `main` (→ staging) and `redesign/v3` (→ preview). PRs can target either branch. (Issue [#235](https://github.com/ilv78/Art-World-Hub/issues/235)) |

--- a/specs/workflows/DEPLOYMENT.md
+++ b/specs/workflows/DEPLOYMENT.md
@@ -123,13 +123,15 @@ ssh -i ~/.ssh/artverse-deploy root@artverse.idata.ro          # Root (for Nginx,
 |------|---------|
 | `/home/staging/app/` | Staging docker-compose + .env |
 | `/home/production/app/` | Production docker-compose + .env |
-| `/etc/nginx/sites-enabled/` | Nginx configs (staging + production) |
+| `/home/preview/app/` | Preview docker-compose + .env |
+| `/etc/nginx/sites-enabled/` | Nginx configs (staging + production + preview) |
 | `/etc/letsencrypt/` | SSL certificates (auto-renewed by certbot) |
 
 ### Docker project names
 
 - `artverse-staging` — staging containers (`artverse-staging-app-1`, `artverse-staging-db-1`)
 - `artverse-production` — production containers (`artverse-production-app-1`, `artverse-production-db-1`)
+- `artverse-preview` — preview containers (`artverse-preview-app-1`, `artverse-preview-db-1`)
 
 ### Ports (all localhost-only)
 
@@ -139,6 +141,8 @@ ssh -i ~/.ssh/artverse-deploy root@artverse.idata.ro          # Root (for Nginx,
 | 5435 | Staging PostgreSQL |
 | 5002 | Production app |
 | 5434 | Production PostgreSQL |
+| 5004 | Preview app |
+| 5436 | Preview PostgreSQL |
 
 ---
 
@@ -197,6 +201,7 @@ Database passwords and session secrets are stored in `.env` files on the VPS, no
 Deploy notifications are sent to Telegram automatically. You'll receive a message for:
 
 - **Staging deploys** — after every push to `main` (success or failure)
+- **Preview deploys** — after every push to `redesign/v3` (success or failure)
 - **Production deploys** — after manual deploy (success or failure)
 - **Production rollbacks** — after rollback (success or failure)
 


### PR DESCRIPTION
## Summary

- Add `deploy-preview` job to `ci.yml` — auto-deploys `redesign/v3` to preview environment
- Expand CI gates (`changes`, `build-image`, `scan-image`) to trigger on both `main` and `redesign/v3`
- Gate `deploy-staging` to `main` only, `deploy-preview` to `redesign/v3` only
- New `deploy/preview/` directory with docker-compose (port 5004/5436) and .env template
- New nginx config for `preview.artverse.idata.ro`
- Updated `deploy/server-setup.sh` with preview user
- Updated `specs/workflows/CI-CD.md` and `specs/workflows/DEPLOYMENT.md`

## VPS Manual Steps (after merge)

1. Create `preview` user on VPS (SSH key, docker group, `~/app/`)
2. Log preview user into GHCR
3. Create `.env` with real passwords
4. DNS A record for `preview.artverse.idata.ro`
5. Nginx config + certbot SSL
6. Add `PREVIEW_URL` GitHub secret

## Test plan

- [ ] CI passes on this PR (lint, types, tests, build)
- [ ] After merge + VPS setup: push to `redesign/v3` triggers preview deploy
- [ ] Preview accessible at `https://preview.artverse.idata.ro`
- [ ] Telegram notification received for preview deploy
- [ ] Push to `main` still deploys to staging only (not preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)