### PR TITLE
docs: catch up SEO documentation for #366-#379

### DIFF
--- a/specs/features/seo/CHANGELOG.md
+++ b/specs/features/seo/CHANGELOG.md
@@ -1,12 +1,25 @@
 # SEO Feature Changelog
 
-## 2026-04-01 — Block Crawlers on Non-Production (#376)
+## 2026-04-01 — Allow Rich Results Test on staging (#379)
+- Changed non-production robots.txt from `Disallow: /` to permissive rules (same as production but without Sitemap)
+- `Disallow: /` was blocking Google Rich Results Test from fetching pages
+- Indexing prevention still enforced by `noindex` meta tag + `X-Robots-Tag` header (don't block fetching, only indexing)
+
+## 2026-04-01 — Add SITE_URL to docker-compose files (#378)
+- `SITE_URL` was missing from all three docker-compose deploy files
+- Without it, code defaulted to `https://vernis9.art` and staging/preview would not block crawlers
+- Added: staging=`https://staging.vernis9.art`, preview=`https://preview.vernis9.art`, production=`https://vernis9.art`
+
+## 2026-04-01 — Block Crawlers on Non-Production (#376, #377)
 - Converted static `robots.txt` to dynamic Express route (`server/routes/robots.ts`)
 - Production: permissive robots.txt (Allow /, Disallow private routes, Sitemap link)
-- Non-production: restrictive robots.txt (Disallow /)
-- Added `<meta name="robots" content="noindex, nofollow">` on non-production via meta injection
-- Added `X-Robots-Tag: noindex, nofollow` HTTP header on non-production
-- Three layers of protection keyed off `SITE_URL` env var
+- Non-production: `<meta name="robots" content="noindex, nofollow">` + `X-Robots-Tag` HTTP header
+- All keyed off `SITE_URL` env var at runtime (same Docker image, different behavior)
+
+## 2026-04-01 — Fix express.static serving raw index.html (#375)
+- `express.static` was serving `index.html` directly for `/` requests, bypassing meta injection
+- This caused `__JSON_LD__` placeholder to render as visible text
+- Fix: set `index: false` on `express.static` so all HTML requests go through the catch-all
 
 ## 2026-04-01 — Structured Data / JSON-LD (#367)
 - Extended `server/meta.ts` to generate JSON-LD structured data per route

--- a/specs/features/seo/SPEC.md
+++ b/specs/features/seo/SPEC.md
@@ -12,7 +12,7 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
 
 | Area | Status | Notes |
 |------|--------|-------|
-| `robots.txt` | Done | #364 — static file at `/robots.txt` |
+| `robots.txt` | Done | #364, #376 — dynamic route at `/robots.txt` (blocks indexing on non-production) |
 | `sitemap.xml` | Done | #365 — dynamic endpoint at `/sitemap.xml` |
 | Per-page meta tags | Done | #366 — server-side injection + react-helmet-async |
 | Structured data (JSON-LD) | Done | #367 — Organization, Person, BlogPosting, BreadcrumbList |

--- a/specs/workflows/DEPLOYMENT.md
+++ b/specs/workflows/DEPLOYMENT.md
@@ -146,6 +146,23 @@ ssh -i ~/.ssh/artverse-deploy root@artverse.idata.ro          # Root (for Nginx,
 | 5004 | Preview app |
 | 5436 | Preview PostgreSQL |
 
+### Runtime environment variables (docker-compose)
+
+All environments share the same Docker image. Behavior differences are controlled by environment variables set in each docker-compose file:
+
+| Variable | Staging | Preview | Production | Purpose |
+|----------|---------|---------|------------|---------|
+| `SITE_URL` | `https://staging.vernis9.art` | `https://preview.vernis9.art` | `https://vernis9.art` | Canonical URLs, OG tags, sitemap links, crawler blocking |
+| `DB_MIGRATION_MODE` | _(unset — uses push)_ | _(unset — uses push)_ | `migrate` | Schema migration strategy |
+| `NODE_ENV` | `production` | `production` | `production` | All deployed environments run in production mode |
+
+**SEO crawler blocking:** When `SITE_URL` is not `https://vernis9.art`, the app automatically:
+- Adds `<meta name="robots" content="noindex, nofollow">` to all pages
+- Adds `X-Robots-Tag: noindex, nofollow` HTTP header to all responses
+- Omits the Sitemap directive from `robots.txt`
+
+This ensures only production is indexed by search engines. Google Rich Results Test can still fetch staging pages for validation (the noindex signals prevent indexing but don't block fetching).
+
 ---
 
 ## 5. Docker Image Layout


### PR DESCRIPTION
## Summary
- **SEO CHANGELOG**: added missing entries for #375 (express.static fix), #378 (SITE_URL in compose), #379 (allow Rich Results Test)
- **SEO SPEC**: updated robots.txt audit note — now a dynamic route, not a static file
- **DEPLOYMENT.md**: added "Runtime environment variables" section documenting `SITE_URL` per environment and crawler blocking behavior

## Test plan
- [ ] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)