### PR TITLE
fix: mobile 3D gallery touch controls and modal trap (closes #451)

### DIFF
--- a/client/src/components/hallway-gallery-3d.tsx
+++ b/client/src/components/hallway-gallery-3d.tsx
@@ -1147,6 +1147,11 @@ export function HallwayGallery3D({ artistRooms, curatorRooms, museumTemplate, is
 
   const handleClick = useCallback((event: MouseEvent) => {
     if (!cameraRef.current || !sceneRef.current || !isPointerLockedRef.current) return;
+    // Mobile uses handleTouchTap with the actual touch position; the center-raycast
+    // here only makes sense under desktop pointer-lock. Without this guard, the
+    // synthetic click that follows a tap re-fires through document and re-opens
+    // whichever mesh is in front of the camera.
+    if (isMobile) return;
     const raycaster = new THREE.Raycaster();
     raycaster.setFromCamera(new THREE.Vector2(0, 0), cameraRef.current);
     const meshes = Array.from(artworkMeshesRef.current.values()).map(v => v.mesh);
@@ -1304,8 +1309,9 @@ export function HallwayGallery3D({ artistRooms, curatorRooms, museumTemplate, is
         const dy = touch.clientY - touchLookRef.current.lastY;
         touchLookRef.current = { lastX: touch.clientX, lastY: touch.clientY };
         euler.current.setFromQuaternion(cameraRef.current.quaternion);
-        euler.current.y -= dx * LOOK_SPEED * 1.5;
-        euler.current.x -= dy * LOOK_SPEED * 1.5;
+        // Drag-to-pan: drag right pans the world right (camera looks left)
+        euler.current.y += dx * LOOK_SPEED * 1.5;
+        euler.current.x += dy * LOOK_SPEED * 1.5;
         euler.current.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, euler.current.x));
         cameraRef.current.quaternion.setFromEuler(euler.current);
       }
@@ -1313,6 +1319,7 @@ export function HallwayGallery3D({ artistRooms, curatorRooms, museumTemplate, is
     const handleTouchEnd = () => { touchLookRef.current = null; };
     const handleTouchTap = (e: TouchEvent) => {
       if (!isPointerLockedRef.current || !cameraRef.current || !rendererRef.current) return;
+      if (selectedArtworkRef.current) return;
       if (e.changedTouches.length !== 1) return;
       const touch = e.changedTouches[0];
       const rect = rendererRef.current.domElement.getBoundingClientRect();
@@ -1531,11 +1538,11 @@ export function HallwayGallery3D({ artistRooms, curatorRooms, museumTemplate, is
       )}
 
       {selectedArtwork && (
-        <div className="absolute inset-0 flex bg-black/80 backdrop-blur-sm" style={{ zIndex: 50 }} data-testid="artwork-detail-panel">
-          <div className="flex-1 relative min-w-0">
+        <div className="absolute inset-0 flex flex-col sm:flex-row bg-black/80 backdrop-blur-sm" style={{ zIndex: 50 }} data-testid="artwork-detail-panel">
+          <div className="flex-1 relative min-w-0 min-h-0">
             <img src={selectedArtwork.imageUrl} alt={selectedArtwork.title} loading="lazy" className="w-full h-full object-contain bg-black/40" />
           </div>
-          <div className="w-64 flex flex-col bg-card p-4 gap-3 relative">
+          <div className="w-full sm:w-64 max-h-[55%] sm:max-h-none overflow-y-auto flex flex-col bg-card p-4 gap-3 relative">
             <Button size="icon" variant="ghost" className="absolute top-2 right-2" onClick={() => { setSelectedArtwork(null); requestPointerLock(); }} data-testid="button-close-artwork">
               <X className="w-5 h-5" />
             </Button>

--- a/client/src/components/maze-gallery-3d.tsx
+++ b/client/src/components/maze-gallery-3d.tsx
@@ -1258,6 +1258,11 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
 
   const handleClick = useCallback((event: MouseEvent) => {
     if (!cameraRef.current || !sceneRef.current || !isPointerLockedRef.current) return;
+    // Mobile uses handleTouchTap with the actual touch position; the center-raycast
+    // here only makes sense under desktop pointer-lock. Without this guard, the
+    // synthetic click that follows a tap re-fires through document and re-opens
+    // whichever mesh is in front of the camera.
+    if (isMobile) return;
 
     const raycaster = new THREE.Raycaster();
     const center = new THREE.Vector2(0, 0);
@@ -1484,8 +1489,9 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
         touchLookRef.current = { lastX: touch.clientX, lastY: touch.clientY };
 
         euler.current.setFromQuaternion(cameraRef.current.quaternion);
-        euler.current.y -= dx * LOOK_SPEED * 1.5;
-        euler.current.x -= dy * LOOK_SPEED * 1.5;
+        // Drag-to-pan: drag right pans the world right (camera looks left)
+        euler.current.y += dx * LOOK_SPEED * 1.5;
+        euler.current.x += dy * LOOK_SPEED * 1.5;
         euler.current.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, euler.current.x));
         cameraRef.current.quaternion.setFromEuler(euler.current);
       }
@@ -1498,6 +1504,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
     // Tap on artwork — raycast from touch position
     const handleTouchTap = (e: TouchEvent) => {
       if (!isPointerLockedRef.current || !cameraRef.current || !rendererRef.current) return;
+      if (selectedArtworkRef.current || showArtistDialogRef.current) return;
       if (e.changedTouches.length !== 1) return;
       const touch = e.changedTouches[0];
       const rect = rendererRef.current.domElement.getBoundingClientRect();
@@ -1854,8 +1861,8 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
 
       {/* Artwork detail panel - fits exactly within gallery */}
       {selectedArtwork && (
-        <div className="absolute inset-0 flex bg-black/80 backdrop-blur-sm" style={{ zIndex: 50 }} data-testid="artwork-detail-panel">
-          <div className="flex-1 relative min-w-0">
+        <div className="absolute inset-0 flex flex-col sm:flex-row bg-black/80 backdrop-blur-sm" style={{ zIndex: 50 }} data-testid="artwork-detail-panel">
+          <div className="flex-1 relative min-w-0 min-h-0">
             <img
               src={selectedArtwork.imageUrl}
               alt={selectedArtwork.title}
@@ -1863,7 +1870,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
               className="w-full h-full object-contain bg-black/40"
             />
           </div>
-          <div className="w-64 flex flex-col bg-card p-4 gap-3 relative">
+          <div className="w-full sm:w-64 max-h-[55%] sm:max-h-none overflow-y-auto flex flex-col bg-card p-4 gap-3 relative">
             <Button
               size="icon"
               variant="ghost"


### PR DESCRIPTION
## Summary

Fixes two mobile 3D gallery bugs reported in #451:

- **Touch rotation feels backwards** on hallway and maze galleries — drag-right rotated camera right (FPS-style). Flipped both `dx` and `dy` signs in `handleTouchMove` so touch is drag-to-pan (drag right → camera looks left).
- **Maze immediately opens a modal and traps the user** — `requestPointerLock()` synchronously sets `isPointerLockedRef` on mobile, so the same tap that triggered "Enter Gallery" bubbled up as a click on `document`; `handleClick` raycast from camera center and opened whichever mesh was in front of the spawn point. The close button then triggered the same loop. Now `handleClick` early-returns on mobile (mobile already has `handleTouchTap` with a real touch position), and `handleTouchTap` early-returns when a modal is already open.

Also reflowed the artwork detail panel from row-only (`flex` + `w-64` info column) to `flex-col` on mobile / `sm:flex-row` on tablet+, so the close button and details are usable on portrait phones. `max-h-[55%]` + `overflow-y-auto` on the info side keeps the image visible above it.

Files: `client/src/components/hallway-gallery-3d.tsx`, `client/src/components/maze-gallery-3d.tsx`.

## Test plan

- [ ] On a real phone, open the museum gallery → enter 3D → confirm drag rotation is now drag-to-pan (both axes).
- [ ] On a real phone, open an artist profile → Gallery tab → enter 3D → confirm the maze actually renders 3D (no immediate modal).
- [ ] Tap an artwork in the maze → confirm the detail panel is laid out vertically with the close button reachable.
- [ ] Tap close → confirm you return to the 3D maze and can keep exploring (no re-opening loop).
- [ ] Walk into the artist poster → confirm the artist intro Dialog opens cleanly and you can dismiss it.
- [ ] Desktop regression: pointer-lock click on artwork still opens detail panel; ESC still releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)