### PR TITLE
chore(security): trivyignore CVE-2026-32280 (esbuild Go stdlib) (closes #486)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,14 +1,13 @@
 # Trivy ignore list for ArtVerse container scan
 # These CVEs are in dependencies we cannot directly update.
 # Review this file when upgrading Node base image or esbuild.
-# Last reviewed: 2026-03-14
+# Last reviewed: 2026-04-14
 
-# ─── npm bundled dependencies (node:20-bookworm-slim) ───
+# ─── npm bundled dependencies (node:25-bookworm-slim) ───
 # These packages are bundled inside npm itself, not our project.
 # Our lockfile already has fixed versions; these come from the
-# Node.js base image's built-in npm 10.x.
+# Node.js base image's built-in npm.
 # Fix: upgrade Node base image or run `npm install -g npm@latest`
-# Tracked in: #73 (Node 25 upgrade)
 
 # cross-spawn 7.0.3 (our lockfile: 7.0.6)
 CVE-2024-21538
@@ -35,9 +34,9 @@ CVE-2026-31802
 # ─── esbuild Go binary (Go stdlib 1.23.12) ───
 # The esbuild binary is compiled with Go 1.23.12 which has
 # known stdlib CVEs. Only esbuild maintainers can fix this
-# by recompiling with Go 1.24.13+/1.25.7+.
-# Fix: upgrade esbuild to a version compiled with newer Go
-# Tracked in: #73 (major dep upgrades)
+# by recompiling with Go 1.25.9+/1.26.2+.
+# Fix: upgrade esbuild when a release compiled with newer Go ships.
+# As of 2026-04-14, esbuild latest is 0.28.0 — still on Go 1.23.12.
 
 CVE-2025-68121
 CVE-2025-58183
@@ -45,3 +44,4 @@ CVE-2025-61726
 CVE-2025-61728
 CVE-2025-61729
 CVE-2026-25679
+CVE-2026-32280


### PR DESCRIPTION
## Summary

Adds CVE-2026-32280 to \`.trivyignore\` so the Trivy Container Scan job stops blocking staging auto-deploy. Same justification as the 6 other esbuild Go stdlib CVEs already in the file.

## Why

Trivy CVE database refresh on 2026-04-14 picked up CVE-2026-32280 (HIGH) in the esbuild Go binary. esbuild bundles a Go-compiled binary in node_modules; that binary is built with Go 1.23.12 which has a growing list of disclosed stdlib CVEs. esbuild is already on the latest version (0.28.0) and still ships with Go 1.23.12 — no upstream fix available. The proper fix is upstream: esbuild needs to release a build compiled with Go ≥ 1.25.9 / 1.26.2.

## What else changed

- Refreshed "Last reviewed" date 2026-03-14 → 2026-04-14
- Removed stale "Tracked in #73" references — that issue (Node 20→25 upgrade) is closed and no longer relevant
- Updated comment for npm-bundled section to reflect the actual base image (\`node:25-bookworm-slim\`, was \`node:20\`)
- Updated esbuild section comment to reflect current Go fix versions (1.25.9+/1.26.2+)

## Test plan

- [ ] CI: \`Lint, Type Check, Test & Build\` passes (no functional change)
- [ ] CI: \`Trivy Container Scan\` passes (CVE now ignored)
- [ ] CI: \`Deploy to Staging\` runs and succeeds (was being skipped due to Trivy failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)