### PR TITLE
fix: open artwork detail dialog instead of navigating to gallery (closes #312)

### DIFF
--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -44,8 +44,8 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
+      <DialogPrimitive.Close className="absolute right-3 top-3 z-10 rounded-full bg-background/90 border shadow-sm p-1.5 opacity-90 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-5 w-5" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -24,6 +24,7 @@ import { useCartStore } from "@/lib/cart-store";
 import { formatPrice } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import { HallwayGallery3D } from "@/components/hallway-gallery-3d";
+import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
 
 type ViewMode = "3d" | "classic";
 
@@ -34,11 +35,14 @@ interface ArtistRoom {
 
 export default function Gallery() {
   const isMobile = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
-  const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? "classic" : "3d");
+  const searchParams = new URLSearchParams(window.location.search);
+  const requestedView = searchParams.get("view");
+  const [viewMode, setViewMode] = useState<ViewMode>(requestedView === "classic" ? "classic" : isMobile ? "classic" : "3d");
   const { isImmersive, toggleImmersive } = useImmersiveMode();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [zoom, setZoom] = useState(1);
   const [showInfo, setShowInfo] = useState(false);
+  const [selectedArtwork, setSelectedArtwork] = useState<ArtworkWithArtist | null>(null);
   const galleryRef = useRef<HTMLDivElement>(null);
 
   const { data: artworks, isLoading: artworksLoading } = useQuery<ArtworkWithArtist[]>({
@@ -247,8 +251,9 @@ export default function Gallery() {
             </Button>
 
             <div
-              className="relative transition-transform duration-500 ease-out"
+              className="relative transition-transform duration-500 ease-out cursor-pointer"
               style={{ transform: `scale(${zoom})` }}
+              onClick={() => setSelectedArtwork(currentArtwork)}
             >
               <img
                 src={currentArtwork.imageUrl}
@@ -388,6 +393,12 @@ export default function Gallery() {
           )}
         </>
       )}
+
+      <ArtworkDetailDialog
+        artwork={selectedArtwork}
+        open={!!selectedArtwork}
+        onOpenChange={(open) => !open && setSelectedArtwork(null)}
+      />
     </div>
   );
 }

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
@@ -486,6 +487,8 @@ function HomeSkeleton() {
 // ---------------------------------------------------------------------------
 
 export default function Home() {
+  const [selectedArtwork, setSelectedArtwork] = useState<ArtworkWithArtist | null>(null);
+
   const { data: artworks, isLoading: artworksLoading } = useQuery<
     ArtworkWithArtist[]
   >({
@@ -535,7 +538,7 @@ export default function Home() {
           title="Featured Artworks"
           subtitle="Handpicked masterpieces from our collection"
           action={
-            <Link href="/gallery">
+            <Link href="/gallery?view=classic">
               <Button variant="ghost" size="sm">
                 View All <ArrowRight className="h-4 w-4 ml-1" />
               </Button>
@@ -546,9 +549,7 @@ export default function Home() {
             <ShelfItem key={artwork.id}>
               <ArtworkCard
                 artwork={artwork}
-                onViewDetails={() => {
-                  window.location.href = `/gallery`;
-                }}
+                onViewDetails={() => setSelectedArtwork(artwork)}
               />
             </ShelfItem>
           ))}
@@ -561,7 +562,7 @@ export default function Home() {
           title="New This Week"
           subtitle="Recently added to our collection"
           action={
-            <Link href="/gallery">
+            <Link href="/gallery?view=classic">
               <Button variant="ghost" size="sm">
                 Browse All <ArrowRight className="h-4 w-4 ml-1" />
               </Button>
@@ -572,9 +573,7 @@ export default function Home() {
             <ShelfItem key={artwork.id}>
               <ArtworkCard
                 artwork={artwork}
-                onViewDetails={() => {
-                  window.location.href = `/gallery`;
-                }}
+                onViewDetails={() => setSelectedArtwork(artwork)}
               />
             </ShelfItem>
           ))}
@@ -598,6 +597,12 @@ export default function Home() {
 
       {/* 7. CTA */}
       <CTASection />
+
+      <ArtworkDetailDialog
+        artwork={selectedArtwork}
+        open={!!selectedArtwork}
+        onOpenChange={(open) => !open && setSelectedArtwork(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Home page**: Clicking artworks in "Featured Artworks" and "New This Week" now opens the artwork detail dialog instead of redirecting to `/gallery`
- **Gallery**: Clicking the main artwork image in classic view opens the detail dialog
- **View All / Browse All** buttons now link to `/gallery?view=classic` to open in 2D mode
- **Dialog close button**: Made larger, round, with visible background — much easier to tap on mobile

Closes #312

## Test plan

- [ ] Home page: click artwork in Featured section → detail dialog opens
- [ ] Home page: click artwork in New This Week → detail dialog opens
- [ ] Home page: click "View All" / "Browse All" → gallery opens in classic (2D) mode
- [ ] Gallery classic view: click main artwork image → detail dialog opens
- [ ] Dialog close button (X) is clearly visible and easy to tap on mobile
- [ ] Add to cart works from the detail dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)