### PR TITLE
feat: use #featured tag in description to select hero artworks (closes #318)

### DIFF
--- a/client/src/components/artwork-detail-dialog.tsx
+++ b/client/src/components/artwork-detail-dialog.tsx
@@ -95,7 +95,7 @@ export function ArtworkDetailDialog({
 
             <div className="space-y-4 flex-1">
               <p className="text-sm text-muted-foreground leading-relaxed">
-                {artwork.description}
+                {artwork.description?.replace(/#featured\b/gi, "").trim()}
               </p>
 
               <div className="grid grid-cols-2 gap-3">

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -337,7 +337,7 @@ export default function Gallery() {
                       <h3 className="font-serif text-xl font-bold">{currentArtwork.title}</h3>
                       <p className="text-muted-foreground">{currentArtwork.artist.name}</p>
                     </div>
-                    <p className="text-sm leading-relaxed">{currentArtwork.description}</p>
+                    <p className="text-sm leading-relaxed">{currentArtwork.description?.replace(/#featured\b/gi, "").trim()}</p>
                     <div className="grid grid-cols-2 gap-4 text-sm">
                       <div>
                         <span className="text-muted-foreground">Medium</span>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -517,8 +517,9 @@ export default function Home() {
   if (artworksLoading) return <HomeSkeleton />;
 
   const allArtworks = artworks ?? [];
-  // Use gallery artworks for the hero, remaining for the shelf
-  const heroArtworks = allArtworks.filter((a) => a.isInGallery).slice(0, 5);
+  // Use #featured artworks for the hero; fall back to isInGallery
+  const featuredArtworks = allArtworks.filter((a) => a.description?.includes("#featured"));
+  const heroArtworks = (featuredArtworks.length > 0 ? featuredArtworks : allArtworks.filter((a) => a.isInGallery)).slice(0, 5);
   const heroIds = new Set(heroArtworks.map((a) => a.id));
   const shelfArtworks = allArtworks.slice(0, 12);
   // "New This Week" — artworks not already in the hero, reversed to show newest first

--- a/client/src/pages/store.tsx
+++ b/client/src/pages/store.tsx
@@ -254,7 +254,7 @@ export default function Store() {
                 <h3 className="font-serif font-semibold truncate">{artwork.title}</h3>
                 <p className="text-sm text-muted-foreground">{artwork.artist.name}</p>
                 <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
-                  {artwork.description}
+                  {artwork.description?.replace(/#featured\b/gi, "").trim()}
                 </p>
               </div>
               <div className="text-right shrink-0">


### PR DESCRIPTION
## Summary

- Artworks with `#featured` in their description are prioritized for the homepage hero carousel
- Falls back to existing `isInGallery` filter if no artworks have the tag
- `#featured` tag is stripped from description display in all views (detail dialog, store, gallery info panel)

Closes #318

## How to use

Add `#featured` anywhere in an artwork's description (via the artist dashboard). That artwork will appear in the homepage hero slider. Remove the tag to exclude it.

## Test plan

- [ ] Add `#featured` to an artwork description → appears in hero carousel
- [ ] Remove `#featured` → falls back to gallery artworks in hero
- [ ] `#featured` text does not display in artwork detail dialog, store list, or gallery info panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)