### PR TITLE
fix: add SITE_URL to all docker-compose deploy files

### DIFF
--- a/deploy/preview/docker-compose.yml
+++ b/deploy/preview/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      SITE_URL: https://preview.vernis9.art
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-}
     ports:

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      SITE_URL: https://vernis9.art
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-}
     ports:

--- a/deploy/staging/docker-compose.yml
+++ b/deploy/staging/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-https://accounts.google.com}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      SITE_URL: https://staging.vernis9.art
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-}
     ports:


### PR DESCRIPTION
## Summary
- `SITE_URL` was missing from all three docker-compose files (staging, production, preview)
- Without it, the code defaults to `https://vernis9.art`, meaning staging/preview would NOT block crawlers
- Now explicitly set per environment:
  - Staging: `https://staging.vernis9.art`
  - Preview: `https://preview.vernis9.art`
  - Production: `https://vernis9.art`

Refs #376

## Test plan
- [ ] After staging redeploy: `curl https://staging.vernis9.art/robots.txt` returns `Disallow: /`
- [ ] After staging redeploy: `curl -sI https://staging.vernis9.art/ | grep X-Robots-Tag` returns `noindex, nofollow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)