### PR TITLE
feat: improve artists, exhibitions, and blog pages (closes #242)

### DIFF
--- a/client/src/pages/artists.tsx
+++ b/client/src/pages/artists.tsx
@@ -89,54 +89,52 @@ export default function Artists() {
         </div>
       ) : (
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {filteredArtists.map((artist) => (
-            <Card
-              key={artist.id}
-              className="overflow-hidden hover-elevate cursor-pointer group"
-              onClick={() => setSelectedArtist(artist)}
-              data-testid={`card-artist-${artist.id}`}
-            >
-              <CardContent className="p-6 text-center space-y-4">
-                <Avatar className="w-24 h-24 mx-auto ring-4 ring-background shadow-lg group-hover:ring-primary/20 transition-all">
-                  <AvatarImage src={artist.avatarUrl || undefined} />
-                  <AvatarFallback className="text-2xl font-serif">
-                    {artist.name
-                      .split(" ")
-                      .map((n) => n[0])
-                      .join("")}
-                  </AvatarFallback>
-                </Avatar>
+          {filteredArtists.map((artist, index) => {
+            const isFeatured = index < 2;
+            return (
+              <Link key={artist.id} href={`/artists/${artist.id}`}>
+                <Card
+                  className={`overflow-hidden hover-elevate cursor-pointer group h-full ${isFeatured ? "sm:col-span-2" : ""}`}
+                  data-testid={`card-artist-${artist.id}`}
+                >
+                  <CardContent className={`${isFeatured ? "p-6 flex gap-6 items-center" : "p-6 text-center space-y-4"}`}>
+                    <Avatar className={`${isFeatured ? "w-32 h-32 shrink-0" : "w-28 h-28 mx-auto"} ring-4 ring-background shadow-lg group-hover:ring-primary/20 transition-all`}>
+                      <AvatarImage src={artist.avatarUrl || undefined} />
+                      <AvatarFallback className={`${isFeatured ? "text-4xl" : "text-2xl"} font-serif`}>
+                        {artist.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")}
+                      </AvatarFallback>
+                    </Avatar>
 
-                <div>
-                  <h3 className="font-serif font-bold text-lg">{artist.name}</h3>
-                  {artist.country && (
-                    <p className="text-sm text-muted-foreground flex items-center justify-center gap-1 mt-1">
-                      <MapPin className="h-3 w-3" />
-                      {artist.country}
-                    </p>
-                  )}
-                </div>
+                    <div className={isFeatured ? "flex-1 min-w-0 space-y-2" : ""}>
+                      <div>
+                        <h3 className={`font-serif font-bold ${isFeatured ? "text-xl" : "text-lg"}`}>{artist.name}</h3>
+                        {artist.country && (
+                          <p className={`text-sm text-muted-foreground flex items-center gap-1 mt-1 ${isFeatured ? "" : "justify-center"}`}>
+                            <MapPin className="h-3 w-3" />
+                            {artist.country}
+                          </p>
+                        )}
+                      </div>
 
-                {artist.specialization && (
-                  <Badge variant="outline" className="mx-auto">
-                    <Palette className="h-3 w-3 mr-1" />
-                    {artist.specialization}
-                  </Badge>
-                )}
+                      {artist.specialization && (
+                        <Badge variant="outline" className={isFeatured ? "" : "mx-auto"}>
+                          <Palette className="h-3 w-3 mr-1" />
+                          {artist.specialization}
+                        </Badge>
+                      )}
 
-                <p className="text-sm text-muted-foreground line-clamp-3">
-                  {artist.bio}
-                </p>
-
-                <Link href={`/artists/${artist.id}`}>
-                  <Button variant="ghost" className="w-full bg-primary text-primary-foreground hover:bg-primary/90" data-testid={`button-view-artist-${artist.id}`}>
-                    View Profile
-                    <ExternalLink className="h-4 w-4 ml-2" />
-                  </Button>
-                </Link>
-              </CardContent>
-            </Card>
-          ))}
+                      <p className={`text-sm text-muted-foreground ${isFeatured ? "line-clamp-2" : "line-clamp-3"}`}>
+                        {artist.bio}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
         </div>
       )}
 

--- a/client/src/pages/blog.tsx
+++ b/client/src/pages/blog.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { BookOpen } from "lucide-react";
 import type { BlogPostWithArtist } from "@shared/schema";
 
@@ -40,48 +41,107 @@ export default function Blog() {
           </p>
         </div>
       ) : (
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {posts.map((post) => (
+        <div className="space-y-8">
+          {/* Lead article — full width, horizontal layout */}
+          {posts.length > 0 && (
             <Link
-              key={post.id}
-              href={`/blog/${post.id}`}
-              className="group bg-card rounded-lg border overflow-hidden hover-elevate transition-shadow"
+              href={`/blog/${posts[0].id}`}
+              className="group bg-card rounded-xl border overflow-hidden hover-elevate transition-shadow block"
             >
-              {post.coverImageUrl ? (
-                <div className="aspect-video overflow-hidden">
-                  <img
-                    src={post.coverImageUrl}
-                    alt={post.title}
-                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                  />
-                </div>
-              ) : (
-                <div className="aspect-video bg-muted flex items-center justify-center">
-                  <BookOpen className="h-10 w-10 text-muted-foreground" />
-                </div>
-              )}
-              <div className="p-4 space-y-2">
-                <h2 className="font-serif text-lg font-semibold line-clamp-2 group-hover:text-primary transition-colors">
-                  {post.title}
-                </h2>
-                {post.excerpt && (
-                  <p className="text-sm text-muted-foreground line-clamp-3">
-                    {post.excerpt}
-                  </p>
+              <div className="grid md:grid-cols-5 gap-0">
+                {posts[0].coverImageUrl ? (
+                  <div className="md:col-span-3 aspect-video md:aspect-auto md:h-full overflow-hidden">
+                    <img
+                      src={posts[0].coverImageUrl}
+                      alt={posts[0].title}
+                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                    />
+                  </div>
+                ) : (
+                  <div className="md:col-span-3 aspect-video md:aspect-auto md:min-h-[280px] bg-muted flex items-center justify-center">
+                    <BookOpen className="h-16 w-16 text-muted-foreground/40" />
+                  </div>
                 )}
-                <div className="flex items-center justify-between text-xs text-muted-foreground pt-2">
-                  <span>{post.artist.name}</span>
-                  <time dateTime={new Date(post.createdAt).toISOString()}>
-                    {new Date(post.createdAt).toLocaleDateString("en-US", {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                    })}
-                  </time>
+                <div className="md:col-span-2 p-6 sm:p-8 flex flex-col justify-center space-y-3">
+                  <h2 className="font-serif text-2xl sm:text-3xl font-bold leading-tight group-hover:text-primary transition-colors">
+                    {posts[0].title}
+                  </h2>
+                  {posts[0].excerpt && (
+                    <p className="text-muted-foreground line-clamp-4">
+                      {posts[0].excerpt}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-3 text-sm text-muted-foreground pt-2">
+                    <Avatar className="w-6 h-6">
+                      <AvatarImage src={posts[0].artist.avatarUrl || undefined} />
+                      <AvatarFallback className="text-xs">{posts[0].artist.name[0]}</AvatarFallback>
+                    </Avatar>
+                    <span>{posts[0].artist.name}</span>
+                    <span>·</span>
+                    <time dateTime={new Date(posts[0].createdAt).toISOString()}>
+                      {new Date(posts[0].createdAt).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </time>
+                  </div>
                 </div>
               </div>
             </Link>
-          ))}
+          )}
+
+          {/* Remaining posts */}
+          {posts.length > 1 && (
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {posts.slice(1).map((post) => (
+                <Link
+                  key={post.id}
+                  href={`/blog/${post.id}`}
+                  className="group bg-card rounded-lg border overflow-hidden hover-elevate transition-shadow"
+                >
+                  {post.coverImageUrl ? (
+                    <div className="aspect-video overflow-hidden">
+                      <img
+                        src={post.coverImageUrl}
+                        alt={post.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                      />
+                    </div>
+                  ) : (
+                    <div className="aspect-video bg-muted flex items-center justify-center">
+                      <BookOpen className="h-10 w-10 text-muted-foreground" />
+                    </div>
+                  )}
+                  <div className="p-4 space-y-2">
+                    <h2 className="font-serif text-lg font-semibold line-clamp-2 group-hover:text-primary transition-colors">
+                      {post.title}
+                    </h2>
+                    {post.excerpt && (
+                      <p className="text-sm text-muted-foreground line-clamp-3">
+                        {post.excerpt}
+                      </p>
+                    )}
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground pt-2">
+                      <Avatar className="w-5 h-5">
+                        <AvatarImage src={post.artist.avatarUrl || undefined} />
+                        <AvatarFallback className="text-[10px]">{post.artist.name[0]}</AvatarFallback>
+                      </Avatar>
+                      <span>{post.artist.name}</span>
+                      <span>·</span>
+                      <time dateTime={new Date(post.createdAt).toISOString()}>
+                        {new Date(post.createdAt).toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "short",
+                          day: "numeric",
+                        })}
+                      </time>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/client/src/pages/exhibitions.tsx
+++ b/client/src/pages/exhibitions.tsx
@@ -53,16 +53,21 @@ export default function Exhibitions() {
       ) : (
         <>
           {active.length > 0 && (
-            <section className="space-y-4">
+            <section className="space-y-6">
               <h2 className="font-serif text-2xl font-semibold flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
                 Now Open
               </h2>
-              <div className="grid gap-4 md:grid-cols-2">
-                {active.map(exhibition => (
-                  <ExhibitionCard key={exhibition.id} exhibition={exhibition} status="active" formatDate={formatDate} />
-                ))}
-              </div>
+              {/* Hero: first active exhibition */}
+              <HeroExhibition exhibition={active[0]} formatDate={formatDate} />
+              {/* Remaining active */}
+              {active.length > 1 && (
+                <div className="grid gap-4 md:grid-cols-2 mt-5">
+                  {active.slice(1).map(exhibition => (
+                    <ExhibitionCard key={exhibition.id} exhibition={exhibition} status="active" formatDate={formatDate} />
+                  ))}
+                </div>
+              )}
             </section>
           )}
 
@@ -74,7 +79,7 @@ export default function Exhibitions() {
               </h2>
               <div className="grid gap-4 md:grid-cols-2">
                 {upcoming.map(exhibition => (
-                  <ExhibitionCard key={exhibition.id} exhibition={exhibition} status="upcoming" formatDate={formatDate} />
+                  <ExhibitionCard key={exhibition.id} exhibition={exhibition} status="upcoming" formatDate={formatDate} variant="upcoming" />
                 ))}
               </div>
             </section>
@@ -85,10 +90,52 @@ export default function Exhibitions() {
   );
 }
 
-function ExhibitionCard({ exhibition, status, formatDate }: {
+function HeroExhibition({ exhibition, formatDate }: {
+  exhibition: CuratorGalleryWithArtworks;
+  formatDate: (d: string | Date | null | undefined, tz?: string | null) => string;
+}) {
+  const curatorName = [exhibition.curator.firstName, exhibition.curator.lastName].filter(Boolean).join(" ") || "Curator";
+  const heroImage = exhibition.artworks[0]?.imageUrl;
+
+  return (
+    <Link href={`/curator-gallery/${exhibition.id}`}>
+      <div className="relative rounded-2xl overflow-hidden group cursor-pointer">
+        {heroImage ? (
+          <img
+            src={heroImage}
+            alt={exhibition.name}
+            className="w-full h-64 sm:h-80 object-cover transition-transform duration-700 group-hover:scale-105"
+          />
+        ) : (
+          <div className="w-full h-64 sm:h-80 bg-muted flex items-center justify-center">
+            <ImageIcon className="w-16 h-16 text-muted-foreground/40" />
+          </div>
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+        <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
+          <Badge className="bg-green-600 mb-3">Open Now</Badge>
+          <h3 className="font-serif text-2xl sm:text-3xl font-bold text-white mb-1">{exhibition.name}</h3>
+          {exhibition.description && (
+            <p className="text-white/70 text-sm mb-2 line-clamp-2">{exhibition.description}</p>
+          )}
+          <p className="text-white/50 text-xs mb-4">
+            Curated by {curatorName} · {exhibition.artworks.length} artworks
+          </p>
+          <Button className="bg-white text-black hover:bg-white/90">
+            Enter Exhibition
+            <ArrowRight className="w-4 h-4 ml-2" />
+          </Button>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function ExhibitionCard({ exhibition, status, formatDate, variant }: {
   exhibition: CuratorGalleryWithArtworks;
   status: "active" | "upcoming";
   formatDate: (d: string | Date | null | undefined, tz?: string | null) => string;
+  variant?: "upcoming";
 }) {
   const curatorName = [exhibition.curator.firstName, exhibition.curator.lastName].filter(Boolean).join(" ") || "Curator";
   const tz = (exhibition as any).timezone || "UTC";
@@ -96,16 +143,16 @@ function ExhibitionCard({ exhibition, status, formatDate }: {
   const previewArtworks = exhibition.artworks.slice(0, 4);
 
   return (
-    <Card className="overflow-hidden hover-elevate">
+    <Card className={`overflow-hidden hover-elevate ${variant === "upcoming" ? "border-dashed opacity-80" : ""}`}>
       {/* Artwork preview strip */}
       {previewArtworks.length > 0 ? (
-        <div className="flex h-32 overflow-hidden">
+        <div className="flex h-48 overflow-hidden">
           {previewArtworks.map(aw => (
             <img key={aw.id} src={aw.imageUrl} alt={aw.title} className="flex-1 object-cover min-w-0" />
           ))}
         </div>
       ) : (
-        <div className="h-32 bg-muted flex items-center justify-center">
+        <div className="h-48 bg-muted flex items-center justify-center">
           <ImageIcon className="w-8 h-8 text-muted-foreground" />
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Artists page**: first 2 artists get prominent horizontal cards with large avatars; all cards link directly to profile (removed redundant button)
- **Exhibitions page**: first active exhibition rendered as full-bleed hero with gradient overlay and CTA; remaining cards have taller image previews (h-48); upcoming exhibitions have dashed borders for visual hierarchy
- **Blog page**: lead article displayed full-width with horizontal layout (image 60% / content 40%); author avatars added to post footers

## Test plan
- [ ] Artists page: first 2 cards are wider with horizontal layout
- [ ] Artists page: clicking any card navigates to artist profile
- [ ] Exhibitions page: hero exhibition renders with overlay and "Enter Exhibition" button
- [ ] Exhibitions page: upcoming exhibitions have dashed border styling
- [ ] Blog page: first post is full-width horizontal layout
- [ ] Blog page: author avatars visible in all post cards
- [ ] All pages responsive on mobile
- [ ] All existing functionality preserved (search, dialog, links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)