### PR TITLE
fix: add www.vernis9.art → vernis9.art 301 redirect

### DIFF
--- a/deploy/nginx/www.vernis9.art.conf
+++ b/deploy/nginx/www.vernis9.art.conf
@@ -1,0 +1,6 @@
+server {
+    listen 80;
+    server_name www.vernis9.art;
+
+    return 301 https://vernis9.art$request_uri;
+}


### PR DESCRIPTION
## Summary
- Adds nginx config to 301-redirect `www.vernis9.art` to `https://vernis9.art`
- Resolves canonical URL conflict reported by Google Search Console (www vs non-www serving the same content with no redirect)
- After deploy, nginx reload required on production server

## Context
Google URL inspection for `www.vernis9.art` showed:
- **User-declared canonical:** `https://vernis9.art/` (correct, from our `<link rel="canonical">`)
- **Google-selected canonical:** `www.vernis9.art` (wrong — no 301 redirect existed to enforce non-www)
- **Sitemap:** "Temporary processing error" — likely related to the domain confusion

## Test plan
- [ ] Verify `curl -I http://www.vernis9.art` returns `301` → `https://vernis9.art/` after nginx reload
- [ ] Re-run Google URL inspection for `www.vernis9.art` and confirm canonical resolves correctly
- [ ] Verify sitemap processing error clears on next crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)