### PR TITLE
chore(deps): remove unused framer-motion (closes #484)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "express": "^5.0.1",
         "express-rate-limit": "^8.3.2",
         "express-session": "^1.19.0",
-        "framer-motion": "^11.13.1",
         "helmet": "^8.1.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^1.8.0",
@@ -7541,33 +7540,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "11.18.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
-      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^11.18.1",
-        "motion-utils": "^11.18.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -9234,21 +9206,6 @@
       "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.6.8.tgz",
       "integrity": "sha512-GJkv/yWPOJTlxj1LZDU2k474cDyOWL+LVaqTdDWQwQ5d8zIuTz1892+1cV9V0ZpK6HYZFo/+BNLBbierO9d2TA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/motion-dom": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
-      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^11.18.1"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
-      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "express": "^5.0.1",
     "express-rate-limit": "^8.3.2",
     "express-session": "^1.19.0",
-    "framer-motion": "^11.13.1",
     "helmet": "^8.1.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.8.0",


### PR DESCRIPTION
## Summary

framer-motion was declared in \`package.json\` but never imported anywhere in the codebase. Removing it — saves 4.2MB from \`node_modules\` and eliminates a recurring Dependabot triage item.

## Evidence it's unused

\`\`\`
$ grep -r \"from ['\\\"']framer-motion['\\\"']\" client/src
# 0 matches

$ grep -r \"motion/react|from ['\\\"']motion['\\\"']\" client
# 0 matches

$ grep -r '\\bmotion\\.' client
# 0 files

$ npm ls framer-motion
rest-express@1.0.0
└── framer-motion@11.18.2    # top-level only, not a sub-dep
\`\`\`

Git history: added in commit \`d912fcf\` (\"Extracted stack files\" — initial project extraction) and never imported since. Leftover from the Replit template.

## Local verification before push

- \`npm run check\` (tsc) ✅
- \`npm run lint\` ✅ (0 errors, 194 warnings — unchanged from pre-existing)
- \`npm test\` ✅ (54/54 passed)
- \`npm run build\` ✅

## Test plan

- [ ] CI green on this PR
- [ ] After merge: \`npm run build\` locally on main still succeeds (sanity)

Closes #484
Closes #464 (the deferred Dependabot framer-motion v12 PR — now moot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)