### PR TITLE
docs: add decision log maintenance rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,16 @@ Key constraints:
 - Security incidents use restricted distribution — do not commit until confirmed safe
 - Run the self-review checklist before presenting the draft
 
+## Decision Log
+
+When work involves an architectural or infrastructure decision (technology choice, security change, process change, major feature design, deployment/CI change), add a row to `specs/decisions/DECISION-LOG.md` as part of the same PR. One-line format:
+
+```
+| YYYY-MM-DD | Decision summary (#issue) | Context/reason | Architecture |
+```
+
+This applies during normal work — do not batch decisions for later.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a "Decision Log" section to CLAUDE.md instructing Claude Code to update `specs/decisions/DECISION-LOG.md` as part of the same PR whenever an architectural decision is made
- Prevents the log from going stale (it was last updated 2026-03-13 until the backfill in #387)

## Test plan
- [x] CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)