### PR TITLE
fix: ensure "release: next" labels are removed after release (closes #361)

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -114,6 +114,7 @@ jobs:
           echo "Production deploy triggered for $TAG"
 
       - name: 'Remove "release: next" labels'
+        if: always() && steps.meta.outputs.issue_numbers != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBERS: ${{ steps.meta.outputs.issue_numbers }}


### PR DESCRIPTION
## Summary
- The "Remove release: next labels" step in `release-finalize.yml` was skipped whenever the preceding "Trigger production deploy" step failed, because it had no `if:` condition (defaults to `if: success()`)
- Added `if: always() && steps.meta.outputs.issue_numbers != ''` so label cleanup runs regardless of deploy trigger outcome
- Manually cleaned up 30 stale `release: next` labels from closed issues spanning v3.0.0–v3.4.0

Closes #361

## Test plan
- [ ] Verify next release correctly removes `release: next` labels from included issues
- [ ] Verify the step is skipped gracefully when there are no issue numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)