### PR TITLE
feat: add Privacy Policy and Terms of Service pages (closes #253)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,8 @@ import CuratorDashboard from "@/pages/curator-dashboard";
 import CuratorGalleryPage from "@/pages/curator-gallery";
 import Exhibitions from "@/pages/exhibitions";
 import Changelog from "@/pages/changelog";
+import Privacy from "@/pages/privacy";
+import Terms from "@/pages/terms";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -42,6 +44,8 @@ function Router() {
       <Route path="/auth" component={AuthPage} />
       <Route path="/auth/set-password" component={SetPassword} />
       <Route path="/changelog" component={Changelog} />
+      <Route path="/privacy" component={Privacy} />
+      <Route path="/terms" component={Terms} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/privacy.tsx
+++ b/client/src/pages/privacy.tsx
@@ -1,0 +1,154 @@
+export default function Privacy() {
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto max-w-3xl px-6 py-12 sm:py-16">
+        <h1 className="font-serif text-4xl font-bold mb-2">Privacy Policy</h1>
+        <p className="text-sm text-muted-foreground mb-10">Last updated: 26 March 2026</p>
+
+        <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8">
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">1. Data Controller</h2>
+            <p>
+              ArtVerse ("we", "us", "our") is the data controller responsible for
+              processing your personal data. If you have any questions about this
+              Privacy Policy or our data practices, please contact us at:
+            </p>
+            <p>
+              Email: <a href="mailto:privacy@artverse.idata.ro" className="text-primary hover:underline">privacy@artverse.idata.ro</a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">2. Personal Data We Collect</h2>
+            <p>We collect the following categories of personal data:</p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li><strong>Account data:</strong> name, email address, password (hashed), profile image</li>
+              <li><strong>Artist profile data:</strong> biography, country, specialisation, social media links, portfolio images</li>
+              <li><strong>Transaction data:</strong> order history, cart contents, shipping information</li>
+              <li><strong>Usage data:</strong> pages visited, actions taken, browser type, IP address, device information</li>
+              <li><strong>Communication data:</strong> messages, support requests, feedback</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">3. Lawful Basis for Processing</h2>
+            <p>We process your personal data on the following legal bases under the GDPR:</p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li><strong>Contract performance (Art. 6(1)(b)):</strong> to provide our platform services, process orders, and manage your account</li>
+              <li><strong>Legitimate interests (Art. 6(1)(f)):</strong> to improve our services, prevent fraud, and ensure platform security</li>
+              <li><strong>Consent (Art. 6(1)(a)):</strong> for optional marketing communications and non-essential cookies</li>
+              <li><strong>Legal obligation (Art. 6(1)(c)):</strong> to comply with applicable laws and regulations</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">4. How We Use Your Data</h2>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>To create and manage your account</li>
+              <li>To display artist profiles and artworks in the gallery</li>
+              <li>To process purchases and facilitate communication between buyers and artists</li>
+              <li>To operate auctions and exhibition features</li>
+              <li>To send transactional emails (order confirmations, account updates)</li>
+              <li>To improve and personalise your experience on the platform</li>
+              <li>To detect and prevent fraudulent or unauthorised activity</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">5. Cookies and Tracking</h2>
+            <p>
+              We use essential cookies to maintain your session and preferences.
+              These are strictly necessary for the platform to function and do not
+              require consent under the ePrivacy Directive.
+            </p>
+            <p>
+              We do not use third-party advertising trackers. If we introduce
+              analytics or non-essential cookies in the future, we will obtain your
+              prior consent through a clear cookie banner.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">6. Data Sharing and Transfers</h2>
+            <p>We do not sell your personal data. We may share data with:</p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li><strong>Infrastructure providers:</strong> hosting and database services located within the EEA</li>
+              <li><strong>Email service providers:</strong> for transactional emails (with appropriate data processing agreements)</li>
+              <li><strong>Authentication providers:</strong> Google OAuth, when you choose to sign in with Google</li>
+            </ul>
+            <p>
+              Where data is transferred outside the EEA, we ensure appropriate
+              safeguards are in place, such as Standard Contractual Clauses (SCCs)
+              or adequacy decisions by the European Commission.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">7. Data Retention</h2>
+            <p>
+              We retain your personal data only for as long as necessary to fulfil
+              the purposes described in this policy, or as required by law. Account
+              data is retained while your account is active. Upon account deletion,
+              personal data is removed within 30 days, except where retention is
+              required for legal or regulatory purposes.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">8. Your Rights</h2>
+            <p>
+              Under the GDPR, you have the following rights regarding your personal data:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li><strong>Right of access (Art. 15):</strong> obtain a copy of your personal data</li>
+              <li><strong>Right to rectification (Art. 16):</strong> correct inaccurate or incomplete data</li>
+              <li><strong>Right to erasure (Art. 17):</strong> request deletion of your data ("right to be forgotten")</li>
+              <li><strong>Right to restrict processing (Art. 18):</strong> limit how we use your data</li>
+              <li><strong>Right to data portability (Art. 20):</strong> receive your data in a machine-readable format</li>
+              <li><strong>Right to object (Art. 21):</strong> object to processing based on legitimate interests</li>
+              <li><strong>Right to withdraw consent:</strong> at any time, without affecting prior processing</li>
+            </ul>
+            <p>
+              To exercise any of these rights, contact us at{" "}
+              <a href="mailto:privacy@artverse.idata.ro" className="text-primary hover:underline">privacy@artverse.idata.ro</a>.
+              We will respond within 30 days as required by the GDPR.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">9. Data Security</h2>
+            <p>
+              We implement appropriate technical and organisational measures to
+              protect your personal data, including encryption in transit (TLS),
+              hashed passwords, access controls, and regular security assessments.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">10. Supervisory Authority</h2>
+            <p>
+              If you believe your data protection rights have been violated, you
+              have the right to lodge a complaint with your local data protection
+              supervisory authority. In Romania, the relevant authority is the
+              Autoritatea Nationala de Supraveghere a Prelucrarii Datelor cu
+              Caracter Personal (ANSPDCP) —{" "}
+              <a href="https://www.dataprotection.ro" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+                www.dataprotection.ro
+              </a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">11. Changes to This Policy</h2>
+            <p>
+              We may update this Privacy Policy from time to time. Material changes
+              will be communicated via email or a prominent notice on the platform.
+              Your continued use of ArtVerse after changes constitutes acceptance of
+              the updated policy.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/terms.tsx
+++ b/client/src/pages/terms.tsx
@@ -1,0 +1,193 @@
+export default function Terms() {
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto max-w-3xl px-6 py-12 sm:py-16">
+        <h1 className="font-serif text-4xl font-bold mb-2">Terms of Service</h1>
+        <p className="text-sm text-muted-foreground mb-10">Last updated: 26 March 2026</p>
+
+        <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8">
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">1. Introduction</h2>
+            <p>
+              Welcome to ArtVerse. These Terms of Service ("Terms") govern your
+              access to and use of the ArtVerse platform, including the website,
+              virtual gallery, marketplace, and all related services. By creating an
+              account or using the platform, you agree to be bound by these Terms.
+            </p>
+            <p>
+              ArtVerse is operated from Romania within the European Union. These
+              Terms are governed by Romanian law and applicable EU regulations.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">2. Eligibility</h2>
+            <p>
+              You must be at least 16 years of age to create an account on ArtVerse.
+              If you are under 18, you may use the platform only with the involvement
+              and consent of a parent or legal guardian. By using the platform, you
+              represent that you meet these requirements.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">3. Account Responsibilities</h2>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>You are responsible for maintaining the confidentiality of your login credentials</li>
+              <li>You must provide accurate and up-to-date information when creating your account</li>
+              <li>You are responsible for all activity that occurs under your account</li>
+              <li>You must notify us immediately of any unauthorised use of your account</li>
+              <li>We reserve the right to suspend or terminate accounts that violate these Terms</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">4. Artist Accounts and Content</h2>
+            <p>
+              Artists who create profiles and upload artworks to ArtVerse retain full
+              ownership and intellectual property rights over their original works.
+              By uploading content, you grant ArtVerse a non-exclusive, worldwide,
+              royalty-free licence to display, reproduce, and distribute your content
+              within the platform for the purpose of operating the gallery, marketplace,
+              and promotional activities.
+            </p>
+            <p>You warrant that:</p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>You are the original creator or have the right to upload the content</li>
+              <li>Your content does not infringe any third-party intellectual property rights</li>
+              <li>Your content does not contain unlawful, defamatory, or objectionable material</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">5. Purchases and Transactions</h2>
+            <p>
+              ArtVerse facilitates transactions between buyers and artists. When you
+              purchase an artwork:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>All prices are displayed in the currency indicated on the listing</li>
+              <li>You enter into a direct transaction with the artist</li>
+              <li>ArtVerse acts as an intermediary to facilitate communication and order tracking</li>
+              <li>Physical artwork shipping, packaging, and delivery are the responsibility of the artist</li>
+            </ul>
+            <p>
+              Under EU consumer protection law, buyers who are consumers have the
+              right to withdraw from a purchase of physical goods within 14 days of
+              delivery, unless the artwork is custom-made or clearly personalised.
+              Digital artworks and exhibition access are excluded from the right of
+              withdrawal once the service has been fully provided.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">6. Auctions</h2>
+            <p>
+              Participation in auctions constitutes a binding offer to purchase at
+              the bid price. The highest bidder at the close of the auction is
+              obligated to complete the purchase. Shill bidding, bid manipulation,
+              and any form of auction fraud are strictly prohibited and may result
+              in immediate account termination.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">7. Curated Exhibitions</h2>
+            <p>
+              Curators may create virtual exhibitions featuring artworks from
+              multiple artists. Inclusion of an artwork in an exhibition does not
+              transfer any rights. Artists may request removal of their works from
+              exhibitions at any time.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">8. Prohibited Conduct</h2>
+            <p>You agree not to:</p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>Use the platform for any unlawful purpose</li>
+              <li>Upload content that infringes intellectual property rights</li>
+              <li>Attempt to gain unauthorised access to other accounts or platform systems</li>
+              <li>Interfere with or disrupt the platform's infrastructure</li>
+              <li>Scrape, crawl, or harvest data from the platform without permission</li>
+              <li>Engage in harassment, discrimination, or abusive behaviour towards other users</li>
+              <li>Create multiple accounts to circumvent bans or restrictions</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">9. Intellectual Property</h2>
+            <p>
+              The ArtVerse platform, including its design, code, branding, and
+              original content (excluding user-uploaded artworks), is the property
+              of ArtVerse and is protected by copyright and intellectual property
+              laws. You may not reproduce, distribute, or create derivative works
+              from platform content without our express written permission.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">10. Limitation of Liability</h2>
+            <p>
+              To the maximum extent permitted by applicable law, ArtVerse shall not
+              be liable for any indirect, incidental, special, consequential, or
+              punitive damages arising from your use of the platform. This includes,
+              but is not limited to, loss of profits, data, or goodwill.
+            </p>
+            <p>
+              Nothing in these Terms excludes or limits liability for death or
+              personal injury caused by negligence, fraud, or any other liability
+              that cannot be excluded under applicable EU or Romanian law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">11. Dispute Resolution</h2>
+            <p>
+              We encourage you to contact us first to resolve any disputes
+              informally. If a dispute cannot be resolved amicably, it shall be
+              subject to the jurisdiction of the competent courts in Romania.
+            </p>
+            <p>
+              EU consumers may also use the European Commission's Online Dispute
+              Resolution platform at{" "}
+              <a href="https://ec.europa.eu/consumers/odr" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+                ec.europa.eu/consumers/odr
+              </a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">12. Termination</h2>
+            <p>
+              You may close your account at any time by contacting us. We may
+              suspend or terminate your account if you violate these Terms, with
+              or without notice. Upon termination, your right to use the platform
+              ceases immediately. Provisions that by their nature should survive
+              termination (intellectual property, limitation of liability, dispute
+              resolution) shall remain in effect.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">13. Changes to These Terms</h2>
+            <p>
+              We may modify these Terms at any time. Material changes will be
+              communicated at least 30 days in advance via email or a prominent
+              notice on the platform. Your continued use after the effective date
+              of changes constitutes acceptance of the updated Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-2xl font-semibold">14. Contact</h2>
+            <p>
+              For questions about these Terms, please contact us at:{" "}
+              <a href="mailto:legal@artverse.idata.ro" className="text-primary hover:underline">legal@artverse.idata.ro</a>
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Privacy Policy** (`/privacy`): GDPR-compliant with data controller, lawful basis (Art. 6), all data subject rights (Art. 15-21), ANSPDCP reference, EEA transfer safeguards
- **Terms of Service** (`/terms`): EU consumer protection with 14-day withdrawal right, Romanian jurisdiction, EC ODR link, age 16+ eligibility
- Routes added to App.tsx, linked from existing footer

## Test plan
- [ ] `/privacy` and `/terms` routes load correctly
- [ ] Pages render in PublicLayout (nav + footer visible)
- [ ] Dark/light theme works
- [ ] Footer links navigate correctly
- [ ] Content is readable and well-formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)