### PR TITLE
fix: allow Google Rich Results Test on non-production environments

### DIFF
--- a/server/routes/robots.ts
+++ b/server/routes/robots.ts
@@ -15,8 +15,15 @@ Disallow: /curator
 Sitemap: ${PRODUCTION_URL}/sitemap.xml
 `;
 
+// Allow fetching (so Google Rich Results Test works) but omit Sitemap
+// so crawlers aren't guided to discover content. The noindex meta tag
+// and X-Robots-Tag header prevent actual indexing.
 const nonProductionRobots = `User-agent: *
-Disallow: /
+Allow: /
+Disallow: /admin
+Disallow: /auth
+Disallow: /dashboard
+Disallow: /curator
 `;
 
 router.get("/robots.txt", (_req, res) => {


### PR DESCRIPTION
## Summary
- Non-production robots.txt was `Disallow: /`, which also blocked Google's Rich Results Test from fetching pages for validation
- Changed to permissive rules (same as production) but without the Sitemap directive
- Indexing prevention still enforced by `<meta name="robots" content="noindex, nofollow">` and `X-Robots-Tag` header — these don't block fetching, only indexing

Refs #376

## Test plan
- [ ] `curl https://staging.vernis9.art/robots.txt` shows `Allow: /` (no `Disallow: /`)
- [ ] `curl -sI https://staging.vernis9.art/` still has `X-Robots-Tag: noindex, nofollow`
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) can fetch and validate staging URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)