### PR TITLE
fix: patch picomatch CVE-2026-33671 (unblocks staging deploy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
   "overrides": {
     "drizzle-kit": {
       "@esbuild-kit/esm-loader": "npm:tsx@^4.20.4"
-    }
+    },
+    "picomatch": "^4.0.4"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- Adds npm override for `picomatch@^4.0.4` to fix CVE-2026-33671 (HIGH — ReDoS via crafted extglob patterns)
- This CVE was causing Trivy container scan to fail in CI, which blocked the deploy-to-staging job
- Staging has not received the last 2 merges due to this

## Test plan
- [x] `npm run check` — passes
- [x] `npm test` — 54/54 passing
- [x] `npm ls picomatch` — all instances at 4.0.4
- [ ] Trivy scan passes in CI
- [ ] Deploy to staging succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)