### PR TITLE
fix: keep artwork for sale after order is placed (closes #326)

### DIFF
--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -217,7 +217,7 @@ describe("POST /api/orders", () => {
 
     expect(res.status).toBe(201);
     expect(mockStorage.createOrder).toHaveBeenCalled();
-    expect(mockStorage.updateArtwork).toHaveBeenCalledWith("a1", { isForSale: false });
+    expect(mockStorage.updateArtwork).not.toHaveBeenCalled();
   });
 
   it("uses DB price instead of client-sent price", async () => {

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -465,7 +465,6 @@ export function createMcpServer(): McpServer {
           totalAmount: artwork.price,
           status: "pending",
         });
-        await storage.updateArtwork(args.artworkId, { isForSale: false });
         return {
           content: [{ type: "text", text: JSON.stringify(order, null, 2) }],
         };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -580,9 +580,6 @@ export async function registerRoutes(
 
       const order = await storage.createOrder(validatedOrder);
 
-      // Mark artwork as sold
-      await storage.updateArtwork(orderData.artworkId, { isForSale: false });
-
       // Send email notifications
       try {
         const artist = await storage.getArtist(artwork.artist.id);


### PR DESCRIPTION
## Summary

- Removes automatic `isForSale = false` when an order is created (REST API and MCP tool)
- The artist manually decides when to take an artwork off sale via the dashboard
- Updated test to verify artwork sale status is NOT changed on order creation

Closes #326

## Test plan

- [ ] Place an order for an artwork → artwork remains listed as for sale
- [ ] Artist can still manually toggle isForSale in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)