### PR TITLE
fix: replace Romania references with Netherlands in legal pages (closes #272)

### DIFF
--- a/client/src/pages/privacy.tsx
+++ b/client/src/pages/privacy.tsx
@@ -129,11 +129,10 @@ export default function Privacy() {
             <p>
               If you believe your data protection rights have been violated, you
               have the right to lodge a complaint with your local data protection
-              supervisory authority. In Romania, the relevant authority is the
-              Autoritatea Nationala de Supraveghere a Prelucrarii Datelor cu
-              Caracter Personal (ANSPDCP) —{" "}
-              <a href="https://www.dataprotection.ro" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
-                www.dataprotection.ro
+              supervisory authority. In the Netherlands, the relevant authority is
+              the Autoriteit Persoonsgegevens (AP) —{" "}
+              <a href="https://www.autoriteitpersoonsgegevens.nl" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+                www.autoriteitpersoonsgegevens.nl
               </a>.
             </p>
           </section>

--- a/client/src/pages/terms.tsx
+++ b/client/src/pages/terms.tsx
@@ -15,8 +15,8 @@ export default function Terms() {
               account or using the platform, you agree to be bound by these Terms.
             </p>
             <p>
-              ArtVerse is operated from Romania within the European Union. These
-              Terms are governed by Romanian law and applicable EU regulations.
+              ArtVerse is operated from the Netherlands within the European Union.
+              These Terms are governed by Dutch law and applicable EU regulations.
             </p>
           </section>
 
@@ -137,7 +137,7 @@ export default function Terms() {
             <p>
               Nothing in these Terms excludes or limits liability for death or
               personal injury caused by negligence, fraud, or any other liability
-              that cannot be excluded under applicable EU or Romanian law.
+              that cannot be excluded under applicable EU or Dutch law.
             </p>
           </section>
 
@@ -146,7 +146,7 @@ export default function Terms() {
             <p>
               We encourage you to contact us first to resolve any disputes
               informally. If a dispute cannot be resolved amicably, it shall be
-              subject to the jurisdiction of the competent courts in Romania.
+              subject to the jurisdiction of the competent courts in the Netherlands.
             </p>
             <p>
               EU consumers may also use the European Commission's Online Dispute


### PR DESCRIPTION
## Summary
- **Privacy Policy**: supervisory authority changed from ANSPDCP (Romania) to Autoriteit Persoonsgegevens (Netherlands)
- **Terms of Service**: operating location, governing law, and court jurisdiction updated from Romania to the Netherlands

## Test plan
- [ ] `/privacy` — no Romania references, Dutch DPA link works
- [ ] `/terms` — Netherlands jurisdiction, Dutch law, no Romania mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)