### PR TITLE
fix: disable submit during image upload & fix stale closures (#307)

### DIFF
--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -581,7 +581,7 @@ export default function ArtistDashboard() {
                       handleImageUpload(
                         file,
                         "/api/upload/artwork",
-                        (url) => setArtworkForm({ ...artworkForm, imageUrl: url }),
+                        (url) => setArtworkForm(prev => ({ ...prev, imageUrl: url })),
                         setArtworkUploading,
                       )
                     }
@@ -677,7 +677,7 @@ export default function ArtistDashboard() {
                 <DialogFooter>
                   <Button 
                     onClick={handleArtworkSubmit}
-                    disabled={!artworkForm.title || !artworkForm.imageUrl || !artworkForm.price || createArtworkMutation.isPending || updateArtworkMutation.isPending}
+                    disabled={!artworkForm.title || !artworkForm.imageUrl || !artworkForm.price || artworkUploading || createArtworkMutation.isPending || updateArtworkMutation.isPending}
                     data-testid="button-save-artwork"
                   >
                     <Save className="h-4 w-4 mr-2" />
@@ -813,7 +813,7 @@ export default function ArtistDashboard() {
                       handleImageUpload(
                         file,
                         "/api/upload/blog-cover",
-                        (url) => setBlogForm({ ...blogForm, coverImageUrl: url }),
+                        (url) => setBlogForm(prev => ({ ...prev, coverImageUrl: url })),
                         setBlogCoverUploading,
                       )
                     }
@@ -842,7 +842,7 @@ export default function ArtistDashboard() {
                 <DialogFooter>
                   <Button 
                     onClick={handleBlogSubmit}
-                    disabled={!blogForm.title || !blogForm.content || createBlogPostMutation.isPending || updateBlogPostMutation.isPending}
+                    disabled={!blogForm.title || !blogForm.content || blogCoverUploading || createBlogPostMutation.isPending || updateBlogPostMutation.isPending}
                     data-testid="button-save-blog"
                   >
                     <Save className="h-4 w-4 mr-2" />
@@ -1147,7 +1147,7 @@ export default function ArtistDashboard() {
                     );
                     updateProfileMutation.mutate({ ...profileForm, socialLinks: cleanedLinks });
                   }}
-                  disabled={updateProfileMutation.isPending || !profileForm.name.trim()}
+                  disabled={updateProfileMutation.isPending || avatarUploading || !profileForm.name.trim()}
                   data-testid="button-save-profile"
                 >
                   <Save className="h-4 w-4 mr-2" />
@@ -1178,7 +1178,7 @@ export default function ArtistDashboard() {
                         handleImageUpload(
                           file,
                           "/api/upload/avatar",
-                          (imageUrl) => setProfileForm({ ...profileForm, avatarUrl: imageUrl }),
+                          (imageUrl) => setProfileForm(prev => ({ ...prev, avatarUrl: imageUrl })),
                           setAvatarUploading,
                         )
                       }


### PR DESCRIPTION
## Summary

- Disable form submit buttons while image uploads are in progress (blog cover, artwork, avatar) — prevents creating posts/artworks with missing images
- Fix stale closure bug in all 3 upload callbacks by using functional state updates (`prev => ({ ...prev, ... })`)

Closes #307

## Root Cause

Blog post image not visible in production because:
1. **Nginx** has no `client_max_body_size` — defaults to 1MB, silently rejects phone-sized photos (separate VPS fix needed)
2. **Submit button** was not disabled during upload — user could submit before upload completes
3. **Stale closure** in upload callbacks could overwrite form fields edited during upload

## Test plan

- [ ] Log in to dashboard, create blog post with cover image — button disabled during upload
- [ ] Create artwork with image — button disabled during upload  
- [ ] Edit profile avatar — save button disabled during upload
- [ ] Verify no form field data is lost when editing fields during upload

> **Note:** Nginx `client_max_body_size 20m` must be added to VPS configs separately to unblock uploads > 1MB in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)