### PR TITLE
feat: add version and changelog smoke test to deploy workflows (closes #296)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,25 @@ jobs:
           fi
           echo "Health check passed — staging deployment verified"
 
+      - name: Smoke test — version and changelog
+        run: |
+          BASE_URL="${{ secrets.STAGING_URL }}"
+
+          VERSION=$(curl --silent --fail "$BASE_URL/api/version" | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "unknown" ]; then
+            echo "WARNING: /api/version returned '${VERSION:-empty}' — CHANGELOG.md may be missing from the image"
+          else
+            echo "Version check passed — $VERSION"
+          fi
+
+          CHANGELOG=$(curl --silent --fail "$BASE_URL/api/changelog" | head -30)
+          if ! echo "$CHANGELOG" | grep -qE '## \[[0-9]+\.[0-9]+\.[0-9]+\]'; then
+            echo "WARNING: /api/changelog has no version entries"
+          else
+            LATEST=$(echo "$CHANGELOG" | grep -oE '## \[[0-9]+\.[0-9]+\.[0-9]+\]' | head -1)
+            echo "Changelog check passed — latest entry: $LATEST"
+          fi
+
       - name: Smoke test — logging infrastructure
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -83,6 +83,28 @@ jobs:
           fi
           echo "Health check passed — production deployment verified"
 
+      - name: Smoke test — version and changelog
+        run: |
+          BASE_URL="${{ secrets.PRODUCTION_URL }}"
+
+          # Check /api/version returns a valid version (not "unknown")
+          VERSION=$(curl --silent --fail "$BASE_URL/api/version" | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "unknown" ]; then
+            echo "WARNING: /api/version returned '${VERSION:-empty}' — CHANGELOG.md may be missing from the image"
+            echo "See postmortem: docs/postmortems/2026-03-29-changelog-version-mismatch.md"
+          else
+            echo "Version check passed — $VERSION"
+          fi
+
+          # Check /api/changelog returns content with at least one version entry
+          CHANGELOG=$(curl --silent --fail "$BASE_URL/api/changelog" | head -30)
+          if ! echo "$CHANGELOG" | grep -qE '## \[[0-9]+\.[0-9]+\.[0-9]+\]'; then
+            echo "WARNING: /api/changelog has no version entries — CHANGELOG.md may be stale"
+          else
+            LATEST=$(echo "$CHANGELOG" | grep -oE '## \[[0-9]+\.[0-9]+\.[0-9]+\]' | head -1)
+            echo "Changelog check passed — latest entry: $LATEST"
+          fi
+
       - name: Rollback on failure
         if: failure()
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1


### PR DESCRIPTION
## Summary
Add a "Smoke test — version and changelog" step to both `deploy-production.yml` and `ci.yml` (staging deploy) that:

1. Fetches `/api/version` and verifies it returns a valid version (not `"unknown"`)
2. Fetches `/api/changelog` and verifies it contains at least one `## [X.Y.Z]` entry

Emits **warnings** (not failures) — this is a detection mechanism, not a gate. The health check remains the deploy gate.

From postmortem action item #2: [docs/postmortems/2026-03-29-changelog-version-mismatch.md](docs/postmortems/2026-03-29-changelog-version-mismatch.md)

Closes #296

## Test plan
- [x] YAML syntax valid
- [x] Steps run after health check, before rollback logic
- [x] curl commands use the correct secret URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)