### PR TITLE
feat: replace sidebar with top nav for all pages (closes #236)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,12 +3,8 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/app-sidebar";
 import { ThemeProvider } from "@/components/theme-provider";
-import { ThemeToggle } from "@/components/theme-toggle";
-import { PalettePicker } from "@/components/palette-picker";
-import { CartSheet } from "@/components/cart-sheet";
+import { PublicLayout } from "@/components/public-layout";
 import Home from "@/pages/home";
 import Gallery from "@/pages/gallery";
 import Store from "@/pages/store";
@@ -52,33 +48,13 @@ function Router() {
 }
 
 function App() {
-  const sidebarStyle = {
-    "--sidebar-width": "16rem",
-    "--sidebar-width-icon": "3rem",
-  };
-
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="light">
         <TooltipProvider>
-          <SidebarProvider style={sidebarStyle as React.CSSProperties}>
-            <div className="flex min-h-screen w-full">
-              <AppSidebar />
-              <div className="flex flex-col flex-1 min-w-0">
-                <header className="sticky top-0 z-40 flex items-center justify-between gap-4 p-3 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
-                  <SidebarTrigger data-testid="button-sidebar-toggle" />
-                  <div className="flex items-center gap-2">
-                    <CartSheet />
-                    <PalettePicker />
-                    <ThemeToggle />
-                  </div>
-                </header>
-                <main className="flex-1 overflow-auto">
-                  <Router />
-                </main>
-              </div>
-            </div>
-          </SidebarProvider>
+          <PublicLayout>
+            <Router />
+          </PublicLayout>
           <Toaster />
         </TooltipProvider>
       </ThemeProvider>

--- a/client/src/components/public-layout.tsx
+++ b/client/src/components/public-layout.tsx
@@ -1,0 +1,166 @@
+import { Link, useLocation } from "wouter";
+import { useAuth } from "@/hooks/use-auth";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { PalettePicker } from "@/components/palette-picker";
+import { CartSheet } from "@/components/cart-sheet";
+import { Button } from "@/components/ui/button";
+import { LogIn, LogOut, Menu, X } from "lucide-react";
+import { useState } from "react";
+
+const navLinks = [
+  { title: "Gallery", url: "/gallery" },
+  { title: "Exhibitions", url: "/exhibitions" },
+  { title: "Store", url: "/store" },
+  { title: "Artists", url: "/artists" },
+  { title: "Blog", url: "/blog" },
+];
+
+export function PublicLayout({ children }: { children: React.ReactNode }) {
+  const [location] = useLocation();
+  const { user, isAuthenticated, logout, isLoggingOut } = useAuth();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const dashboardUrl = user?.role === "admin"
+    ? "/admin"
+    : user?.role === "curator"
+      ? "/curator"
+      : "/dashboard";
+
+  const dashboardLabel = user?.role === "admin"
+    ? "Admin Dashboard"
+    : user?.role === "curator"
+      ? "Curator Dashboard"
+      : "Artist Dashboard";
+
+  return (
+    <div className="flex flex-col min-h-screen w-full">
+      {/* Top Navigation */}
+      <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
+        <div className="mx-auto flex h-14 items-center justify-between px-4 sm:px-6 lg:px-8">
+          {/* Left: Logo */}
+          <Link href="/" className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-md bg-primary flex items-center justify-center">
+              <span className="text-primary-foreground font-serif font-bold text-lg">A</span>
+            </div>
+            <span className="font-serif text-xl font-bold tracking-tight hidden sm:inline">
+              ArtVerse
+            </span>
+          </Link>
+
+          {/* Center: Nav links (desktop) */}
+          <nav className="hidden md:flex items-center gap-1">
+            {navLinks.map((link) => (
+              <Link key={link.url} href={link.url}>
+                <Button
+                  variant={location === link.url ? "secondary" : "ghost"}
+                  size="sm"
+                  className="text-sm"
+                >
+                  {link.title}
+                </Button>
+              </Link>
+            ))}
+          </nav>
+
+          {/* Right: Controls */}
+          <div className="flex items-center gap-2">
+            <CartSheet />
+            <PalettePicker />
+            <ThemeToggle />
+            {isAuthenticated && user ? (
+              <div className="hidden sm:flex items-center gap-2">
+                <Link href={dashboardUrl}>
+                  <Button size="sm" className="text-sm">
+                    {dashboardLabel}
+                  </Button>
+                </Link>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => logout()}
+                  disabled={isLoggingOut}
+                  title="Sign out"
+                >
+                  <LogOut className="w-4 h-4" />
+                </Button>
+              </div>
+            ) : (
+              <Link href="/auth" className="hidden sm:block">
+                <Button variant="outline" size="sm">
+                  <LogIn className="w-4 h-4 mr-2" />
+                  Sign in
+                </Button>
+              </Link>
+            )}
+
+            {/* Mobile menu toggle */}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="md:hidden"
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            >
+              {mobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+            </Button>
+          </div>
+        </div>
+
+        {/* Mobile menu */}
+        {mobileMenuOpen && (
+          <div className="md:hidden border-t bg-background px-4 py-3 space-y-1">
+            {navLinks.map((link) => (
+              <Link key={link.url} href={link.url} onClick={() => setMobileMenuOpen(false)}>
+                <Button
+                  variant={location === link.url ? "secondary" : "ghost"}
+                  className="w-full justify-start text-sm"
+                >
+                  {link.title}
+                </Button>
+              </Link>
+            ))}
+            {isAuthenticated && user ? (
+              <>
+                <Link href={dashboardUrl} onClick={() => setMobileMenuOpen(false)}>
+                  <Button variant="ghost" className="w-full justify-start text-sm">
+                    {dashboardLabel}
+                  </Button>
+                </Link>
+                <Button
+                  variant="ghost"
+                  className="w-full justify-start text-sm"
+                  onClick={() => logout()}
+                  disabled={isLoggingOut}
+                >
+                  <LogOut className="w-4 h-4 mr-2" />
+                  Sign out
+                </Button>
+              </>
+            ) : (
+              <Link href="/auth" onClick={() => setMobileMenuOpen(false)}>
+                <Button variant="outline" className="w-full justify-start text-sm">
+                  <LogIn className="w-4 h-4 mr-2" />
+                  Sign in
+                </Button>
+              </Link>
+            )}
+          </div>
+        )}
+      </header>
+
+      {/* Main content — full width */}
+      <main className="flex-1">
+        {children}
+      </main>
+
+      {/* Footer placeholder — will be built in #238 */}
+      <footer className="border-t py-6 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto flex items-center justify-between text-xs text-muted-foreground">
+          <p>Discover. Collect. Create.</p>
+          <Link href="/changelog" className="hover:underline">
+            Changelog
+          </Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -514,9 +514,6 @@ export default function ArtistDashboard() {
             <p className="text-sm text-muted-foreground">Your Artist Dashboard</p>
           </div>
         </div>
-        <Button variant="outline" asChild data-testid="button-logout">
-          <a href="/api/logout">Log Out</a>
-        </Button>
       </div>
 
       <Tabs defaultValue="artworks" className="space-y-6">


### PR DESCRIPTION
## Summary

- Replace sidebar navigation with a top nav bar across all pages (public + dashboards)
- New `PublicLayout` component: sticky top nav with logo, nav links, cart, theme controls, auth
- Role-aware dashboard button: "Artist Dashboard" / "Curator Dashboard" / "Admin Dashboard" with primary color
- Mobile hamburger menu for responsive navigation
- Removed duplicate logout from artist dashboard
- Removed unused `DashboardLayout` component

## Test plan

- [x] Public pages show top nav, no sidebar, full-width content
- [x] Dashboard pages also use top nav
- [x] Dashboard button shows correct role label
- [x] Mobile hamburger menu works
- [x] Cart, palette, theme toggle all functional
- [x] Auth state reflected (sign in button vs dashboard + logout)
- [x] All checks pass (lint, types, tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)