### PR TITLE
perf(seo): fetchpriority on LCP images + Playfair font preload (closes #506)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,4 +13,9 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   exit 0
 fi
 
-gitleaks git --pre-commit --staged --verbose
+# gitleaks v8.19+ uses `git --pre-commit --staged`; older v8 / v7 use `protect --staged`.
+if gitleaks git --help >/dev/null 2>&1; then
+  gitleaks git --pre-commit --staged --verbose
+else
+  gitleaks protect --staged --verbose
+fi

--- a/client/index.html
+++ b/client/index.html
@@ -24,6 +24,7 @@
     <meta name="apple-mobile-web-app-title" content="Vernis9" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="https://fonts.gstatic.com/s/playfairdisplay/v40/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Tenor+Sans&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -157,7 +157,7 @@ export default function ArtistProfile() {
           <CardContent className="pt-6">
             <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6">
               <Avatar className="w-32 h-32 ring-4 ring-background shadow-xl">
-                <AvatarImage src={artist.avatarUrl || undefined} alt={artist.name} />
+                <AvatarImage src={artist.avatarUrl || undefined} alt={artist.name} fetchPriority="high" />
                 <AvatarFallback className="text-4xl font-serif">
                   {artist.name.split(" ").map((n) => n[0]).join("")}
                 </AvatarFallback>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -73,6 +73,7 @@ function HeroCarousel({ artworks }: { artworks: ArtworkWithArtist[] }) {
           <img
             src={s.imageUrl}
             alt={s.title}
+            fetchPriority={i === 0 ? "high" : undefined}
             className="w-full h-full object-cover animate-ken-burns"
             style={{
               animationDelay: `${i * -3}s`,


### PR DESCRIPTION
## Summary
- `fetchPriority="high"` on home hero carousel slide 0 only (slides 1–4 cross-fade in the same viewport spot — only slide 0 is the LCP candidate)
- `fetchPriority="high"` on artist-profile `<AvatarImage>` (the artist profile has no cover image — just a 192px gradient banner above a 128px avatar, so the avatar is the LCP image)
- `<link rel="preload" as="font" type="font/woff2" crossorigin>` for the Playfair Display Latin variable woff2 in `client/index.html` — covers weight 700, the audit-cited target
- Drive-by: `.husky/pre-commit` now falls back to `gitleaks protect --staged` when the v8.19+ `git --pre-commit` subcommand isn't available, so commits work on machines with the older Ubuntu apt build of gitleaks

Addresses §3.11 of the SEO audit (#496).

## Test plan
- [x] `npm run check` clean
- [x] `npm test` — 118/118 pass
- [x] `npm run build` clean; built `dist/public/index.html` contains the preload link
- [x] Local dev smoke test (manual) — preload link served, hero carousel still cross-fades, artist avatar renders
- [ ] Post-merge on staging: Lighthouse run on `/` and `/artists/alexandra-constantin-c62bba40`, confirm "Lazy load LCP image" / "Preload key requests" findings drop and LCP score is same-or-better

## Out of scope
- `width`/`height` on `<img>` for CLS (audit item #8, separate issue)
- Self-hosting fonts (would eliminate Google Fonts URL-rotation risk; revisit if rotation actually breaks the preload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)