### PR TITLE
chore: enforce VPS infra workflow check (hook + CLAUDE.md)

### DIFF
--- a/.claude/hooks/check-vps-infra-ops.sh
+++ b/.claude/hooks/check-vps-infra-ops.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Bash. Reminds Claude to read specs/workflows/DEPLOYMENT.md
+# before improvising sudo/nginx commands against the production/staging VPS.
+# See #550 — Claude improvised raw sudo cp/reload chains for staging instead of
+# using the documented passwordless `deploy-nginx-config` helper, forcing a
+# password prompt that the helper would have avoided.
+#
+# Triggers when a Bash command contains all three signals:
+#   1. "ssh"
+#   2. a VPS host/user marker (artverse.idata.ro, staging@, production@, @artverse)
+#   3. an infra-sensitive token (sudo, nginx, systemctl, /etc/nginx)
+#
+# On match: emits a hookSpecificOutput.additionalContext reminder. Non-blocking.
+# On no match: exits silently with code 0.
+
+set -euo pipefail
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+if [[ "$cmd" =~ ssh ]] \
+  && [[ "$cmd" =~ (artverse\.idata\.ro|staging@|production@|@artverse) ]] \
+  && [[ "$cmd" =~ (sudo|nginx|systemctl|/etc/nginx) ]]; then
+
+  msg="VPS infra reminder (per #550): this command targets the artverse.idata.ro VPS with sudo/nginx/systemctl. Read specs/workflows/DEPLOYMENT.md §5 first. Prefer the documented passwordless helper 'sudo deploy-nginx-config <source> <dest-name>' over improvising 'sudo cp + nginx -t + systemctl reload' chains — the helper is in the NOPASSWD list, backs up + validates + reloads + auto-rollbacks on nginx -t failure. NOPASSWD list: deploy-nginx-config, remove-nginx-config, nginx -t, nginx -s reload. Anything else will prompt the user for a password."
+
+  jq -n --arg msg "$msg" '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$msg}}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/check-vps-infra-ops.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,12 @@ Three developer keywords drive handoffs (recognize the listed aliases too):
 
 Full protocol, edge cases, and recovery procedures: `specs/workflows/MULTI-DEVICE.md`. KEEP UPDATED with workflow changes.
 
+## VPS Infra Operations
+
+Before SSH-ing to the production/staging VPS (`artverse.idata.ro`) for any operation that needs `sudo` or affects nginx, systemd, or other system state — read `specs/workflows/DEPLOYMENT.md` §5 first. The `staging` and `production` users have **passwordless** sudo only for a specific allowlist (`deploy-nginx-config`, `remove-nginx-config`, `nginx -t`, `nginx -s reload`); anything else (`sudo cp`, `sudo systemctl`, `sudo bash`) prompts for a password. Always prefer the documented helpers — they're non-interactive AND include backup + validate + reload + auto-rollback on `nginx -t` failure.
+
+A PreToolUse hook in `.claude/settings.json` (script at `.claude/hooks/check-vps-infra-ops.sh`) reminds Claude of this when a Bash command targets the VPS with sudo/nginx tokens. Lesson from #550.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Memory said *\"read DEPLOYMENT.md before sudo on the VPS\"* but #550 showed that's not enforced — I improvised raw `sudo cp + nginx -t + systemctl reload` for staging instead of using the documented passwordless `deploy-nginx-config` helper, which forced a password prompt the helper would have avoided.

This PR adds two reinforcing layers on top of the existing memory entry:

### 1. `CLAUDE.md` — \"VPS Infra Operations\" section

A short rule loaded into every session's context:

> Before SSH-ing to the production/staging VPS for any operation that needs `sudo` or affects nginx/systemd, read `specs/workflows/DEPLOYMENT.md` §5 first. The `staging`/`production` users have passwordless sudo only for a specific allowlist...

### 2. `PreToolUse` hook on `Bash` — actually enforced

`.claude/hooks/check-vps-infra-ops.sh` runs before every Bash tool call. It triggers when the command contains all three signals:

- `ssh`
- A VPS host/user marker: `artverse.idata.ro`, `staging@`, `production@`, or `@artverse`
- An infra-sensitive token: `sudo`, `nginx`, `systemctl`, or `/etc/nginx`

On match, it emits a `hookSpecificOutput.additionalContext` reminder pointing at `DEPLOYMENT.md §5` and the NOPASSWD allowlist. **Non-blocking** — reminder mode for the first iteration. We can tighten to a block (`permissionDecision: \"ask\"`) later if reminders don't stick.

`.claude/settings.local.json` continues to be globally gitignored — only `settings.json` and the hook script are committed, so the policy applies on both the laptop and the dev VPS once main is pulled.

## Why this PR exists in two layers

CLAUDE.md is loaded every session but still trust-based — I have to apply the rule. The hook is **actually enforced by the harness regardless of my state**. Memory + CLAUDE.md + hook = belt-and-suspenders.

## Test plan

- [x] Hook script handles 5 representative inputs correctly:
  - matching: `ssh ... staging@artverse.idata.ro ... sudo cp /etc/nginx/...` → emits reminder
  - matching: `ssh ... production@... sudo deploy-nginx-config ...` → emits reminder (tolerable false positive — confirms correct path)
  - non-matching: ssh+VPS but read-only (no sudo/nginx) → silent
  - non-matching: `git status` → silent
  - non-matching: `ssh ilc01node03 sudo systemctl status nginx` (different host, the personal dev VPS) → silent
- [x] Live: hook fires correctly (verified in-session — additionalContext appears as a `system-reminder` in the model context)
- [x] Settings JSON validates against the schema (`jq -e ...` passes)
- [x] `gitleaks` clean

## Out of scope

- Tightening to `permissionDecision: \"ask\"` (blocking confirmation) — defer until we see whether the reminder is sufficient
- Hook for write-side ops (e.g., `Edit` on `/etc/nginx/*` paths) — not needed; we don't edit VPS files via Edit tool, only via SSH+sudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)