### PR TITLE
fix: trivyignore picomatch CVE in base image (unblocks staging)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -21,6 +21,9 @@ CVE-2026-26996
 CVE-2026-27903
 CVE-2026-27904
 
+# picomatch 4.0.3 via tinyglobby (our lockfile: 4.0.4)
+CVE-2026-33671
+
 # tar 6.2.1 (not used by our project directly)
 CVE-2026-23745
 CVE-2026-23950

--- a/package.json
+++ b/package.json
@@ -133,8 +133,7 @@
   "overrides": {
     "drizzle-kit": {
       "@esbuild-kit/esm-loader": "npm:tsx@^4.20.4"
-    },
-    "picomatch": "^4.0.4"
+    }
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- Adds `CVE-2026-33671` (picomatch ReDoS) to `.trivyignore` — this CVE is in the **Node.js base image's bundled npm** (`usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch@4.0.3`), not in our application dependencies
- Reverts the npm override from #356 since it can't fix base image packages
- Our lockfile already has `picomatch@4.0.4`

This has been blocking Trivy → deploy-staging for the last 3 merges.

## Test plan
- [ ] Trivy container scan passes in CI
- [ ] Deploy to staging succeeds
- [ ] All accumulated changes (lucide-react, color scheme, this fix) reach staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)