### PR TITLE
release: v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ Deployment tags (`release-{run_number}`) are created automatically on every push
 
 ## [Unreleased]
 
-_Nothing yet — all recent work included in v3.6.0 below._
+_Nothing yet — all recent work included in v3.7.0 below._
+
+## [3.7.0] - 2026-04-14
+
+### Added
+- Upgrade React 18 → 19 (deferred from #466 + #482) ([#485](https://github.com/ilv78/Art-World-Hub/issues/485))
+- Enlarge artwork detail dialog on desktop ([#455](https://github.com/ilv78/Art-World-Hub/issues/455))
 
 ## [3.6.0] - 2026-04-10
 


### PR DESCRIPTION
## Release v3.7.0

**Version:** 3.7.0
**Bump:** minor

### Changelog

### Added
- Upgrade React 18 → 19 (deferred from #466 + #482) ([#485](https://github.com/ilv78/Art-World-Hub/issues/485))
- Enlarge artwork detail dialog on desktop ([#455](https://github.com/ilv78/Art-World-Hub/issues/455))

<!-- RELEASE_ISSUES: 485 455 -->
