### PR TITLE
docs: add newsletter_subscribers and site_settings to DATA-MODEL.md (closes #300, #294, #292, #290)

### DIFF
--- a/specs/architecture/DATA-MODEL.md
+++ b/specs/architecture/DATA-MODEL.md
@@ -33,6 +33,8 @@ All tables defined using Drizzle ORM. Main schema in `shared/schema.ts`, auth ta
 | **exhibitions** | `shared/schema.ts` | id, name, description, layout (text/JSON), isActive, createdAt | Curated shows |
 | **exhibition_artworks** | `shared/schema.ts` | id, exhibitionId (FK), artworkId (FK), wallId, position | Wall placement in exhibitions |
 | **blog_posts** | `shared/schema.ts` | id, artistId (FK→artists), title, content, excerpt, coverImageUrl, isPublished, createdAt, updatedAt | Artist blog entries |
+| **site_settings** | `shared/schema.ts` | id (default "default"), galleryTemplate (varchar), updatedAt | Global site configuration (singleton row) |
+| **newsletter_subscribers** | `shared/schema.ts` | id (serial), email (unique, varchar 255), subscribedAt (timestamp), unsubscribedAt (timestamp, nullable) | Newsletter signup list — managed via admin panel |
 
 ---
 


### PR DESCRIPTION
## Summary
- Document `newsletter_subscribers` table (added in migration 0006 for newsletter signup feature)
- Document `site_settings` table (was also undocumented)
- Resolves the stale DATA-MODEL.md warning from the Documentation Agent

Closes #300, #294, #292, #290

## Test plan
- [x] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)