### PR TITLE
feat(ui): iOS home-screen app title → "Vernis9" (closes #493)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -21,6 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="Vernis9" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Tenor+Sans&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary

One-line change — adds \`<meta name=\"apple-mobile-web-app-title\" content=\"Vernis9\" />\` to \`client/index.html\`. Follow-up to #491 (apple-touch-icon).

iOS uses this meta tag in preference to \`<title>\` for the home-screen label. Result: home-screen bookmark reads \"Vernis9\" cleanly instead of truncating the full descriptive title.

No change to \`server/meta.ts\` — browser tabs, OG cards, SERP results still use the full \"Vernis9 — Virtual Art Gallery & Marketplace\".

## Test plan

- [ ] CI green
- [ ] After merge: iOS Safari → Share → Add to Home Screen → confirm label reads just \"Vernis9\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)