### PR TITLE
feat: JSON-LD structured data for SEO rich snippets

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,6 +16,7 @@
     <meta name="twitter:title" content="__META_OG_TITLE__" />
     <meta name="twitter:description" content="__META_OG_DESCRIPTION__" />
     <meta name="twitter:image" content="__META_OG_IMAGE__" />
+    __JSON_LD__
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/server/meta.ts
+++ b/server/meta.ts
@@ -14,6 +14,7 @@ interface MetaTags {
   ogType: string;
   ogUrl: string;
   ogImage: string;
+  jsonLd: Record<string, unknown>[];
 }
 
 const STATIC_ROUTES: Record<string, Pick<MetaTags, "title" | "ogType">> = {
@@ -29,6 +30,43 @@ const STATIC_ROUTES: Record<string, Pick<MetaTags, "title" | "ogType">> = {
   "/terms": { title: "Terms of Service \u2014 Vernis9", ogType: "website" },
 };
 
+const STATIC_ROUTE_NAMES: Record<string, string> = {
+  "/": "Home",
+  "/gallery": "3D Virtual Gallery",
+  "/exhibitions": "Exhibitions",
+  "/store": "Art Store",
+  "/auctions": "Auctions",
+  "/artists": "Artists",
+  "/blog": "Blog",
+  "/changelog": "Changelog",
+  "/privacy": "Privacy Policy",
+  "/terms": "Terms of Service",
+};
+
+function breadcrumb(...items: { name: string; url?: string }[]): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      ...(item.url ? { item: item.url } : {}),
+    })),
+  };
+}
+
+function organizationLd(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Vernis9",
+    url: SITE_URL,
+    logo: `${SITE_URL}/favicon.svg`,
+    description: "Virtual art gallery and marketplace",
+  };
+}
+
 /** Strip query string and hash, normalize trailing slash */
 function normalizePath(url: string): string {
   const path = url.split("?")[0].split("#")[0];
@@ -41,6 +79,17 @@ async function resolveMetaTags(url: string): Promise<MetaTags> {
   // Static routes
   const staticRoute = STATIC_ROUTES[path];
   if (staticRoute) {
+    const jsonLd: Record<string, unknown>[] = [];
+    if (path === "/") {
+      jsonLd.push(organizationLd());
+      jsonLd.push(breadcrumb({ name: "Home", url: SITE_URL }));
+    } else {
+      const name = STATIC_ROUTE_NAMES[path] || staticRoute.title;
+      jsonLd.push(breadcrumb(
+        { name: "Home", url: SITE_URL },
+        { name },
+      ));
+    }
     return {
       title: staticRoute.title,
       description: DEFAULT_DESCRIPTION,
@@ -49,6 +98,7 @@ async function resolveMetaTags(url: string): Promise<MetaTags> {
       ogType: staticRoute.ogType,
       ogUrl: `${SITE_URL}${path === "/" ? "" : path}`,
       ogImage: DEFAULT_OG_IMAGE,
+      jsonLd,
     };
   }
 
@@ -64,14 +114,33 @@ async function resolveMetaTags(url: string): Promise<MetaTags> {
         const image = artist.avatarUrl
           ? toAbsoluteUrl(artist.avatarUrl)
           : DEFAULT_OG_IMAGE;
+        const artistUrl = `${SITE_URL}/artists/${artist.id}`;
+        const personLd: Record<string, unknown> = {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          name: artist.name,
+          url: artistUrl,
+          description: artist.bio || undefined,
+          jobTitle: "Artist",
+          ...(artist.avatarUrl ? { image: toAbsoluteUrl(artist.avatarUrl) } : {}),
+          ...(artist.specialization ? { knowsAbout: artist.specialization } : {}),
+        };
         return {
           title: `${artist.name} \u2014 Vernis9`,
           description,
           ogTitle: `${artist.name} \u2014 Vernis9`,
           ogDescription: description,
           ogType: "profile",
-          ogUrl: `${SITE_URL}/artists/${artist.id}`,
+          ogUrl: artistUrl,
           ogImage: image,
+          jsonLd: [
+            personLd,
+            breadcrumb(
+              { name: "Home", url: SITE_URL },
+              { name: "Artists", url: `${SITE_URL}/artists` },
+              { name: artist.name },
+            ),
+          ],
         };
       }
     } catch {
@@ -91,14 +160,43 @@ async function resolveMetaTags(url: string): Promise<MetaTags> {
         const image = post.coverImageUrl
           ? toAbsoluteUrl(post.coverImageUrl)
           : DEFAULT_OG_IMAGE;
+        const postUrl = `${SITE_URL}/blog/${post.id}`;
+        const blogPostingLd: Record<string, unknown> = {
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          headline: post.title,
+          description,
+          url: postUrl,
+          datePublished: post.createdAt,
+          dateModified: post.updatedAt,
+          author: {
+            "@type": "Person",
+            name: post.artist.name,
+            ...(post.artist.avatarUrl ? { image: toAbsoluteUrl(post.artist.avatarUrl) } : {}),
+          },
+          publisher: {
+            "@type": "Organization",
+            name: "Vernis9",
+            logo: { "@type": "ImageObject", url: `${SITE_URL}/favicon.svg` },
+          },
+          ...(post.coverImageUrl ? { image: toAbsoluteUrl(post.coverImageUrl) } : {}),
+        };
         return {
           title: `${post.title} \u2014 Vernis9 Blog`,
           description,
           ogTitle: `${post.title} \u2014 Vernis9 Blog`,
           ogDescription: description,
           ogType: "article",
-          ogUrl: `${SITE_URL}/blog/${post.id}`,
+          ogUrl: postUrl,
           ogImage: image,
+          jsonLd: [
+            blogPostingLd,
+            breadcrumb(
+              { name: "Home", url: SITE_URL },
+              { name: "Blog", url: `${SITE_URL}/blog` },
+              { name: post.title },
+            ),
+          ],
         };
       }
     } catch {
@@ -115,10 +213,15 @@ async function resolveMetaTags(url: string): Promise<MetaTags> {
     ogType: "website",
     ogUrl: `${SITE_URL}${path}`,
     ogImage: DEFAULT_OG_IMAGE,
+    jsonLd: [breadcrumb({ name: "Home", url: SITE_URL })],
   };
 }
 
 export function injectMetaTags(html: string, meta: MetaTags): string {
+  const jsonLdScripts = meta.jsonLd
+    .map((ld) => `<script type="application/ld+json">${JSON.stringify(ld)}</script>`)
+    .join("\n    ");
+
   return html
     .replace(/__META_TITLE__/g, escapeHtml(meta.title))
     .replace(/__META_DESCRIPTION__/g, escapeHtml(meta.description))
@@ -127,7 +230,8 @@ export function injectMetaTags(html: string, meta: MetaTags): string {
     .replace(/__META_OG_DESCRIPTION__/g, escapeHtml(meta.ogDescription))
     .replace(/__META_OG_TYPE__/g, escapeHtml(meta.ogType))
     .replace(/__META_OG_URL__/g, escapeHtml(meta.ogUrl))
-    .replace(/__META_OG_IMAGE__/g, escapeHtml(meta.ogImage));
+    .replace(/__META_OG_IMAGE__/g, escapeHtml(meta.ogImage))
+    .replace(/__JSON_LD__/g, jsonLdScripts);
 }
 
 function toAbsoluteUrl(url: string): string {

--- a/specs/features/seo/CHANGELOG.md
+++ b/specs/features/seo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # SEO Feature Changelog
 
+## 2026-04-01 — Structured Data / JSON-LD (#367)
+- Extended `server/meta.ts` to generate JSON-LD structured data per route
+- Homepage: Organization schema (name, url, logo, description)
+- Artist pages: Person schema (name, image, description, jobTitle, knowsAbout)
+- Blog posts: BlogPosting schema (headline, image, datePublished, author, publisher)
+- All pages: BreadcrumbList schema for navigation path
+- Added `__JSON_LD__` placeholder to `client/index.html`
+- JSON-LD injected server-side in raw HTML (not by JavaScript)
+
 ## 2026-04-01 — Server-Side Meta Tags + react-helmet-async (#366)
 - Added placeholder tokens to `client/index.html` for server-side meta injection
 - Created `server/meta.ts` — route-specific meta tag resolution (static routes + dynamic `/artists/:id`, `/blog/:id`)

--- a/specs/features/seo/SPEC.md
+++ b/specs/features/seo/SPEC.md
@@ -15,7 +15,7 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
 | `robots.txt` | Done | #364 — static file at `/robots.txt` |
 | `sitemap.xml` | Done | #365 — dynamic endpoint at `/sitemap.xml` |
 | Per-page meta tags | Done | #366 — server-side injection + react-helmet-async |
-| Structured data (JSON-LD) | Missing | No rich snippets in search results |
+| Structured data (JSON-LD) | Done | #367 — Organization, Person, BlogPosting, BreadcrumbList |
 | Twitter cards | Done | #366 — `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` |
 | Canonical URLs | Done | #366 — `<link rel="canonical">` on every page |
 | Image lazy loading | Missing | Page speed penalty |


### PR DESCRIPTION
## Summary
- Extends `server/meta.ts` to generate JSON-LD structured data per route
- **Homepage**: Organization schema (name, url, logo, description)
- **Artist pages**: Person schema (name, image, description, jobTitle, knowsAbout)
- **Blog posts**: BlogPosting schema (headline, dates, author, publisher, cover image)
- **All pages**: BreadcrumbList schema for navigation path
- JSON-LD injected server-side in raw HTML (not by JavaScript), so crawlers can read it

Closes #367

## Test plan
- [ ] `curl /` has Organization + BreadcrumbList JSON-LD
- [ ] `curl /artists/:id` has Person + BreadcrumbList JSON-LD
- [ ] `curl /blog/:id` has BlogPosting + BreadcrumbList JSON-LD
- [ ] Static pages have BreadcrumbList JSON-LD
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results) on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)