### PR TITLE
feat(seo): image sitemap namespace on /sitemap.xml (closes #504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Deployment tags (`release-{run_number}`) are created automatically on every push
 
 ### Added
 - feat: `/koningsdag` welcome landing for the Koningsdag flea-market QR — captures email via existing newsletter signup tagged with a new `source` column; reuses `newsletter_subscribers` ([#526](https://github.com/ilv78/Art-World-Hub/issues/526))
+- SEO: image sitemap — `/sitemap.xml` now declares the Google image namespace and emits `<image:image>` entries for artist avatars, published artwork images (title + caption), and blog cover images ([#504](https://github.com/ilv78/Art-World-Hub/issues/504))
 
 ### Fixed
 - fix: `/koningsdag` 301-loops on staging because the campaign asset sat under a directory that shadowed the SPA route — moved to `/campaigns/koningsdag/alexandra-painting.jpg` ([#528](https://github.com/ilv78/Art-World-Hub/issues/528))

--- a/server/__tests__/sitemap.test.ts
+++ b/server/__tests__/sitemap.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+
+const { mockStorage } = vi.hoisted(() => ({
+  mockStorage: {
+    getArtists: vi.fn(),
+    getAllBlogPosts: vi.fn(),
+    getArtworks: vi.fn(),
+  },
+}));
+
+vi.mock("../storage", () => ({ storage: mockStorage }));
+
+vi.mock("../logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Dynamic import after mocks so the router picks up the mocked storage.
+let sitemapRouter: express.Router;
+let resetCache: () => void;
+
+beforeAll(async () => {
+  const mod = await import("../routes/sitemap");
+  sitemapRouter = mod.default;
+  resetCache = mod.__resetSitemapCacheForTests;
+});
+
+function makeApp() {
+  const app = express();
+  app.use("/", sitemapRouter);
+  return app;
+}
+
+function artistRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "artist-1",
+    name: "Alexandra",
+    bio: "bio",
+    avatarUrl: null,
+    galleryLayout: null,
+    ...overrides,
+  };
+}
+
+function artworkRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "artwork-1",
+    slug: "my-piece-abc123",
+    title: "My Piece",
+    description: "A reverse glass painting, hand-finished.",
+    imageUrl: "https://cdn.example.com/images/piece.jpg",
+    artistId: "artist-1",
+    price: "100",
+    medium: "oil",
+    dimensions: null,
+    year: 2026,
+    isPublished: true,
+    isForSale: true,
+    isInGallery: true,
+    isReadyForExhibition: false,
+    exhibitionOrder: null,
+    category: "painting",
+    ...overrides,
+  };
+}
+
+function blogPostRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "post-1",
+    title: "My Post",
+    content: "body",
+    excerpt: "excerpt",
+    artistId: "artist-1",
+    coverImageUrl: null,
+    isPublished: true,
+    createdAt: new Date("2026-04-01T00:00:00Z"),
+    updatedAt: new Date("2026-04-10T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetCache();
+  mockStorage.getArtists.mockReset();
+  mockStorage.getAllBlogPosts.mockReset();
+  mockStorage.getArtworks.mockReset();
+  mockStorage.getArtists.mockResolvedValue([]);
+  mockStorage.getAllBlogPosts.mockResolvedValue([]);
+  mockStorage.getArtworks.mockResolvedValue([]);
+});
+
+describe("GET /sitemap.xml — image sitemap (#504)", () => {
+  it("declares the Google image-sitemap namespace", async () => {
+    const res = await request(makeApp()).get("/sitemap.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/xml/);
+    expect(res.text).toContain(
+      'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
+    );
+  });
+
+  it("adds <image:image> with title + caption for each artwork URL", async () => {
+    mockStorage.getArtworks.mockResolvedValue([artworkRow()]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    expect(res.text).toContain("<loc>https://vernis9.art/artworks/my-piece-abc123</loc>");
+    expect(res.text).toContain("<image:loc>https://cdn.example.com/images/piece.jpg</image:loc>");
+    expect(res.text).toContain("<image:title>My Piece</image:title>");
+    expect(res.text).toContain(
+      "<image:caption>A reverse glass painting, hand-finished.</image:caption>",
+    );
+  });
+
+  it("adds <image:image> for an artist with an avatar", async () => {
+    mockStorage.getArtists.mockResolvedValue([
+      artistRow({ avatarUrl: "https://cdn.example.com/avatars/a.jpg" }),
+    ]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    expect(res.text).toContain("<image:loc>https://cdn.example.com/avatars/a.jpg</image:loc>");
+    expect(res.text).toContain("<image:title>Alexandra</image:title>");
+  });
+
+  it("omits <image:image> for an artist without an avatar", async () => {
+    mockStorage.getArtists.mockResolvedValue([artistRow({ avatarUrl: null })]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    const artistBlock = res.text.match(
+      /<url>\s*<loc>https:\/\/vernis9\.art\/artists\/artist-1<\/loc>[\s\S]*?<\/url>/,
+    );
+    expect(artistBlock).not.toBeNull();
+    expect(artistBlock![0]).not.toContain("<image:image>");
+  });
+
+  it("XML-escapes titles and captions containing special characters", async () => {
+    mockStorage.getArtworks.mockResolvedValue([
+      artworkRow({
+        title: 'Foo & Bar <i> "quoted"',
+        description: "He said: 'escape me'",
+      }),
+    ]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    expect(res.text).toContain(
+      "<image:title>Foo &amp; Bar &lt;i&gt; &quot;quoted&quot;</image:title>",
+    );
+    expect(res.text).toContain(
+      "<image:caption>He said: &apos;escape me&apos;</image:caption>",
+    );
+    // And crucially, no raw ampersand escapes into the emitted XML body.
+    expect(res.text).not.toMatch(/<image:title>[^<]*& [^<]*<\/image:title>/);
+  });
+
+  it("truncates oversize captions to ~500 chars with an ellipsis", async () => {
+    const longDesc = "x".repeat(1200);
+    mockStorage.getArtworks.mockResolvedValue([artworkRow({ description: longDesc })]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    const match = res.text.match(/<image:caption>([\s\S]*?)<\/image:caption>/);
+    expect(match).not.toBeNull();
+    expect(match![1].length).toBeLessThanOrEqual(500);
+    expect(match![1].endsWith("…")).toBe(true);
+  });
+
+  it("adds <image:image> for a blog post with a cover image, skips posts without one", async () => {
+    mockStorage.getAllBlogPosts.mockResolvedValue([
+      blogPostRow({ id: "post-with-cover", coverImageUrl: "https://cdn.example.com/cover.jpg" }),
+      blogPostRow({ id: "post-no-cover", coverImageUrl: null }),
+    ]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    expect(res.text).toContain("<loc>https://vernis9.art/blog/post-with-cover</loc>");
+    expect(res.text).toContain("<image:loc>https://cdn.example.com/cover.jpg</image:loc>");
+    const noCoverBlock = res.text.match(
+      /<url>\s*<loc>https:\/\/vernis9\.art\/blog\/post-no-cover<\/loc>[\s\S]*?<\/url>/,
+    );
+    expect(noCoverBlock).not.toBeNull();
+    expect(noCoverBlock![0]).not.toContain("<image:image>");
+  });
+
+  it("drops unpublished blog posts (published gate preserved)", async () => {
+    mockStorage.getAllBlogPosts.mockResolvedValue([
+      blogPostRow({ id: "draft-post", isPublished: false }),
+    ]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    expect(res.text).not.toContain("/blog/draft-post");
+  });
+
+  it("serves the cached XML on the second hit without re-querying storage", async () => {
+    const app = makeApp();
+    await request(app).get("/sitemap.xml");
+    const callsAfterFirst = mockStorage.getArtworks.mock.calls.length;
+    await request(app).get("/sitemap.xml");
+    expect(mockStorage.getArtworks.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("absolutizes image URLs that come in as site-relative paths", async () => {
+    mockStorage.getArtworks.mockResolvedValue([
+      artworkRow({ imageUrl: "/uploads/foo.jpg" }),
+    ]);
+    const res = await request(makeApp()).get("/sitemap.xml");
+    expect(res.text).toContain("<image:loc>https://vernis9.art/uploads/foo.jpg</image:loc>");
+  });
+});

--- a/server/routes/sitemap.ts
+++ b/server/routes/sitemap.ts
@@ -4,7 +4,39 @@ import { logger } from "../logger";
 
 const router = Router();
 const SITE_URL = process.env.SITE_URL || "https://vernis9.art";
+const CAPTION_MAX = 500;
+const TITLE_MAX = 100;
+
 let sitemapCache: { xml: string; expires: number } | null = null;
+
+export function __resetSitemapCacheForTests() {
+  sitemapCache = null;
+}
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1).trimEnd() + "…";
+}
+
+function absolutize(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : `${SITE_URL}${url.startsWith("/") ? "" : "/"}${url}`;
+}
+
+function imageBlock(loc: string, title?: string, caption?: string): string {
+  const parts = [`    <image:image>`, `      <image:loc>${xmlEscape(absolutize(loc))}</image:loc>`];
+  if (title) parts.push(`      <image:title>${xmlEscape(truncate(title, TITLE_MAX))}</image:title>`);
+  if (caption) parts.push(`      <image:caption>${xmlEscape(truncate(caption, CAPTION_MAX))}</image:caption>`);
+  parts.push(`    </image:image>`);
+  return parts.join("\n");
+}
 
 router.get("/sitemap.xml", async (_req, res) => {
   const now = Date.now();
@@ -39,26 +71,49 @@ router.get("/sitemap.xml", async (_req, res) => {
     );
 
     for (const artist of artists) {
-      urls.push(
-        `  <url>\n    <loc>${SITE_URL}/artists/${artist.id}</loc>\n    <changefreq>monthly</changefreq>\n    <priority>0.7</priority>\n  </url>`
-      );
+      const lines = [
+        `  <url>`,
+        `    <loc>${SITE_URL}/artists/${artist.id}</loc>`,
+        `    <changefreq>monthly</changefreq>`,
+        `    <priority>0.7</priority>`,
+      ];
+      if (artist.avatarUrl) {
+        lines.push(imageBlock(artist.avatarUrl, artist.name));
+      }
+      lines.push(`  </url>`);
+      urls.push(lines.join("\n"));
     }
 
     for (const artwork of artworks) {
-      urls.push(
-        `  <url>\n    <loc>${SITE_URL}/artworks/${artwork.slug}</loc>\n    <changefreq>monthly</changefreq>\n    <priority>0.6</priority>\n  </url>`
-      );
+      const lines = [
+        `  <url>`,
+        `    <loc>${SITE_URL}/artworks/${artwork.slug}</loc>`,
+        `    <changefreq>monthly</changefreq>`,
+        `    <priority>0.6</priority>`,
+        imageBlock(artwork.imageUrl, artwork.title, artwork.description),
+        `  </url>`,
+      ];
+      urls.push(lines.join("\n"));
     }
 
     const publishedPosts = blogPosts.filter((p) => p.isPublished);
     for (const post of publishedPosts) {
       const lastmod = post.updatedAt.toISOString().split("T")[0];
-      urls.push(
-        `  <url>\n    <loc>${SITE_URL}/blog/${post.id}</loc>\n    <lastmod>${lastmod}</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.6</priority>\n  </url>`
-      );
+      const lines = [
+        `  <url>`,
+        `    <loc>${SITE_URL}/blog/${post.id}</loc>`,
+        `    <lastmod>${lastmod}</lastmod>`,
+        `    <changefreq>monthly</changefreq>`,
+        `    <priority>0.6</priority>`,
+      ];
+      if (post.coverImageUrl) {
+        lines.push(imageBlock(post.coverImageUrl, post.title));
+      }
+      lines.push(`  </url>`);
+      urls.push(lines.join("\n"));
     }
 
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join("\n")}\n</urlset>`;
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">\n${urls.join("\n")}\n</urlset>`;
 
     sitemapCache = { xml, expires: now + 60 * 60 * 1000 };
     res.set("Content-Type", "application/xml");

--- a/specs/features/seo/CHANGELOG.md
+++ b/specs/features/seo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SEO Feature Changelog
 
+## 2026-04-20 — Image sitemap namespace on `/sitemap.xml` (#504)
+- `<urlset>` now declares `xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"`.
+- Each published artwork URL carries `<image:image>` with `<image:loc>`, `<image:title>` (≤100 chars), and `<image:caption>` (≤500 chars, truncated with an ellipsis).
+- Artist URL carries `<image:image>` when `avatarUrl` is set; blog URL carries `<image:image>` when `coverImageUrl` is set. A URL without its optional image is omitted cleanly (no empty `<image:image>` block).
+- New `xmlEscape()` + `absolutize()` helpers for user-supplied strings and site-relative image paths — required now that titles/descriptions are injected into the sitemap.
+- Cache (1h) preserved. New `server/__tests__/sitemap.test.ts` covers namespace, per-URL image blocks, XML escaping, caption truncation, cache reuse, and the published-only gate.
+
 ## 2026-04-17 — Public artwork detail pages with VisualArtwork JSON-LD (#503)
 - New public route `GET /artworks/:slug` with server-rendered meta tags + `VisualArtwork` JSON-LD (creator Person, artMedium, dateCreated, genre). `offers` with EUR currency + `InStock` emitted when `isForSale && price > 0`.
 - New `slug` column on `artworks` with unique index (migration `0008_superb_silver_centurion.sql`). Backfilled for existing rows; generated server-side on new artworks via `shared/artwork-slug.ts`.

--- a/specs/features/seo/SPEC.md
+++ b/specs/features/seo/SPEC.md
@@ -13,7 +13,7 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
 | Area | Status | Notes |
 |------|--------|-------|
 | `robots.txt` | Done | #364, #376 — dynamic route at `/robots.txt` (blocks indexing on non-production) |
-| `sitemap.xml` | Done | #365 — dynamic endpoint at `/sitemap.xml` |
+| `sitemap.xml` | Done | #365 — dynamic endpoint at `/sitemap.xml`; #504 — Google image-sitemap namespace + `<image:image>` for artist avatars, artwork images (title + caption), and blog cover images |
 | Per-page meta tags | Done | #366 — server-side injection + react-helmet-async |
 | Structured data (JSON-LD) | Done | #367 — Organization, Person, BlogPosting, BreadcrumbList; #501 — WebSite+SearchAction, FAQPage (homepage); #503 — VisualArtwork + Offer on `/artworks/:slug` |
 | Public artwork detail pages | Done | #503 — `/artworks/:slug` server-rendered meta + JSON-LD, sitemap entries |
@@ -87,7 +87,8 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
 **XML format:**
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://vernis9.art/</loc>
     <changefreq>weekly</changefreq>
@@ -95,13 +96,34 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
   </url>
   <url>
     <loc>https://vernis9.art/artists/abc-123</loc>
-    <lastmod>2026-03-31</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://cdn.example.com/avatars/a.jpg</image:loc>
+      <image:title>Alexandra</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://vernis9.art/artworks/my-piece-abc123</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <image:image>
+      <image:loc>https://cdn.example.com/images/piece.jpg</image:loc>
+      <image:title>My Piece</image:title>
+      <image:caption>A reverse glass painting, hand-finished.</image:caption>
+    </image:image>
   </url>
   <!-- ... -->
 </urlset>
 ```
+
+**Image sitemap rules (#504):**
+- Namespace `xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"` on the `<urlset>` root.
+- Every published artwork URL carries a single `<image:image>` (`imageUrl` is NOT NULL on the schema).
+- Artist URL carries `<image:image>` only when `avatarUrl` is set — a URL with no image is fine.
+- Blog post URL carries `<image:image>` only when `coverImageUrl` is set.
+- `<image:title>` is truncated to 100 chars; `<image:caption>` to 500. Both are XML-escaped — every user-supplied string on the sitemap must go through `xmlEscape()`.
+- Relative image paths are absolutized against `SITE_URL`.
 
 **Acceptance criteria:**
 - [ ] `GET /sitemap.xml` returns valid XML
@@ -110,6 +132,8 @@ Prepare Vernis9 for search engine discovery and social sharing. The site is a cl
 - [ ] All published blog posts are listed
 - [ ] Response is cached (not a DB query per request)
 - [ ] `lastmod` is set where data is available
+- [ ] `xmlns:image` namespace is declared on the root element
+- [ ] Every artwork URL has `<image:image>` with `<image:title>` + `<image:caption>`
 
 ---
 


### PR DESCRIPTION
## Summary
- Enriched the existing `/sitemap.xml` in place (single endpoint, per the issue's preference) with the Google image-sitemap namespace.
- Artwork URLs always carry `<image:image>` with title (≤100 chars) + caption (≤500 chars, ellipsis-truncated). Artist and blog URLs carry `<image:image>` when an avatar / cover image is available.
- New `xmlEscape()` + `absolutize()` helpers in the sitemap route — required now that we inject user-supplied titles and descriptions, and so that relative upload paths resolve against `SITE_URL`.
- New `server/__tests__/sitemap.test.ts` (10 tests) covering namespace, per-URL image blocks, escaping, truncation, cache, published-only gate.

## Test plan
- [x] `vitest run server/__tests__/sitemap.test.ts` — 10/10 pass
- [x] Full test suite — 94/94 pass
- [x] `npm run check` (tsc) — clean
- [x] Manual dev smoke: `curl http://localhost:5000/sitemap.xml | python3 -c "import sys,xml.etree.ElementTree as ET; ET.fromstring(sys.stdin.read())"` → well-formed; 25 `<image:image>` blocks emitted against real staging data; site-relative `/uploads/avatars/...` got absolutized to `https://vernis9.art/uploads/avatars/...` as expected.
- [ ] After deploy: re-submit `https://vernis9.art/sitemap.xml` in Google Search Console and confirm it is accepted without warnings (manual, post-merge).

## Not in this PR
- Sitemap-index splitting — we're far under the 50 MB / 50k URL thresholds.
- Google Image Structured Data testing tool — superseded by Rich Results test; one-off manual step at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)