### PR TITLE
feat: add 2D classic view for exhibitions, default on mobile (closes #320)

### DIFF
--- a/client/src/pages/curator-gallery.tsx
+++ b/client/src/pages/curator-gallery.tsx
@@ -1,16 +1,25 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useRoute } from "wouter";
 import { MazeGallery3D } from "@/components/maze-gallery-3d";
+import { ArtworkCard } from "@/components/artwork-card";
+import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { Box, X } from "lucide-react";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Box, X, Frame } from "lucide-react";
 import { useImmersiveMode } from "@/hooks/use-immersive-mode";
-import type { CuratorGalleryWithArtworks, MazeLayout } from "@shared/schema";
+import type { ArtworkWithArtist, CuratorGalleryWithArtworks, MazeLayout } from "@shared/schema";
+
+type ViewMode = "3d" | "classic";
 
 export default function CuratorGalleryPage() {
   const [, params] = useRoute("/curator-gallery/:id");
   const galleryId = params?.id;
   const { isImmersive, toggleImmersive } = useImmersiveMode();
+  const isMobile = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+  const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? "classic" : "3d");
+  const [selectedArtwork, setSelectedArtwork] = useState<ArtworkWithArtist | null>(null);
 
   const { data: gallery, isLoading, error } = useQuery<CuratorGalleryWithArtworks>({
     queryKey: [`/api/curator-galleries/${galleryId}`],
@@ -67,24 +76,48 @@ export default function CuratorGalleryPage() {
         </Button>
       )}
       {!isImmersive && (
-        <div className="p-4 border-b bg-background">
-          <h1 className="font-serif text-2xl font-bold">{gallery.name}</h1>
-          <p className="text-sm text-muted-foreground">
-            Curated by {curatorName}
-            {gallery.description && ` — ${gallery.description}`}
-          </p>
+        <div className="p-4 border-b bg-background flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="font-serif text-2xl font-bold">{gallery.name}</h1>
+            <p className="text-sm text-muted-foreground">
+              Curated by {curatorName}
+              {gallery.description && ` — ${gallery.description}`}
+            </p>
+          </div>
+          {gallery.artworks.length > 0 && layout && (
+            <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)} className="shrink-0">
+              <TabsList>
+                <TabsTrigger value="3d"><Box className="h-4 w-4 mr-1" /> 3D</TabsTrigger>
+                <TabsTrigger value="classic"><Frame className="h-4 w-4 mr-1" /> 2D</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          )}
         </div>
       )}
       <div className="flex-1 relative">
         {gallery.artworks.length > 0 && layout ? (
-          <MazeGallery3D
-            artworks={gallery.artworks}
-            layout={layout}
-            galleryTemplate={gallery.galleryTemplate || "contemporary"}
-            artist={{ id: gallery.id, name: gallery.name, avatarUrl: null, specialization: `Curated by ${curatorName}`, bio: posterBio, email: null, country: null, userId: null, galleryLayout: null, galleryTemplate: null, socialLinks: null }}
-            isImmersive={isImmersive}
-            onRequestImmersive={toggleImmersive}
-          />
+          viewMode === "3d" ? (
+            <MazeGallery3D
+              artworks={gallery.artworks}
+              layout={layout}
+              galleryTemplate={gallery.galleryTemplate || "contemporary"}
+              artist={{ id: gallery.id, name: gallery.name, avatarUrl: null, specialization: `Curated by ${curatorName}`, bio: posterBio, email: null, country: null, userId: null, galleryLayout: null, galleryTemplate: null, socialLinks: null }}
+              isImmersive={isImmersive}
+              onRequestImmersive={toggleImmersive}
+            />
+          ) : (
+            <div className="p-4 sm:p-6 overflow-y-auto h-full">
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+                {gallery.artworks.map((artwork) => (
+                  <ArtworkCard
+                    key={artwork.id}
+                    artwork={artwork}
+                    onViewDetails={() => setSelectedArtwork(artwork)}
+                  />
+                ))}
+              </div>
+            </div>
+          )
         ) : (
           <div className="flex items-center justify-center h-full">
             <div className="text-center">
@@ -94,6 +127,12 @@ export default function CuratorGalleryPage() {
           </div>
         )}
       </div>
+
+      <ArtworkDetailDialog
+        artwork={selectedArtwork}
+        open={!!selectedArtwork}
+        onOpenChange={(open) => !open && setSelectedArtwork(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a 3D/2D view toggle to the curator gallery (exhibition) page
- Mobile devices default to 2D grid view with artwork cards
- Desktop defaults to 3D maze gallery as before
- Clicking artworks in 2D view opens the detail dialog

Closes #320

## Test plan

- [ ] On mobile: exhibition opens in 2D grid view by default
- [ ] 3D/2D toggle visible in exhibition header — switching works
- [ ] Clicking artwork in 2D view opens detail dialog
- [ ] Desktop: still defaults to 3D

🤖 Generated with [Claude Code](https://claude.com/claude-code)