### PR TITLE
chore(seo): add BingSiteAuth.xml for Bing Webmaster Tools verification

### DIFF
--- a/client/public/BingSiteAuth.xml
+++ b/client/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>C220A64F10AFE718AC57C263D8FEA3BE</user>
+</users>


### PR DESCRIPTION
Part of #500 (Search Console + Bing Webmaster Tools setup).

## Summary
- Persists the Bing site verification file at `client/public/BingSiteAuth.xml` so it ships in `dist/public/` and is served at `https://vernis9.art/BingSiteAuth.xml`.
- The file is currently `docker cp`'d into the running production container as a one-off — it would be wiped on the next deploy without this commit.

## Test plan
- [x] File is reachable at `https://vernis9.art/BingSiteAuth.xml` from the temporary `docker cp` (verified pre-PR)
- [ ] After this merges + ships to production, re-verify `curl -I https://vernis9.art/BingSiteAuth.xml` returns 200
- [ ] After production deploy, confirm Bing Webmaster Tools still shows verified (no re-verification needed)

## Why no dev test
Static asset, no logic. Dev verification adds nothing — Bing only checks the production URL.