### PR TITLE
Fix auto-merge workflow: remove self-approval step

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,14 +17,6 @@ jobs:
       github.event.pull_request.user.login == github.repository_owner
 
     steps:
-      - name: Approve PR
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          gh pr review "$PR_URL" --approve \
-            --body "Auto-approved (repo owner PR, all required checks must pass before merge)."
-
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
Closes #278

## Summary
- Removed the approval step from `auto-merge.yml` — it always failed because `RELEASE_PAT` belongs to the same user who opens the PRs, and GitHub prevents self-approval
- Branch protection doesn't require approvals, so the step was unnecessary
- Auto-merge enable step is kept as-is

## Test plan
- [ ] CI passes
- [ ] Auto-merge workflow succeeds on this PR (no more approval failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)