### PR TITLE
feat: add lazy loading to all below-the-fold images

### DIFF
--- a/client/src/components/artwork-card.tsx
+++ b/client/src/components/artwork-card.tsx
@@ -40,6 +40,7 @@ export function ArtworkCard({ artwork, onViewDetails, showAddToCart = true }: Ar
         <img
           src={artwork.imageUrl}
           alt={artwork.title}
+          loading="lazy"
           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
         />
         <div className="absolute inset-0 bg-linear-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/client/src/components/artwork-detail-dialog.tsx
+++ b/client/src/components/artwork-detail-dialog.tsx
@@ -51,6 +51,7 @@ export function ArtworkDetailDialog({
             <img
               src={artwork.imageUrl}
               alt={artwork.title}
+              loading="lazy"
               className="w-full h-auto object-contain max-h-[60vh]"
             />
             {!artwork.isForSale && (

--- a/client/src/components/cart-sheet.tsx
+++ b/client/src/components/cart-sheet.tsx
@@ -71,6 +71,7 @@ export function CartSheet() {
                         <img
                           src={item.artwork.imageUrl}
                           alt={item.artwork.title}
+                          loading="lazy"
                           className="w-full h-full object-cover"
                         />
                       </div>

--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -1533,7 +1533,7 @@ export function HallwayGallery3D({ artistRooms, curatorRooms, museumTemplate, is
       {selectedArtwork && (
         <div className="absolute inset-0 flex bg-black/80 backdrop-blur-sm" style={{ zIndex: 50 }} data-testid="artwork-detail-panel">
           <div className="flex-1 relative min-w-0">
-            <img src={selectedArtwork.imageUrl} alt={selectedArtwork.title} className="w-full h-full object-contain bg-black/40" />
+            <img src={selectedArtwork.imageUrl} alt={selectedArtwork.title} loading="lazy" className="w-full h-full object-contain bg-black/40" />
           </div>
           <div className="w-64 flex flex-col bg-card p-4 gap-3 relative">
             <Button size="icon" variant="ghost" className="absolute top-2 right-2" onClick={() => { setSelectedArtwork(null); requestPointerLock(); }} data-testid="button-close-artwork">

--- a/client/src/components/maze-gallery-3d.tsx
+++ b/client/src/components/maze-gallery-3d.tsx
@@ -1859,6 +1859,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
             <img
               src={selectedArtwork.imageUrl}
               alt={selectedArtwork.title}
+              loading="lazy"
               className="w-full h-full object-contain bg-black/40"
             />
           </div>
@@ -2001,6 +2002,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
                           <img
                             src={artwork.imageUrl}
                             alt={artwork.title}
+                            loading="lazy"
                             className="w-full h-full object-cover transition-transform duration-300 group-hover/artwork:scale-110"
                           />
                         </div>

--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -83,6 +83,7 @@ function FileUploadField({
         <img
           src={imageUrl}
           alt={previewAlt}
+          loading="lazy"
           className="mt-2 rounded-md max-h-40 object-contain border"
         />
       )}
@@ -699,9 +700,10 @@ export default function ArtistDashboard() {
               {artworks.map((artwork) => (
                 <Card key={artwork.id} className="overflow-hidden" data-testid={`card-artwork-${artwork.id}`}>
                   <div className="aspect-4/3 relative">
-                    <img 
-                      src={artwork.imageUrl} 
+                    <img
+                      src={artwork.imageUrl}
                       alt={artwork.title}
+                      loading="lazy"
                       className="w-full h-full object-cover"
                     />
                     <div className="absolute top-2 right-2 flex flex-col gap-1 items-end">
@@ -886,9 +888,10 @@ export default function ArtistDashboard() {
                       </CardDescription>
                     </div>
                     {post.coverImageUrl && (
-                      <img 
-                        src={post.coverImageUrl} 
+                      <img
+                        src={post.coverImageUrl}
                         alt={post.title}
+                        loading="lazy"
                         className="w-24 h-16 object-cover rounded-md"
                       />
                     )}
@@ -998,6 +1001,7 @@ export default function ArtistDashboard() {
                           <img
                             src={order.artwork.imageUrl}
                             alt={order.artwork.title}
+                            loading="lazy"
                             className="w-full h-full object-cover"
                           />
                         </div>

--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -270,9 +270,10 @@ export default function ArtistProfile() {
                       data-testid={`card-profile-artwork-${artwork.id}`}
                     >
                       <div className="aspect-4/3 relative overflow-visible">
-                        <img 
-                          src={artwork.imageUrl} 
+                        <img
+                          src={artwork.imageUrl}
                           alt={artwork.title}
+                          loading="lazy"
                           className="w-full h-full object-cover"
                         />
                         <div className="absolute top-2 right-2 flex flex-col gap-1 items-end">
@@ -350,9 +351,10 @@ export default function ArtistProfile() {
                   >
                     {post.coverImageUrl && (
                       <div className="aspect-3/1 overflow-hidden">
-                        <img 
-                          src={post.coverImageUrl} 
+                        <img
+                          src={post.coverImageUrl}
                           alt={post.title}
+                          loading="lazy"
                           className="w-full h-full object-cover"
                         />
                       </div>

--- a/client/src/pages/artists.tsx
+++ b/client/src/pages/artists.tsx
@@ -221,6 +221,7 @@ export default function Artists() {
                             <img
                               src={artwork.imageUrl}
                               alt={artwork.title}
+                              loading="lazy"
                               className="w-full h-full object-cover transition-transform duration-300 group-hover/artwork:scale-110"
                             />
                           </div>

--- a/client/src/pages/auctions.tsx
+++ b/client/src/pages/auctions.tsx
@@ -76,6 +76,7 @@ function AuctionCard({
         <img
           src={auction.artwork.imageUrl}
           alt={auction.artwork.title}
+          loading="lazy"
           className="w-full h-full object-cover"
         />
         <Badge
@@ -374,6 +375,7 @@ export default function Auctions() {
                     <img
                       src={selectedAuction.artwork.imageUrl}
                       alt={selectedAuction.artwork.title}
+                      loading="lazy"
                       className="w-full h-full object-cover"
                     />
                   </div>

--- a/client/src/pages/blog-post.tsx
+++ b/client/src/pages/blog-post.tsx
@@ -54,6 +54,7 @@ export default function BlogPost({ params }: { params: { id: string } }) {
           <img
             src={post.coverImageUrl}
             alt={post.title}
+            loading="lazy"
             className="w-full h-full object-cover"
           />
         </div>

--- a/client/src/pages/blog.tsx
+++ b/client/src/pages/blog.tsx
@@ -56,6 +56,7 @@ export default function Blog() {
                     <img
                       src={posts[0].coverImageUrl}
                       alt={posts[0].title}
+                      loading="lazy"
                       className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
                     />
                   </div>
@@ -107,6 +108,7 @@ export default function Blog() {
                       <img
                         src={post.coverImageUrl}
                         alt={post.title}
+                        loading="lazy"
                         className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                       />
                     </div>

--- a/client/src/pages/curator-dashboard.tsx
+++ b/client/src/pages/curator-dashboard.tsx
@@ -480,6 +480,7 @@ function ArtworkPicker({ galleryId, selectedArtworks }: { galleryId: string; sel
               <img
                 src={artwork.imageUrl}
                 alt={artwork.title}
+                loading="lazy"
                 className="w-full aspect-square object-cover rounded-lg"
               />
               <div className="absolute bottom-0 inset-x-0 bg-black/60 text-white text-xs p-1.5 rounded-b-lg">
@@ -536,7 +537,7 @@ function ArtworkPicker({ galleryId, selectedArtworks }: { galleryId: string; sel
                   className={`relative cursor-pointer rounded-lg overflow-hidden border-2 transition-colors ${isSelected ? "border-primary" : "border-transparent hover:border-muted-foreground/30"}`}
                   onClick={() => toggleArtwork(artwork.id)}
                 >
-                  <img src={artwork.imageUrl} alt={artwork.title} className="w-full aspect-square object-cover" />
+                  <img src={artwork.imageUrl} alt={artwork.title} loading="lazy" className="w-full aspect-square object-cover" />
                   <div className="absolute bottom-0 inset-x-0 bg-black/60 text-white text-xs p-1.5">
                     <div className="truncate font-medium">{artwork.title}</div>
                     <div className="truncate text-white/70">{artwork.artist.name}</div>

--- a/client/src/pages/exhibitions.tsx
+++ b/client/src/pages/exhibitions.tsx
@@ -107,6 +107,7 @@ function HeroExhibition({ exhibition, formatDate }: {
           <img
             src={heroImage}
             alt={exhibition.name}
+            loading="lazy"
             className="w-full h-64 sm:h-80 object-cover transition-transform duration-700 group-hover:scale-105"
           />
         ) : (
@@ -151,7 +152,7 @@ function ExhibitionCard({ exhibition, status, formatDate, variant }: {
       {previewArtworks.length > 0 ? (
         <div className="flex h-48 overflow-hidden">
           {previewArtworks.map(aw => (
-            <img key={aw.id} src={aw.imageUrl} alt={aw.title} className="flex-1 object-cover min-w-0" />
+            <img key={aw.id} src={aw.imageUrl} alt={aw.title} loading="lazy" className="flex-1 object-cover min-w-0" />
           ))}
         </div>
       ) : (

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -260,6 +260,7 @@ export default function Gallery() {
               <img
                 src={currentArtwork.imageUrl}
                 alt={currentArtwork.title}
+                loading="lazy"
                 className="max-w-[70vw] sm:max-w-lg max-h-[50vh] sm:max-h-[60vh] object-contain shadow-2xl rounded-sm"
                 data-testid="img-current-artwork"
               />
@@ -314,7 +315,7 @@ export default function Gallery() {
                     }`}
                     data-testid={`button-thumbnail-${artwork.id}`}
                   >
-                    <img src={artwork.imageUrl} alt={artwork.title} className="w-full h-full object-cover" />
+                    <img src={artwork.imageUrl} alt={artwork.title} loading="lazy" className="w-full h-full object-cover" />
                   </button>
                 ))}
               </div>
@@ -332,7 +333,7 @@ export default function Gallery() {
               <ScrollArea className="flex-1">
                 <div className="p-4 space-y-6">
                   <div className="aspect-4/3 rounded-lg overflow-hidden">
-                    <img src={currentArtwork.imageUrl} alt={currentArtwork.title} className="w-full h-full object-cover" />
+                    <img src={currentArtwork.imageUrl} alt={currentArtwork.title} loading="lazy" className="w-full h-full object-cover" />
                   </div>
                   <div className="space-y-4">
                     <div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -228,6 +228,7 @@ function ArtistSpotlight({ artists }: { artists: Artist[] }) {
                     <img
                       src={artist.avatarUrl}
                       alt={artist.name}
+                      loading="lazy"
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                     />
                   ) : (
@@ -297,6 +298,7 @@ function BlogHighlights({ posts }: { posts: BlogPostWithArtist[] }) {
                     <img
                       src={post.coverImageUrl}
                       alt={post.title}
+                      loading="lazy"
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                     />
                   </div>
@@ -499,6 +501,7 @@ export default function Home() {
                           <img
                             src={heroImage}
                             alt={exhibition.name}
+                            loading="lazy"
                             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                           />
                         ) : (

--- a/client/src/pages/store.tsx
+++ b/client/src/pages/store.tsx
@@ -249,6 +249,7 @@ export default function Store() {
                 <img
                   src={artwork.imageUrl}
                   alt={artwork.title}
+                  loading="lazy"
                   className="w-full h-full object-cover"
                 />
               </div>

--- a/specs/features/seo/CHANGELOG.md
+++ b/specs/features/seo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SEO Feature Changelog
 
+## 2026-04-01 — Image Lazy Loading (#368)
+- Added `loading="lazy"` to 29 of 30 `<img>` tags across 16 files
+- Hero carousel images on homepage kept eager (no lazy) for LCP optimization
+- Covers: artwork cards, detail dialogs, store grid, blog covers, artist avatars, exhibitions, auctions, gallery views, dashboard images, cart thumbnails, 3D gallery overlays
+
 ## 2026-04-01 — Allow Rich Results Test on staging (#379)
 - Changed non-production robots.txt from `Disallow: /` to permissive rules (same as production but without Sitemap)
 - `Disallow: /` was blocking Google Rich Results Test from fetching pages

--- a/specs/features/seo/SPEC.md
+++ b/specs/features/seo/SPEC.md
@@ -18,7 +18,7 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
 | Structured data (JSON-LD) | Done | #367 — Organization, Person, BlogPosting, BreadcrumbList |
 | Twitter cards | Done | #366 — `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` |
 | Canonical URLs | Done | #366 — `<link rel="canonical">` on every page |
-| Image lazy loading | Missing | Page speed penalty |
+| Image lazy loading | Done | #368 — `loading="lazy"` on all below-the-fold images |
 | OG image | Done | #366 — default `og-default.png` + per-entity images |
 | Semantic HTML | Good | Proper heading hierarchy, `<section>`, `<article>`, `<main>` |
 | URL structure | Good | Clean paths: `/artists/:id`, `/blog/:id` |


### PR DESCRIPTION
## Summary
- Added `loading="lazy"` to 29 of 30 `<img>` tags across 16 files (components + pages)
- Hero carousel images on homepage kept eager (default) for LCP optimization
- Covers: artwork cards, detail dialogs, store grid, blog covers, artist avatars, exhibitions, auctions, gallery views, dashboard images, cart thumbnails, 3D gallery overlays

Closes #368

## Test plan
- [ ] Homepage hero images load immediately (no lazy)
- [ ] Scroll down on any page with images — images load as they enter viewport
- [ ] DevTools Network tab confirms deferred image loading
- [ ] No visual regressions — all images display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)