### PR TITLE
docs(seo): record search-engine property ownership in SEO spec

### DIFF
--- a/specs/features/seo/SPEC.md
+++ b/specs/features/seo/SPEC.md
@@ -352,3 +352,15 @@ After implementation, validate with:
 - [Twitter Card Validator](https://cards-dev.twitter.com/validator) — Twitter cards
 - [Google Search Console](https://search.google.com/search-console) — sitemap submission, indexing status
 - Lighthouse SEO audit (Chrome DevTools) — overall score
+
+## Search-Engine Property Ownership
+
+Recorded for handoff continuity — if access to a property is ever lost, this is who to contact / which account to recover.
+
+| Search engine | Property | Verification method | Owner account |
+|---|---|---|---|
+| Google Search Console | `https://vernis9.art` (URL prefix) | _to be recorded_ | `<owner: Liviu's primary Google account>` |
+| Google Search Console | `https://vernis9.nl` (URL prefix — 301 redirect to `.art`, registered to track redirect signals) | _to be recorded_ | `<owner: Liviu's primary Google account>` |
+| Bing Webmaster Tools | `https://vernis9.art` | XML file (`client/public/BingSiteAuth.xml`, served at `/BingSiteAuth.xml`) | `<owner: Liviu's primary Microsoft account>` |
+
+**When adding new properties:** record the verification method here (file / meta tag / DNS / analytics) and update if the method ever changes. The verification artifact itself (file or meta tag) lives in `client/public/` or `client/index.html` so it survives redeploys — never rely solely on a `docker cp` into a running container.


### PR DESCRIPTION
Part of #500.

## Summary
- Adds a **Search-Engine Property Ownership** table to `specs/features/seo/SPEC.md` covering Google Search Console (`vernis9.art` + `vernis9.nl`) and Bing Webmaster Tools (`vernis9.art`).
- Records verification method per property so future handoffs know what to look for.
- Documents the rule that verification artifacts must live in `client/public/` (not just `docker cp`'d) so they survive redeploys.

## Notes
- Account names use generic placeholders (`<owner: Liviu's primary Google account>` etc.) to keep PII out of the repo.
- "Verification method" cells say _to be recorded_ for Google — fill in once verification is completed in the portal (assertion type Google chose: HTML file / meta tag / DNS / analytics).

## Test plan
- [x] Markdown renders correctly on GitHub
- [ ] After merge: confirm the table is the right shape if a real handoff ever happens

This is the last code/doc step on #500. After it merges, #500 just needs the sitemap-submission portal actions ticked off and it can close.