### PR TITLE
feat: rebrand ArtVerse to Vernis9 (closes #244)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,15 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
-    <meta name="description" content="ArtVerse - Experience art like never before. Explore our immersive 3D virtual gallery, discover stunning artworks from talented artists, and participate in exclusive auctions." />
-    <meta property="og:title" content="ArtVerse - Virtual Art Gallery & Marketplace" />
+    <meta name="description" content="Vernis9 - Experience art like never before. Explore our immersive 3D virtual gallery, discover stunning artworks from talented artists, and participate in exclusive auctions." />
+    <meta property="og:title" content="Vernis9 - Virtual Art Gallery & Marketplace" />
     <meta property="og:description" content="Experience art like never before. Explore our immersive 3D virtual gallery, discover stunning artworks, and participate in exclusive auctions." />
     <meta property="og:type" content="website" />
-    <title>ArtVerse - Virtual Art Gallery & Marketplace</title>
+    <title>Vernis9 - Virtual Art Gallery & Marketplace</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Tenor+Sans&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/client/public/favicon.svg
+++ b/client/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="20" fill="#F97316"/>
+  <text x="64" y="72" text-anchor="middle" dominant-baseline="central" font-family="'Bodoni Moda', Georgia, serif" font-weight="bold" font-size="52" fill="white">V9</text>
+</svg>

--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -60,10 +60,10 @@ export function AppSidebar() {
       <SidebarHeader className="p-4 border-b border-sidebar-border">
         <Link href="/" className="flex items-center gap-3" data-testid="link-logo" onClick={closeMobileSidebar}>
           <div className="w-10 h-10 rounded-md bg-primary flex items-center justify-center">
-            <span className="text-primary-foreground font-serif font-bold text-xl">A</span>
+            <span className="text-primary-foreground font-bold text-xl" style={{ fontFamily: "'Tenor Sans', sans-serif" }}>V9</span>
           </div>
           <div>
-            <h1 className="font-serif text-xl font-bold tracking-tight">ArtVerse</h1>
+            <h1 className="text-xl tracking-tight" style={{ fontFamily: "'Tenor Sans', sans-serif" }}>Vernis<span className="ml-0.5">9</span></h1>
             <p className="text-xs text-muted-foreground">Virtual Art Experience</p>
           </div>
         </Link>

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -69,12 +69,12 @@ export function Footer() {
           <div className="space-y-4">
             <Link href="/" className="flex items-center gap-3">
               <div className="w-9 h-9 rounded-md bg-primary flex items-center justify-center">
-                <span className="text-primary-foreground font-serif font-bold text-lg">
-                  A
+                <span className="text-primary-foreground font-bold text-lg" style={{ fontFamily: "'Tenor Sans', sans-serif" }}>
+                  V9
                 </span>
               </div>
-              <span className="font-serif text-xl font-bold tracking-tight">
-                ArtVerse
+              <span className="text-xl tracking-tight" style={{ fontFamily: "'Tenor Sans', sans-serif" }}>
+                Vernis<span className="ml-0.5">9</span>
               </span>
             </Link>
             <p className="text-sm text-muted-foreground leading-relaxed">
@@ -162,7 +162,7 @@ export function Footer() {
       {/* Bottom bar */}
       <div className="border-t">
         <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8 flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-muted-foreground">
-          <p>&copy; {year} ArtVerse. All rights reserved.</p>
+          <p>&copy; {year} Vernis9. All rights reserved.</p>
           <div className="flex items-center gap-4">
             <Link
               href="/privacy"

--- a/client/src/components/top-nav.tsx
+++ b/client/src/components/top-nav.tsx
@@ -77,10 +77,10 @@ export function TopNav() {
         {/* Left: Logo */}
         <Link href="/" className="flex items-center gap-3 shrink-0">
           <div className="w-9 h-9 rounded-md bg-primary flex items-center justify-center">
-            <span className="text-primary-foreground font-serif font-bold text-lg">A</span>
+            <span className="text-primary-foreground font-bold text-lg" style={{ fontFamily: "'Tenor Sans', sans-serif" }}>V9</span>
           </div>
-          <span className="font-serif text-xl font-bold tracking-tight hidden sm:inline">
-            ArtVerse
+          <span className="text-xl tracking-tight hidden sm:inline" style={{ fontFamily: "'Tenor Sans', sans-serif" }}>
+            Vernis<span className="ml-0.5">9</span>
           </span>
         </Link>
 

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -188,7 +188,7 @@ export default function AuthPage() {
             <CardHeader>
               <CardTitle className="font-serif text-2xl">Sign in</CardTitle>
               <CardDescription>
-                Welcome back to ArtVerse.
+                Welcome back to Vernis9.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/client/src/pages/privacy.tsx
+++ b/client/src/pages/privacy.tsx
@@ -9,12 +9,12 @@ export default function Privacy() {
           <section>
             <h2 className="font-serif text-2xl font-semibold">1. Data Controller</h2>
             <p>
-              ArtVerse ("we", "us", "our") is the data controller responsible for
+              Vernis9 ("we", "us", "our") is the data controller responsible for
               processing your personal data. If you have any questions about this
               Privacy Policy or our data practices, please contact us at:
             </p>
             <p>
-              Email: <a href="mailto:privacy@artverse.idata.ro" className="text-primary hover:underline">privacy@artverse.idata.ro</a>
+              Email: <a href="mailto:privacy@vernis9.art" className="text-primary hover:underline">privacy@vernis9.art</a>
             </p>
           </section>
 
@@ -110,7 +110,7 @@ export default function Privacy() {
             </ul>
             <p>
               To exercise any of these rights, contact us at{" "}
-              <a href="mailto:privacy@artverse.idata.ro" className="text-primary hover:underline">privacy@artverse.idata.ro</a>.
+              <a href="mailto:privacy@vernis9.art" className="text-primary hover:underline">privacy@vernis9.art</a>.
               We will respond within 30 days as required by the GDPR.
             </p>
           </section>
@@ -129,10 +129,11 @@ export default function Privacy() {
             <p>
               If you believe your data protection rights have been violated, you
               have the right to lodge a complaint with your local data protection
-              supervisory authority. In the Netherlands, the relevant authority is
-              the Autoriteit Persoonsgegevens (AP) —{" "}
-              <a href="https://www.autoriteitpersoonsgegevens.nl" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
-                www.autoriteitpersoonsgegevens.nl
+              supervisory authority. Under the GDPR, you may contact the
+              supervisory authority in your EU/EEA member state of residence. A
+              full list of EU data protection authorities is available at{" "}
+              <a href="https://edpb.europa.eu/about-edpb/about-edpb/members_en" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+                edpb.europa.eu
               </a>.
             </p>
           </section>
@@ -142,7 +143,7 @@ export default function Privacy() {
             <p>
               We may update this Privacy Policy from time to time. Material changes
               will be communicated via email or a prominent notice on the platform.
-              Your continued use of ArtVerse after changes constitutes acceptance of
+              Your continued use of Vernis9 after changes constitutes acceptance of
               the updated policy.
             </p>
           </section>

--- a/client/src/pages/set-password.tsx
+++ b/client/src/pages/set-password.tsx
@@ -51,7 +51,7 @@ export default function SetPassword() {
               <CheckCircle className="w-8 h-8 text-green-600" />
             </div>
             <CardTitle className="font-serif text-2xl">You're all set!</CardTitle>
-            <CardDescription>Redirecting to ArtVerse...</CardDescription>
+            <CardDescription>Redirecting to Vernis9...</CardDescription>
           </CardHeader>
         ) : (
           <>

--- a/client/src/pages/terms.tsx
+++ b/client/src/pages/terms.tsx
@@ -9,13 +9,13 @@ export default function Terms() {
           <section>
             <h2 className="font-serif text-2xl font-semibold">1. Introduction</h2>
             <p>
-              Welcome to ArtVerse. These Terms of Service ("Terms") govern your
-              access to and use of the ArtVerse platform, including the website,
+              Welcome to Vernis9. These Terms of Service ("Terms") govern your
+              access to and use of the Vernis9 platform, including the website,
               virtual gallery, marketplace, and all related services. By creating an
               account or using the platform, you agree to be bound by these Terms.
             </p>
             <p>
-              ArtVerse is operated from the Netherlands within the European Union.
+              Vernis9 is operated from the Netherlands within the European Union.
               These Terms are governed by Dutch law and applicable EU regulations.
             </p>
           </section>
@@ -23,7 +23,7 @@ export default function Terms() {
           <section>
             <h2 className="font-serif text-2xl font-semibold">2. Eligibility</h2>
             <p>
-              You must be at least 16 years of age to create an account on ArtVerse.
+              You must be at least 16 years of age to create an account on Vernis9.
               If you are under 18, you may use the platform only with the involvement
               and consent of a parent or legal guardian. By using the platform, you
               represent that you meet these requirements.
@@ -44,9 +44,9 @@ export default function Terms() {
           <section>
             <h2 className="font-serif text-2xl font-semibold">4. Artist Accounts and Content</h2>
             <p>
-              Artists who create profiles and upload artworks to ArtVerse retain full
+              Artists who create profiles and upload artworks to Vernis9 retain full
               ownership and intellectual property rights over their original works.
-              By uploading content, you grant ArtVerse a non-exclusive, worldwide,
+              By uploading content, you grant Vernis9 a non-exclusive, worldwide,
               royalty-free licence to display, reproduce, and distribute your content
               within the platform for the purpose of operating the gallery, marketplace,
               and promotional activities.
@@ -62,13 +62,13 @@ export default function Terms() {
           <section>
             <h2 className="font-serif text-2xl font-semibold">5. Purchases and Transactions</h2>
             <p>
-              ArtVerse facilitates transactions between buyers and artists. When you
+              Vernis9 facilitates transactions between buyers and artists. When you
               purchase an artwork:
             </p>
             <ul className="list-disc pl-6 space-y-1">
               <li>All prices are displayed in the currency indicated on the listing</li>
               <li>You enter into a direct transaction with the artist</li>
-              <li>ArtVerse acts as an intermediary to facilitate communication and order tracking</li>
+              <li>Vernis9 acts as an intermediary to facilitate communication and order tracking</li>
               <li>Physical artwork shipping, packaging, and delivery are the responsibility of the artist</li>
             </ul>
             <p>
@@ -118,9 +118,9 @@ export default function Terms() {
           <section>
             <h2 className="font-serif text-2xl font-semibold">9. Intellectual Property</h2>
             <p>
-              The ArtVerse platform, including its design, code, branding, and
+              The Vernis9 platform, including its design, code, branding, and
               original content (excluding user-uploaded artworks), is the property
-              of ArtVerse and is protected by copyright and intellectual property
+              of Vernis9 and is protected by copyright and intellectual property
               laws. You may not reproduce, distribute, or create derivative works
               from platform content without our express written permission.
             </p>
@@ -129,7 +129,7 @@ export default function Terms() {
           <section>
             <h2 className="font-serif text-2xl font-semibold">10. Limitation of Liability</h2>
             <p>
-              To the maximum extent permitted by applicable law, ArtVerse shall not
+              To the maximum extent permitted by applicable law, Vernis9 shall not
               be liable for any indirect, incidental, special, consequential, or
               punitive damages arising from your use of the platform. This includes,
               but is not limited to, loss of profits, data, or goodwill.
@@ -183,7 +183,7 @@ export default function Terms() {
             <h2 className="font-serif text-2xl font-semibold">14. Contact</h2>
             <p>
               For questions about these Terms, please contact us at:{" "}
-              <a href="mailto:legal@artverse.idata.ro" className="text-primary hover:underline">legal@artverse.idata.ro</a>
+              <a href="mailto:legal@vernis9.art" className="text-primary hover:underline">legal@vernis9.art</a>
             </p>
           </section>
         </div>

--- a/server/email.ts
+++ b/server/email.ts
@@ -14,7 +14,7 @@ export function getResendClient(): Resend {
 }
 
 export function getFromEmail(): string {
-  return process.env.RESEND_FROM_EMAIL || "ArtVerse <gallery@idata.ro>";
+  return process.env.RESEND_FROM_EMAIL || "Vernis9 <gallery@idata.ro>";
 }
 
 export async function sendMagicLinkEmail(
@@ -28,11 +28,11 @@ export async function sendMagicLinkEmail(
   await client.emails.send({
     from: getFromEmail(),
     to: email,
-    subject: "Verify your email - ArtVerse",
+    subject: "Verify your email - Vernis9",
     html: `
       <div style="font-family: Georgia, serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h1 style="color: #1a1a2e; border-bottom: 2px solid #F97316; padding-bottom: 10px;">
-          Welcome to ArtVerse
+          Welcome to Vernis9
         </h1>
         <p>Click the button below to verify your email and create your account:</p>
         <div style="text-align: center; margin: 30px 0;">
@@ -45,7 +45,7 @@ export async function sendMagicLinkEmail(
           This link expires in 1 hour. If you didn't request this, you can safely ignore this email.
         </p>
         <p style="color: #999; font-size: 12px; margin-top: 30px;">
-          ArtVerse — Discover. Collect. Create.
+          Vernis9 — Discover. Collect. Create.
         </p>
       </div>
     `,

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -15,7 +15,7 @@ const storage = new DatabaseStorage();
 export function createMcpServer(): McpServer {
   const mcp = new McpServer(
     {
-      name: "artverse-mcp",
+      name: "vernis9-mcp",
       version: "1.0.0",
     },
     {
@@ -31,12 +31,12 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "all-artists",
-    "artverse://artists",
-    { description: "List all artists on ArtVerse" },
+    "vernis9://artists",
+    { description: "List all artists on Vernis9" },
     async () => ({
       contents: [
         {
-          uri: "artverse://artists",
+          uri: "vernis9://artists",
           mimeType: "application/json",
           text: JSON.stringify(await storage.getArtists(), null, 2),
         },
@@ -46,7 +46,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "artist-by-id",
-    new ResourceTemplate("artverse://artists/{artistId}", { list: undefined }),
+    new ResourceTemplate("vernis9://artists/{artistId}", { list: undefined }),
     { description: "Get a specific artist's profile by ID" },
     async (uri, params) => {
       const artist = await storage.getArtist(params.artistId as string);
@@ -64,12 +64,12 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "all-artworks",
-    "artverse://artworks",
+    "vernis9://artworks",
     { description: "List all artworks with artist information" },
     async () => ({
       contents: [
         {
-          uri: "artverse://artworks",
+          uri: "vernis9://artworks",
           mimeType: "application/json",
           text: JSON.stringify(await storage.getArtworks(), null, 2),
         },
@@ -79,7 +79,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "artworks-by-artist",
-    new ResourceTemplate("artverse://artists/{artistId}/artworks", { list: undefined }),
+    new ResourceTemplate("vernis9://artists/{artistId}/artworks", { list: undefined }),
     { description: "Get all artworks by a specific artist" },
     async (uri, params) => {
       const artworks = await storage.getArtworksByArtist(params.artistId as string);
@@ -97,7 +97,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "artwork-by-id",
-    new ResourceTemplate("artverse://artworks/{artworkId}", { list: undefined }),
+    new ResourceTemplate("vernis9://artworks/{artworkId}", { list: undefined }),
     { description: "Get a specific artwork by ID" },
     async (uri, params) => {
       const artwork = await storage.getArtwork(params.artworkId as string);
@@ -115,12 +115,12 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "all-auctions",
-    "artverse://auctions",
+    "vernis9://auctions",
     { description: "List all auctions" },
     async () => ({
       contents: [
         {
-          uri: "artverse://auctions",
+          uri: "vernis9://auctions",
           mimeType: "application/json",
           text: JSON.stringify(await storage.getAuctions(), null, 2),
         },
@@ -130,7 +130,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "auction-by-id",
-    new ResourceTemplate("artverse://auctions/{auctionId}", { list: undefined }),
+    new ResourceTemplate("vernis9://auctions/{auctionId}", { list: undefined }),
     { description: "Get a specific auction with details" },
     async (uri, params) => {
       const auction = await storage.getAuction(params.auctionId as string);
@@ -148,7 +148,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "auction-bids",
-    new ResourceTemplate("artverse://auctions/{auctionId}/bids", { list: undefined }),
+    new ResourceTemplate("vernis9://auctions/{auctionId}/bids", { list: undefined }),
     { description: "Get all bids for a specific auction" },
     async (uri, params) => {
       const bids = await storage.getBidsByAuction(params.auctionId as string);
@@ -166,7 +166,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "orders-by-artist",
-    new ResourceTemplate("artverse://artists/{artistId}/orders", { list: undefined }),
+    new ResourceTemplate("vernis9://artists/{artistId}/orders", { list: undefined }),
     { description: "Get all orders for a specific artist's artworks" },
     async (uri, params) => {
       const orders = await storage.getOrdersByArtist(params.artistId as string);
@@ -184,12 +184,12 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "blog-posts",
-    "artverse://blog",
+    "vernis9://blog",
     { description: "List all published blog posts" },
     async () => ({
       contents: [
         {
-          uri: "artverse://blog",
+          uri: "vernis9://blog",
           mimeType: "application/json",
           text: JSON.stringify(await storage.getBlogPosts(), null, 2),
         },
@@ -199,7 +199,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "blog-posts-by-artist",
-    new ResourceTemplate("artverse://artists/{artistId}/blog", { list: undefined }),
+    new ResourceTemplate("vernis9://artists/{artistId}/blog", { list: undefined }),
     { description: "Get all blog posts by a specific artist" },
     async (uri, params) => {
       const posts = await storage.getBlogPostsByArtist(params.artistId as string);
@@ -217,7 +217,7 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "artist-gallery",
-    new ResourceTemplate("artverse://artists/{artistId}/gallery", { list: undefined }),
+    new ResourceTemplate("vernis9://artists/{artistId}/gallery", { list: undefined }),
     { description: "Get an artist's personal gallery layout and exhibition-ready artworks" },
     async (uri, params) => {
       const artistId = params.artistId as string;
@@ -239,12 +239,12 @@ export function createMcpServer(): McpServer {
 
   mcp.resource(
     "exhibitions",
-    "artverse://exhibitions",
+    "vernis9://exhibitions",
     { description: "List all exhibitions" },
     async () => ({
       contents: [
         {
-          uri: "artverse://exhibitions",
+          uri: "vernis9://exhibitions",
           mimeType: "application/json",
           text: JSON.stringify(await storage.getExhibitions(), null, 2),
         },
@@ -775,7 +775,7 @@ Write 2-3 paragraphs that capture the essence of the piece, its visual qualities
           role: "user",
           content: {
             type: "text",
-            text: `Draft a blog post for the artist ${args.artistName}'s profile on ArtVerse.
+            text: `Draft a blog post for the artist ${args.artistName}'s profile on Vernis9.
 
 Topic: ${args.topic}
 ${args.tone ? `Tone: ${args.tone}` : "Tone: reflective and personal"}
@@ -845,7 +845,7 @@ Keep the summary clear and actionable.`,
           role: "user",
           content: {
             type: "text",
-            text: `Write a professional artist biography for ${args.name} to display on their ArtVerse profile.
+            text: `Write a professional artist biography for ${args.name} to display on their Vernis9 profile.
 
 ${args.specialization ? `Specialization: ${args.specialization}` : ""}
 ${args.country ? `Based in: ${args.country}` : ""}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -76,7 +76,7 @@ async function sendOrderNotificationEmail(
       <p style="color: #666; font-size: 14px; margin-top: 30px;">
         Please prepare the artwork for shipping. You can view all your orders in your artist dashboard.
       </p>
-      <p style="color: #999; font-size: 12px;">This is an automated notification from ArtVerse.</p>
+      <p style="color: #999; font-size: 12px;">This is an automated notification from Vernis9.</p>
     </div>
   `;
 
@@ -132,7 +132,7 @@ async function sendBuyerConfirmationEmail(
       <p style="color: #666; font-size: 14px; margin-top: 30px;">
         The artist will prepare your artwork for shipping. You will be contacted if any additional information is needed.
       </p>
-      <p style="color: #999; font-size: 12px;">This is an automated confirmation from ArtVerse.</p>
+      <p style="color: #999; font-size: 12px;">This is an automated confirmation from Vernis9.</p>
     </div>
   `;
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -137,7 +137,7 @@ export class DatabaseStorage implements IStorage {
     const displayName = [opts.firstName, opts.lastName].filter(Boolean).join(" ") || "New Artist";
     return this.createArtist({
       name: displayName,
-      bio: "Welcome to my gallery! I'm a new artist on ArtVerse.",
+      bio: "Welcome to my gallery! I'm a new artist on Vernis9.",
       userId,
       email: opts.email || undefined,
     });

--- a/specs/features/redesign/NAMING-SPEC.md
+++ b/specs/features/redesign/NAMING-SPEC.md
@@ -1,8 +1,9 @@
 # Brand Naming Specification
 
-**Status:** Draft — Selection Pending
+**Status:** DECIDED — **vernis9.art**
 **Created:** 2026-03-24
-**Required TLDs:** .art, .nu, .ro, .nl
+**Decided:** 2026-03-28
+**Primary TLD:** .art
 
 ---
 
@@ -114,14 +115,40 @@ Worth considering if .nl could be acquired:
 
 ## 7. Selection
 
-**Status:** Pending user decision
+**Status:** DECIDED
+**Chosen name:** **vernis9**
+**Primary domain:** **vernis9.art**
+**Decided:** 2026-03-28
 
-Once a name is selected:
-1. Register all 4 TLDs immediately
+### Why vernis9
+
+- **"Vernis"** — from *vernissage*, the French term for an art gallery opening night (literally "varnishing day"). A deeply art-world insider word.
+- **"9"** — adds uniqueness, ensures domain availability, and keeps it short (7 chars).
+- **French sound, Dutch soul** — "vernissage" is used identically in both French and Dutch art worlds, making it a perfect Belgian/BeNeLux crossover.
+- **Memorable & pronounceable** — "ver-NEE-nine" flows naturally in any language.
+
+### Availability (verified 2026-03-28)
+
+| Domain | Status |
+|--------|--------|
+| vernis9.art | AVAILABLE |
+
+### Pricing (.art TLD)
+
+| Registrar | Registration | Renewal/yr |
+|-----------|-------------|------------|
+| Porkbun | $3.60 | $21.11 |
+| Namecheap | ~$2 | ~$20 |
+
+*Note: Verify at checkout — some names may be premium-priced.*
+
+### Next Steps
+
+1. Register **vernis9.art** immediately
 2. Update UI-SPEC.md with brand name
-3. Create GitHub issue for rebrand implementation
-4. Update logo, metadata, SEO, favicon, sidebar branding
+3. Create GitHub issue for rebrand implementation (#244)
+4. Update logo, metadata, SEO, favicon, navigation branding
 
 ---
 
-*Availability checked on 2026-03-24. Domain availability can change at any time — register promptly once a decision is made.*
+*Rounds 1–2 checked on 2026-03-24. Rounds 3–5 checked on 2026-03-28. Domain availability can change at any time — register promptly.*

--- a/specs/features/redesign/UI-SPEC.md
+++ b/specs/features/redesign/UI-SPEC.md
@@ -384,7 +384,7 @@ These issues can be worked on in parallel once the public shell, top nav, and fo
 **Priority:** Medium — deliberately last, easier once layout is settled.
 
 **Scope:**
-- Apply new brand name (see `NAMING-SPEC.md` — selection pending)
+- Apply new brand name: **Vernis9** (see `NAMING-SPEC.md` — decided 2026-03-28)
 - Update logo, favicon, meta tags, OpenGraph images
 - Update sidebar brand section (dashboard shell)
 - Update top nav brand section (public shell)
@@ -400,7 +400,7 @@ These issues can be worked on in parallel once the public shell, top nav, and fo
 - `client/src/components/footer.tsx` — brand name
 - All page components with hardcoded "ArtVerse" references
 
-**Depends on:** Brand name selection from NAMING-SPEC.md
+**Brand name:** Vernis9 (from "vernissage" — art gallery opening night). See NAMING-SPEC.md.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace all user-visible "ArtVerse" text with **Vernis9** across UI, emails, and MCP server
- Add **Tenor Sans** as brand name font (from Google Fonts) — refined geometric, gallery catalog feel
- New **SVG favicon** with V9 mark on orange (#F97316) rounded rectangle
- Update contact emails to `vernis9.art` domain (`privacy@`, `legal@`)
- Privacy policy Section 10: supervisory authority updated from NL-specific (Autoriteit Persoonsgegevens) to EU-wide (EDPB directory)
- Update NAMING-SPEC.md with final selection and UI-SPEC.md with brand name

### Files changed (15)
**Client UI:** `index.html`, `top-nav.tsx`, `footer.tsx`, `app-sidebar.tsx`, `public-layout.tsx`, `auth-page.tsx`, `set-password.tsx`, `terms.tsx`, `privacy.tsx`, `favicon.svg`
**Server:** `email.ts`, `routes.ts`, `storage.ts`, `mcp.ts`
**Specs:** `NAMING-SPEC.md`, `UI-SPEC.md`

### Out of scope
- Internal persistence keys (`artverse-theme`, `artverse-cart`) — renaming would break existing user data
- Infrastructure (docker, nginx, CI, deploy scripts, `.env`)

## Test plan
- [x] `npm run check` — passes
- [x] `npm test` — 54/54 pass
- [x] `npm run build` — succeeds
- [x] Manual testing: top nav, footer, sidebar, auth page, privacy, terms all show "Vernis9"
- [ ] Verify favicon renders in browser tab
- [ ] Check email templates render "Vernis9" (requires Resend test)

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)