### PR TITLE
fix: prevent express.static from serving raw index.html

### DIFF
--- a/server/static.ts
+++ b/server/static.ts
@@ -17,7 +17,9 @@ export function serveStatic(app: Express) {
     "utf-8",
   );
 
-  app.use(express.static(distPath));
+  // Disable automatic index.html serving so all HTML requests go through the
+  // catch-all below, which injects meta tags and JSON-LD before serving.
+  app.use(express.static(distPath, { index: false }));
 
   // SPA catch-all with meta tag injection
   app.use("/{*path}", async (req, res) => {


### PR DESCRIPTION
## Summary
- `express.static` was serving `index.html` directly for `/` requests, bypassing the catch-all that injects meta tags and JSON-LD
- This caused the `__JSON_LD__` placeholder to render as visible text on every page
- Fix: set `index: false` on `express.static` so all HTML requests go through the meta injection catch-all

Refs #367

## Test plan
- [ ] No `__JSON_LD__` text visible on any page
- [ ] Homepage has correct `<title>`, OG tags, and JSON-LD in page source
- [ ] Static assets (JS, CSS, images) still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)