### PR TITLE
feat: add Nginx redirect from vernis9.nl to vernis9.art

### DIFF
--- a/deploy/nginx/vernis9.nl.conf
+++ b/deploy/nginx/vernis9.nl.conf
@@ -1,0 +1,6 @@
+server {
+    listen 80;
+    server_name vernis9.nl www.vernis9.nl;
+
+    return 301 https://vernis9.art$request_uri;
+}

--- a/specs/architecture/CONTAINERS.md
+++ b/specs/architecture/CONTAINERS.md
@@ -115,8 +115,9 @@ Nginx runs directly on the host (not containerized). Each environment has a serv
 | `artverse.idata.ro.conf` | `vernis9.art` | `http://127.0.0.1:5002` |
 | `staging.artverse.idata.ro.conf` | `staging.vernis9.art` | `http://127.0.0.1:5003` |
 | `preview.artverse.idata.ro.conf` | `preview.vernis9.art` | `http://127.0.0.1:5004` |
+| `vernis9.nl.conf` | `vernis9.nl`, `www.vernis9.nl` | 301 redirect to `https://vernis9.art` |
 
-> **Note:** The Nginx config filenames in the repo still reference `artverse.idata.ro` (the original domain). The live server configs have been updated to serve `vernis9.art`.
+> **Note:** The Nginx config filenames for the main environments still reference `artverse.idata.ro` (the original domain). The live server configs have been updated to serve `vernis9.art`.
 
 All configs:
 - Proxy HTTP/1.1 with WebSocket upgrade support (`Upgrade` + `Connection` headers)


### PR DESCRIPTION
## Summary
- Adds `deploy/nginx/vernis9.nl.conf` — 301 redirects `vernis9.nl` and `www.vernis9.nl` to `https://vernis9.art` (preserving request URI)
- Documents the new redirect in `specs/architecture/CONTAINERS.md`

## Manual steps after merge
1. Copy the config to the VPS: `scp deploy/nginx/vernis9.nl.conf production:~/`
2. SSH in and symlink it: `sudo cp ~/vernis9.nl.conf /etc/nginx/sites-available/ && sudo ln -s /etc/nginx/sites-available/vernis9.nl.conf /etc/nginx/sites-enabled/`
3. Get TLS cert: `sudo certbot --nginx -d vernis9.nl -d www.vernis9.nl`
4. Reload Nginx: `sudo nginx -t && sudo systemctl reload nginx`

## Test plan
- [ ] `curl -I http://vernis9.nl` returns 301 to `https://vernis9.art`
- [ ] `curl -I http://www.vernis9.nl` returns 301 to `https://vernis9.art`
- [ ] `curl -I http://vernis9.nl/store` preserves path → `https://vernis9.art/store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)