### PR TITLE
feat: block search engine indexing on non-production environments

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>__META_TITLE__</title>
     <meta name="description" content="__META_DESCRIPTION__" />
+    __META_ROBOTS__
     <link rel="canonical" href="__META_CANONICAL__" />
     <meta property="og:title" content="__META_OG_TITLE__" />
     <meta property="og:description" content="__META_OG_DESCRIPTION__" />

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,8 +1,0 @@
-User-agent: *
-Allow: /
-Disallow: /admin
-Disallow: /auth
-Disallow: /dashboard
-Disallow: /curator
-
-Sitemap: https://vernis9.art/sitemap.xml

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { serveStatic } from "./static";
 import { createServer } from "http";
 import { registerMcpRoutes } from "./mcp";
 import healthRouter from "./routes/health";
+import robotsRouter from "./routes/robots";
 import sitemapRouter from "./routes/sitemap";
 import { logger } from "./logger";
 
@@ -41,9 +42,19 @@ app.use(
 
 app.use(express.urlencoded({ extended: false }));
 
-// Health check and sitemap (registered before auth/session middleware and Vite)
+// Health check, robots.txt, and sitemap (registered before auth/session middleware and Vite)
 app.use("/", healthRouter);
+app.use("/", robotsRouter);
 app.use("/", sitemapRouter);
+
+// Block search engine indexing on non-production environments
+const SITE_URL = process.env.SITE_URL || "https://vernis9.art";
+if (SITE_URL !== "https://vernis9.art") {
+  app.use((_req, res, next) => {
+    res.set("X-Robots-Tag", "noindex, nofollow");
+    next();
+  });
+}
 
 // Structured request logging via pino-http
 app.use(

--- a/server/meta.ts
+++ b/server/meta.ts
@@ -1,6 +1,8 @@
 import { storage } from "./storage";
 
 const SITE_URL = process.env.SITE_URL || "https://vernis9.art";
+const PRODUCTION_URL = "https://vernis9.art";
+const isProduction = SITE_URL === PRODUCTION_URL;
 const DEFAULT_TITLE = "Vernis9 \u2014 Virtual Art Gallery & Marketplace";
 const DEFAULT_DESCRIPTION =
   "Experience art like never before. Explore our immersive 3D virtual gallery, discover stunning artworks from talented artists, and participate in exclusive auctions.";
@@ -231,6 +233,7 @@ export function injectMetaTags(html: string, meta: MetaTags): string {
     .replace(/__META_OG_TYPE__/g, escapeHtml(meta.ogType))
     .replace(/__META_OG_URL__/g, escapeHtml(meta.ogUrl))
     .replace(/__META_OG_IMAGE__/g, escapeHtml(meta.ogImage))
+    .replace(/__META_ROBOTS__/g, isProduction ? "" : '<meta name="robots" content="noindex, nofollow" />')
     .replace(/__JSON_LD__/g, jsonLdScripts);
 }
 

--- a/server/routes/robots.ts
+++ b/server/routes/robots.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+
+const router = Router();
+const SITE_URL = process.env.SITE_URL || "https://vernis9.art";
+const PRODUCTION_URL = "https://vernis9.art";
+const isProduction = SITE_URL === PRODUCTION_URL;
+
+const productionRobots = `User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /auth
+Disallow: /dashboard
+Disallow: /curator
+
+Sitemap: ${PRODUCTION_URL}/sitemap.xml
+`;
+
+const nonProductionRobots = `User-agent: *
+Disallow: /
+`;
+
+router.get("/robots.txt", (_req, res) => {
+  res.set("Content-Type", "text/plain");
+  res.send(isProduction ? productionRobots : nonProductionRobots);
+});
+
+export default router;

--- a/specs/features/seo/CHANGELOG.md
+++ b/specs/features/seo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # SEO Feature Changelog
 
+## 2026-04-01 — Block Crawlers on Non-Production (#376)
+- Converted static `robots.txt` to dynamic Express route (`server/routes/robots.ts`)
+- Production: permissive robots.txt (Allow /, Disallow private routes, Sitemap link)
+- Non-production: restrictive robots.txt (Disallow /)
+- Added `<meta name="robots" content="noindex, nofollow">` on non-production via meta injection
+- Added `X-Robots-Tag: noindex, nofollow` HTTP header on non-production
+- Three layers of protection keyed off `SITE_URL` env var
+
 ## 2026-04-01 — Structured Data / JSON-LD (#367)
 - Extended `server/meta.ts` to generate JSON-LD structured data per route
 - Homepage: Organization schema (name, url, logo, description)

--- a/specs/features/seo/SPEC.md
+++ b/specs/features/seo/SPEC.md
@@ -34,24 +34,16 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
 **Effort:** Small
 
 **Implementation:**
-- Create `client/public/robots.txt` (Vite copies `public/` contents to build output as-is)
-- Content:
-  ```
-  User-agent: *
-  Allow: /
-  Disallow: /admin
-  Disallow: /auth
-  Disallow: /dashboard
-  Disallow: /curator
-  Disallow: /auth/set-password
-
-  Sitemap: https://vernis9.art/sitemap.xml
-  ```
+- Dynamic Express route at `server/routes/robots.ts` (replaces static file)
+- Production (`SITE_URL=https://vernis9.art`): permissive robots.txt with `Allow: /`
+- Non-production (staging, preview): restrictive `Disallow: /` to block all crawlers
+- Non-production also gets `<meta name="robots" content="noindex, nofollow">` and `X-Robots-Tag` HTTP header
 
 **Acceptance criteria:**
-- [ ] `GET https://vernis9.art/robots.txt` returns valid robots.txt
-- [ ] Private routes are disallowed
-- [ ] Sitemap URL is declared
+- [x] `GET https://vernis9.art/robots.txt` returns valid robots.txt
+- [x] Private routes are disallowed
+- [x] Sitemap URL is declared
+- [x] Non-production environments block all crawlers (robots.txt, meta tag, HTTP header)
 
 ---
 


### PR DESCRIPTION
## Summary
- Converts static `robots.txt` to dynamic Express route — serves `Disallow: /` on staging/preview
- Adds `<meta name="robots" content="noindex, nofollow">` on non-production via meta injection
- Adds `X-Robots-Tag: noindex, nofollow` HTTP header on non-production
- All three layers keyed off `SITE_URL` env var — production (`vernis9.art`) is unaffected

Closes #376

## Test plan
- [ ] `curl https://staging.vernis9.art/robots.txt` returns `Disallow: /`
- [ ] `curl https://staging.vernis9.art/` contains `<meta name="robots" content="noindex, nofollow">`
- [ ] `curl -I https://staging.vernis9.art/` has `X-Robots-Tag: noindex, nofollow` header
- [ ] `curl https://vernis9.art/robots.txt` still returns permissive robots.txt (after production deploy)
- [ ] Production has no noindex tag or header

🤖 Generated with [Claude Code](https://claude.com/claude-code)