### PR TITLE
feat: replace Gallery with Exhibitions in mobile bottom tabs (closes #313)

### DIFF
--- a/client/src/components/bottom-tabs.tsx
+++ b/client/src/components/bottom-tabs.tsx
@@ -1,11 +1,11 @@
 import { Link, useLocation } from "wouter";
-import { Home, Image, Store, Users, ShoppingCart } from "lucide-react";
+import { Home, Ticket, Store, Users, ShoppingCart } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useCartStore } from "@/lib/cart-store";
 
 const tabs = [
   { label: "Home", icon: Home, href: "/" },
-  { label: "Gallery", icon: Image, href: "/gallery" },
+  { label: "Exhibitions", icon: Ticket, href: "/exhibitions" },
   { label: "Store", icon: Store, href: "/store" },
   { label: "Artists", icon: Users, href: "/artists" },
 ];


### PR DESCRIPTION
## Summary

- Replaces the Gallery link with Exhibitions in the mobile bottom navigation bar
- Uses Ticket icon instead of Image icon to match the exhibitions context
- Gallery remains accessible via the home page and top navigation

Closes #313

## Test plan

- [ ] On mobile: bottom tab shows "Exhibitions" with ticket icon instead of "Gallery"
- [ ] Tapping Exhibitions navigates to `/exhibitions`
- [ ] Active state highlights correctly when on exhibitions page

🤖 Generated with [Claude Code](https://claude.com/claude-code)