### PR TITLE
feat: add dynamic sitemap.xml endpoint for SEO (closes #365)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { serveStatic } from "./static";
 import { createServer } from "http";
 import { registerMcpRoutes } from "./mcp";
 import healthRouter from "./routes/health";
+import sitemapRouter from "./routes/sitemap";
 import { logger } from "./logger";
 
 const app = express();
@@ -40,8 +41,9 @@ app.use(
 
 app.use(express.urlencoded({ extended: false }));
 
-// Health check endpoint (registered before auth/session middleware)
+// Health check and sitemap (registered before auth/session middleware and Vite)
 app.use("/", healthRouter);
+app.use("/", sitemapRouter);
 
 // Structured request logging via pino-http
 app.use(

--- a/server/routes/sitemap.ts
+++ b/server/routes/sitemap.ts
@@ -1,0 +1,65 @@
+import { Router } from "express";
+import { storage } from "../storage";
+import { logger } from "../logger";
+
+const router = Router();
+const SITE_URL = process.env.SITE_URL || "https://vernis9.art";
+let sitemapCache: { xml: string; expires: number } | null = null;
+
+router.get("/sitemap.xml", async (_req, res) => {
+  const now = Date.now();
+  if (sitemapCache && now < sitemapCache.expires) {
+    res.set("Content-Type", "application/xml");
+    return res.send(sitemapCache.xml);
+  }
+
+  try {
+    const [artists, blogPosts] = await Promise.all([
+      storage.getArtists(),
+      storage.getAllBlogPosts(),
+    ]);
+
+    const staticRoutes = [
+      { path: "/", changefreq: "weekly", priority: "1.0" },
+      { path: "/gallery", changefreq: "weekly", priority: "0.9" },
+      { path: "/exhibitions", changefreq: "weekly", priority: "0.8" },
+      { path: "/store", changefreq: "weekly", priority: "0.8" },
+      { path: "/auctions", changefreq: "daily", priority: "0.8" },
+      { path: "/artists", changefreq: "weekly", priority: "0.8" },
+      { path: "/blog", changefreq: "weekly", priority: "0.7" },
+      { path: "/privacy", changefreq: "yearly", priority: "0.3" },
+      { path: "/terms", changefreq: "yearly", priority: "0.3" },
+      { path: "/changelog", changefreq: "monthly", priority: "0.3" },
+    ];
+
+    const urls = staticRoutes.map(
+      (r) =>
+        `  <url>\n    <loc>${SITE_URL}${r.path}</loc>\n    <changefreq>${r.changefreq}</changefreq>\n    <priority>${r.priority}</priority>\n  </url>`
+    );
+
+    for (const artist of artists) {
+      urls.push(
+        `  <url>\n    <loc>${SITE_URL}/artists/${artist.id}</loc>\n    <changefreq>monthly</changefreq>\n    <priority>0.7</priority>\n  </url>`
+      );
+    }
+
+    const publishedPosts = blogPosts.filter((p) => p.isPublished);
+    for (const post of publishedPosts) {
+      const lastmod = post.updatedAt.toISOString().split("T")[0];
+      urls.push(
+        `  <url>\n    <loc>${SITE_URL}/blog/${post.id}</loc>\n    <lastmod>${lastmod}</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.6</priority>\n  </url>`
+      );
+    }
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join("\n")}\n</urlset>`;
+
+    sitemapCache = { xml, expires: now + 60 * 60 * 1000 };
+    res.set("Content-Type", "application/xml");
+    res.send(xml);
+  } catch (error) {
+    logger.error({ error }, "Failed to generate sitemap");
+    res.status(500).send("Failed to generate sitemap");
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Added `server/routes/sitemap.ts` — dynamic sitemap endpoint querying all artists and published blog posts
- Generates valid XML per the [Sitemaps protocol](https://www.sitemaps.org/protocol.html)
- 10 static public routes + all artist profiles + all published blog posts with `lastmod`
- Response cached in memory for 1 hour
- Registered in `server/index.ts` before Vite middleware (so it works in dev mode too)

Closes #365
Parent epic: #363

## Test plan
- [ ] `GET /sitemap.xml` returns valid XML with `Content-Type: application/xml`
- [ ] Static routes listed (/, /gallery, /store, /artists, /blog, etc.)
- [ ] All artists listed with IDs
- [ ] Published blog posts listed with `lastmod` dates
- [ ] Second request within 1 hour is served from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)