### PR TITLE
fix: artwork price overflow and exhibition 2D layout on mobile (closes #325)

### DIFF
--- a/client/src/components/artwork-card.tsx
+++ b/client/src/components/artwork-card.tsx
@@ -91,12 +91,12 @@ export function ArtworkCard({ artwork, onViewDetails, showAddToCart = true }: Ar
           <p className="text-sm text-muted-foreground line-clamp-1">
             {artwork.artist.name}
           </p>
-          <div className="flex items-center justify-between gap-2 pt-1">
+          <div className="flex items-center justify-between gap-2 pt-1 min-w-0">
             <Badge variant="outline" className="text-xs">
               {artwork.medium}
             </Badge>
             {artwork.isForSale && (
-              <span className="font-semibold text-primary" data-testid={`text-price-${artwork.id}`}>
+              <span className="font-semibold text-primary text-sm truncate" data-testid={`text-price-${artwork.id}`}>
                 {formatPrice(artwork.price)}
               </span>
             )}

--- a/client/src/pages/curator-gallery.tsx
+++ b/client/src/pages/curator-gallery.tsx
@@ -63,7 +63,7 @@ export default function CuratorGalleryPage() {
   })();
 
   return (
-    <div className={`flex flex-col ${isImmersive ? "h-screen" : "h-[calc(100vh-4rem)]"}`}>
+    <div className={`flex flex-col ${isImmersive ? "h-screen" : viewMode === "3d" ? "h-[calc(100vh-4rem)]" : "min-h-[calc(100vh-4rem)]"}`}>
       {isImmersive && (
         <Button
           size="icon"
@@ -106,7 +106,7 @@ export default function CuratorGalleryPage() {
               onRequestImmersive={toggleImmersive}
             />
           ) : (
-            <div className="p-4 sm:p-6 overflow-y-auto h-full">
+            <div className="p-4 sm:p-6">
               <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
                 {gallery.artworks.map((artwork) => (
                   <ArtworkCard


### PR DESCRIPTION
## Summary

- **Price overflow**: Added `text-sm`, `truncate`, and `min-w-0` to artwork card price to prevent it from crossing card borders on narrow mobile screens
- **Exhibition 2D overlap**: Changed container from fixed `h-[calc(100vh-4rem)]` to `min-h-[...]` for 2D mode, so content flows naturally without overlapping bottom page elements

Closes #325

## Test plan

- [ ] On mobile 2D exhibition: prices fit within card borders
- [ ] Large exhibitions in 2D scroll naturally without overlapping footer/bottom nav
- [ ] 3D view still fills the viewport correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)