### PR TITLE
fix(ui): enlarge artwork detail dialog on desktop (closes #455)

### DIFF
--- a/client/src/components/artwork-detail-dialog.tsx
+++ b/client/src/components/artwork-detail-dialog.tsx
@@ -45,14 +45,14 @@ export function ArtworkDetailDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-[1200px] lg:max-w-[1400px] max-h-[90vh] overflow-y-auto">
         <div className="grid gap-6 md:grid-cols-2">
           <div className="relative flex items-center justify-center overflow-hidden rounded-lg bg-muted min-h-[200px]">
             <img
               src={artwork.imageUrl}
               alt={artwork.title}
               loading="lazy"
-              className="w-full h-auto object-contain max-h-[60vh]"
+              className="w-full h-auto object-contain max-h-[75vh]"
             />
             {!artwork.isForSale && (
               <Badge className="absolute top-3 right-3" variant="secondary">


### PR DESCRIPTION
## Summary

- Widens the artwork detail dialog on desktop: `sm:max-w-[700px]` → `sm:max-w-[1200px] lg:max-w-[1400px]` (~2× previous width at ≥1024px).
- Raises the image cap from `max-h-[60vh]` → `max-h-[75vh]` so the artwork dominates the wider frame.
- Mobile (<640px) is untouched — only the `sm:`/`lg:` breakpoints changed.

Closes #455.

## Test plan

- [x] `npm run check` — clean
- [x] Manual desktop test: dialog visibly larger, both columns balanced
- [x] Manual narrow-viewport test: mobile layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)