### PR TITLE
feat: upgrade lucide-react to v1.7.0 (closes #352)

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "wouter";
-import { Instagram, Twitter, Facebook, Youtube, Send, Check, Loader2 } from "lucide-react";
+import { Send, Check, Loader2 } from "lucide-react";
+import { SiInstagram, SiX, SiFacebook, SiYoutube } from "react-icons/si";
 import { useTheme, ACCENT_COLORS } from "@/components/theme-provider";
 import { Vernis9Logo } from "@/components/vernis9-logo";
 import { Input } from "@/components/ui/input";
@@ -21,10 +22,10 @@ const artistLinks = [
 ];
 
 const socialLinks = [
-  { icon: Instagram, label: "Instagram", url: "#" },
-  { icon: Twitter, label: "X / Twitter", url: "#" },
-  { icon: Facebook, label: "Facebook", url: "#" },
-  { icon: Youtube, label: "YouTube", url: "#" },
+  { icon: SiInstagram, label: "Instagram", url: "#" },
+  { icon: SiX, label: "X / Twitter", url: "#" },
+  { icon: SiFacebook, label: "Facebook", url: "#" },
+  { icon: SiYoutube, label: "YouTube", url: "#" },
 ];
 
 export function Footer() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "framer-motion": "^11.13.1",
         "helmet": "^8.1.0",
         "input-otp": "^1.4.2",
-        "lucide-react": "^0.453.0",
+        "lucide-react": "^1.7.0",
         "memoizee": "^0.4.17",
         "memorystore": "^1.6.7",
         "multer": "^2.1.1",
@@ -8048,12 +8048,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.453.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.453.0.tgz",
-      "integrity": "sha512-kL+RGZCcJi9BvJtzg2kshO192Ddy9hv3ij+cPrVPWSRzgCWCVazoQJxOjAwgK53NomL07HB7GPHW120FimjNhQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "framer-motion": "^11.13.1",
     "helmet": "^8.1.0",
     "input-otp": "^1.4.2",
-    "lucide-react": "^0.453.0",
+    "lucide-react": "^1.7.0",
     "memoizee": "^0.4.17",
     "memorystore": "^1.6.7",
     "multer": "^2.1.1",


### PR DESCRIPTION
## Summary
- Upgrades `lucide-react` from `0.453.0` to `1.7.0` (major version)
- Replaces removed brand icons (`Instagram`, `Twitter`, `Facebook`, `Youtube`) in `footer.tsx` with `react-icons/si` equivalents, consistent with `artist-dashboard.tsx` and `artist-profile.tsx`
- Deprecated icon aliases (e.g. `AlertCircle`, `Loader2`, `Home`) still work in v1 — can be renamed to canonical names in a follow-up

## Test plan
- [x] `npm run check` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 54/54 passing
- [x] Dev server starts, footer renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)