### PR TITLE
feat: add robots.txt for SEO crawler control (closes #364)

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /auth
+Disallow: /dashboard
+Disallow: /curator
+
+Sitemap: https://vernis9.art/sitemap.xml


### PR DESCRIPTION
## Summary
- Added `client/public/robots.txt` to control search engine crawling
- Disallows private routes: `/admin`, `/auth`, `/dashboard`, `/curator`
- Declares sitemap URL: `https://vernis9.art/sitemap.xml`
- Vite copies `public/` to build output — no server changes needed

Closes #364
Parent epic: #363

## Test plan
- [ ] `GET /robots.txt` returns valid content
- [ ] File present in `dist/public/` after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)