### PR TITLE
fix: scroll to top on page navigation (closes #310)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, useLocation } from "wouter";
+import { useEffect } from "react";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -24,6 +25,14 @@ import Changelog from "@/pages/changelog";
 import Privacy from "@/pages/privacy";
 import Terms from "@/pages/terms";
 import NotFound from "@/pages/not-found";
+
+function ScrollToTop() {
+  const [location] = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+  return null;
+}
 
 function Router() {
   return (
@@ -56,6 +65,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="light">
         <TooltipProvider>
+          <ScrollToTop />
           <PublicLayout>
             <Router />
           </PublicLayout>


### PR DESCRIPTION
## Summary

- Adds a `ScrollToTop` component that calls `window.scrollTo(0, 0)` on every Wouter route change
- Fixes the issue where navigating to a new page on mobile would land mid-page instead of at the top

Closes #310

## Test plan

- [ ] On mobile (or narrow browser), scroll down on any page, then navigate to another page — should start at the top
- [ ] Verify back/forward browser navigation also scrolls to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)