### PR TITLE
perf(server): inject LCP image preload tag into / HTML (closes #560)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -25,6 +25,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" as="font" type="font/woff2" crossorigin href="https://fonts.gstatic.com/s/playfairdisplay/v40/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2">
+    __LCP_IMAGE_PRELOAD__
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Tenor+Sans&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/server/__tests__/helpers/mock-storage.ts
+++ b/server/__tests__/helpers/mock-storage.ts
@@ -19,6 +19,7 @@ export function createMockStorage(): IStorage {
     getPublishedArtworkBySlug: vi.fn().mockResolvedValue(undefined),
     getRelatedArtworksByArtist: vi.fn().mockResolvedValue([]),
     getArtworksByArtist: vi.fn().mockResolvedValue([]),
+    getHomeHeroSlide0: vi.fn().mockResolvedValue(null),
     createArtwork: vi.fn().mockResolvedValue({}),
     updateArtwork: vi.fn().mockResolvedValue(undefined),
     deleteArtwork: vi.fn().mockResolvedValue(false),

--- a/server/__tests__/helpers/test-app.ts
+++ b/server/__tests__/helpers/test-app.ts
@@ -18,6 +18,7 @@ const { mockStorage } = vi.hoisted(() => {
     getPublishedArtworkBySlug: fn().mockResolvedValue(undefined),
     getRelatedArtworksByArtist: fn().mockResolvedValue([]),
     getArtworksByArtist: fn().mockResolvedValue([]),
+    getHomeHeroSlide0: fn().mockResolvedValue(null),
     createArtwork: fn().mockResolvedValue({}),
     updateArtwork: fn().mockResolvedValue(undefined),
     deleteArtwork: fn().mockResolvedValue(false),

--- a/server/__tests__/meta.test.ts
+++ b/server/__tests__/meta.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockStorageState: {
   artwork: Record<string, unknown> | undefined;
   artist: Record<string, unknown> | undefined;
-} = { artwork: undefined, artist: undefined };
+  homeHero: { id: string; imageUrl: string } | null;
+} = { artwork: undefined, artist: undefined, homeHero: null };
+
+const getHomeHeroSlide0Mock = vi.fn(async () => mockStorageState.homeHero);
 
 vi.mock("../storage", () => ({
   storage: {
@@ -11,10 +14,11 @@ vi.mock("../storage", () => ({
     getArtistBySlug: vi.fn(async () => mockStorageState.artist),
     getBlogPost: vi.fn().mockResolvedValue(undefined),
     getPublishedArtworkBySlug: vi.fn(async () => mockStorageState.artwork),
+    getHomeHeroSlide0: getHomeHeroSlide0Mock,
   },
 }));
 
-const { resolveMetaTags } = await import("../meta");
+const { resolveMetaTags, injectMetaTags, __resetHomeHeroCache } = await import("../meta");
 
 function setMockArtwork(artwork: Record<string, unknown> | undefined) {
   mockStorageState.artwork = artwork;
@@ -264,5 +268,108 @@ describe("resolveMetaTags — /artists/:slug canonical URL (issue #537)", () => 
     const meta = await resolveMetaTags("/artists/does-not-exist-00000000");
     const types = meta.jsonLd.map((ld) => ld["@type"]);
     expect(types).not.toContain("Person");
+  });
+});
+
+describe("LCP image preload — / only (issue #560)", () => {
+  beforeEach(() => {
+    __resetHomeHeroCache();
+    getHomeHeroSlide0Mock.mockClear();
+    mockStorageState.homeHero = null;
+  });
+
+  it("populates lcpImagePreload on / when storage returns a hero", async () => {
+    mockStorageState.homeHero = {
+      id: "art-1",
+      imageUrl: "/uploads/artworks/featured.jpg",
+    };
+    const meta = await resolveMetaTags("/");
+    expect(meta.lcpImagePreload).toBe("/uploads/artworks/featured.jpg");
+  });
+
+  it("leaves lcpImagePreload undefined on / when storage returns null", async () => {
+    mockStorageState.homeHero = null;
+    const meta = await resolveMetaTags("/");
+    expect(meta.lcpImagePreload).toBeUndefined();
+  });
+
+  it("never populates lcpImagePreload on non-root static routes", async () => {
+    mockStorageState.homeHero = {
+      id: "art-1",
+      imageUrl: "/uploads/artworks/featured.jpg",
+    };
+    for (const path of ["/gallery", "/store", "/artists", "/blog", "/changelog"]) {
+      const meta = await resolveMetaTags(path);
+      expect(meta.lcpImagePreload).toBeUndefined();
+    }
+  });
+
+  it("caches the storage result within the TTL (only one DB call across N / requests)", async () => {
+    mockStorageState.homeHero = {
+      id: "art-1",
+      imageUrl: "/uploads/artworks/featured.jpg",
+    };
+    await resolveMetaTags("/");
+    await resolveMetaTags("/");
+    await resolveMetaTags("/");
+    expect(getHomeHeroSlide0Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null and does not cache on storage error", async () => {
+    getHomeHeroSlide0Mock.mockRejectedValueOnce(new Error("db down"));
+    const first = await resolveMetaTags("/");
+    expect(first.lcpImagePreload).toBeUndefined();
+
+    // Second call should retry, not serve a cached null
+    mockStorageState.homeHero = {
+      id: "art-2",
+      imageUrl: "/uploads/artworks/recovered.jpg",
+    };
+    const second = await resolveMetaTags("/");
+    expect(second.lcpImagePreload).toBe("/uploads/artworks/recovered.jpg");
+    expect(getHomeHeroSlide0Mock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("injectMetaTags — LCP preload tag (issue #560)", () => {
+  function baseMeta(): Parameters<typeof injectMetaTags>[1] {
+    return {
+      title: "T",
+      description: "D",
+      ogTitle: "OT",
+      ogDescription: "OD",
+      ogType: "website",
+      ogUrl: "https://x/",
+      ogImage: "https://x/og.png",
+      jsonLd: [],
+    };
+  }
+
+  it("injects <link rel=preload as=image> when lcpImagePreload is set", () => {
+    const html = "<head>__LCP_IMAGE_PRELOAD__</head>";
+    const out = injectMetaTags(html, {
+      ...baseMeta(),
+      lcpImagePreload: "/uploads/artworks/x.jpg",
+    });
+    expect(out).toContain(
+      '<link rel="preload" as="image" href="/uploads/artworks/x.jpg" fetchpriority="high">',
+    );
+  });
+
+  it("strips the placeholder to empty when lcpImagePreload is undefined", () => {
+    const html = "<head>__LCP_IMAGE_PRELOAD__</head>";
+    const out = injectMetaTags(html, baseMeta());
+    expect(out).toBe("<head></head>");
+  });
+
+  it("escapes the URL to prevent attribute injection", () => {
+    const html = "<head>__LCP_IMAGE_PRELOAD__</head>";
+    const out = injectMetaTags(html, {
+      ...baseMeta(),
+      lcpImagePreload: '/uploads/x.jpg" onerror="alert(1)',
+    });
+    // The double-quote and HTML-significant chars must be escaped
+    expect(out).not.toContain('onerror="alert(1)"');
+    expect(out).toContain("&quot;");
   });
 });

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -142,13 +142,15 @@ describe("DatabaseStorage", () => {
       const chain = selectMock();
       vi.mocked(chain.from).mockReturnThis();
       vi.mocked(chain.innerJoin).mockReturnThis();
-      vi.mocked(chain.where).mockResolvedValueOnce(joinResult as any);
+      vi.mocked(chain.where).mockReturnThis();
+      vi.mocked(chain.orderBy).mockResolvedValueOnce(joinResult as any);
 
       const result = await storage.getArtworks();
       expect(result).toHaveLength(1);
       expect(result[0].title).toBe("Painting");
       expect(result[0].artist.name).toBe("Alice");
       expect(chain.where).toHaveBeenCalled();
+      expect(chain.orderBy).toHaveBeenCalled();
     });
 
     it("skips the published filter when includeDrafts is set", async () => {
@@ -162,11 +164,13 @@ describe("DatabaseStorage", () => {
       const selectMock = vi.mocked(db.select);
       const chain = selectMock();
       vi.mocked(chain.from).mockReturnThis();
-      vi.mocked(chain.innerJoin).mockResolvedValueOnce(joinResult as any);
+      vi.mocked(chain.innerJoin).mockReturnThis();
+      vi.mocked(chain.orderBy).mockResolvedValueOnce(joinResult as any);
 
       const result = await storage.getArtworks({ includeDrafts: true });
       expect(result).toHaveLength(1);
       expect(result[0].isPublished).toBe(false);
+      expect(chain.orderBy).toHaveBeenCalled();
     });
   });
 

--- a/server/meta.ts
+++ b/server/meta.ts
@@ -18,6 +18,36 @@ interface MetaTags {
   ogUrl: string;
   ogImage: string;
   jsonLd: Record<string, unknown>[];
+  lcpImagePreload?: string; // path of the LCP image to preload (only / today)
+}
+
+// In-memory cache for the home-page LCP candidate. Refreshed on a TTL because
+// `/` is the most-hit URL and we don't want to query the DB on every request.
+// 30s is short enough that hero changes (admin tagging "#featured") propagate
+// quickly, long enough to absorb spike traffic. (#560)
+const HOME_HERO_TTL_MS = 30_000;
+let homeHeroCache: { value: string | null; expiresAt: number } | null = null;
+
+async function getHomeHeroPreloadPath(): Promise<string | null> {
+  const now = Date.now();
+  if (homeHeroCache && homeHeroCache.expiresAt > now) {
+    return homeHeroCache.value;
+  }
+  try {
+    const slide0 = await storage.getHomeHeroSlide0();
+    const value = slide0 ? slide0.imageUrl : null;
+    homeHeroCache = { value, expiresAt: now + HOME_HERO_TTL_MS };
+    return value;
+  } catch {
+    // On error, return null and DO NOT cache — let the next request retry.
+    // Worst case we serve `/` without the preload (the original behavior).
+    return null;
+  }
+}
+
+// Test-only: reset the in-memory cache so unit tests are deterministic.
+export function __resetHomeHeroCache(): void {
+  homeHeroCache = null;
 }
 
 const STATIC_ROUTES: Record<string, Pick<MetaTags, "title" | "ogType"> & { description?: string }> = {
@@ -173,6 +203,8 @@ async function resolveMetaTags(url: string): Promise<MetaTags> {
       ));
     }
     const description = staticRoute.description ?? DEFAULT_DESCRIPTION;
+    const lcpImagePreload =
+      path === "/" ? (await getHomeHeroPreloadPath()) ?? undefined : undefined;
     return {
       title: staticRoute.title,
       description,
@@ -182,6 +214,7 @@ async function resolveMetaTags(url: string): Promise<MetaTags> {
       ogUrl: `${SITE_URL}${path === "/" ? "/" : path}`,
       ogImage: DEFAULT_OG_IMAGE,
       jsonLd,
+      lcpImagePreload,
     };
   }
 
@@ -372,6 +405,10 @@ export function injectMetaTags(html: string, meta: MetaTags): string {
     .map((ld) => `<script type="application/ld+json">${JSON.stringify(ld)}</script>`)
     .join("\n    ");
 
+  const lcpPreload = meta.lcpImagePreload
+    ? `<link rel="preload" as="image" href="${escapeHtml(meta.lcpImagePreload)}" fetchpriority="high">`
+    : "";
+
   return html
     .replace(/__META_TITLE__/g, escapeHtml(meta.title))
     .replace(/__META_DESCRIPTION__/g, escapeHtml(meta.description))
@@ -382,7 +419,8 @@ export function injectMetaTags(html: string, meta: MetaTags): string {
     .replace(/__META_OG_URL__/g, escapeHtml(meta.ogUrl))
     .replace(/__META_OG_IMAGE__/g, escapeHtml(meta.ogImage))
     .replace(/__META_ROBOTS__/g, isProduction ? "" : '<meta name="robots" content="noindex, nofollow" />')
-    .replace(/__JSON_LD__/g, jsonLdScripts);
+    .replace(/__JSON_LD__/g, jsonLdScripts)
+    .replace(/__LCP_IMAGE_PRELOAD__/g, lcpPreload);
 }
 
 function toAbsoluteUrl(url: string): string {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -43,6 +43,7 @@ export interface IStorage {
   getPublishedArtworkBySlug(slug: string): Promise<ArtworkWithArtist | undefined>;
   getRelatedArtworksByArtist(artistId: string, excludeId: string, limit: number): Promise<ArtworkWithArtist[]>;
   getArtworksByArtist(artistId: string, opts?: { includeDrafts?: boolean }): Promise<ArtworkWithArtist[]>;
+  getHomeHeroSlide0(): Promise<{ id: string; imageUrl: string } | null>;
   createArtwork(artwork: InsertArtwork): Promise<Artwork>;
   updateArtwork(id: string, artwork: Partial<InsertArtwork>): Promise<Artwork | undefined>;
   
@@ -171,14 +172,19 @@ export class DatabaseStorage implements IStorage {
 
   // Artworks
   async getArtworks(opts: { includeDrafts?: boolean } = {}): Promise<ArtworkWithArtist[]> {
-    const query = db
+    // Order by id ASC for a deterministic stream. Without it Postgres returns
+    // physical order, which can shift after VACUUM or reindex and de-syncs the
+    // client carousel's slide 0 from the server-side LCP preload picker
+    // (`getHomeHeroSlide0` shares this ordering). UUID-id ordering isn't
+    // user-meaningful but it's stable, which is the property we need. (#560)
+    const baseQuery = db
       .select()
       .from(artworks)
       .innerJoin(artists, eq(artworks.artistId, artists.id));
 
     const result = opts.includeDrafts
-      ? await query
-      : await query.where(eq(artworks.isPublished, true));
+      ? await baseQuery.orderBy(asc(artworks.id))
+      : await baseQuery.where(eq(artworks.isPublished, true)).orderBy(asc(artworks.id));
 
     return result.map(({ artworks: artwork, artists: artist }) => ({
       ...artwork,
@@ -254,6 +260,39 @@ export class DatabaseStorage implements IStorage {
       ...artwork,
       artist,
     }));
+  }
+
+  // Picks the artwork that the home-page hero carousel will display as slide 0.
+  // Mirrors `client/src/pages/home.tsx` ordering so the URL we preload matches
+  // the URL the React carousel ultimately renders. Priority:
+  //   1. Published artworks whose description contains "#featured"
+  //   2. Else published artworks with isInGallery=true
+  //   3. Else any published artwork
+  // Within each tier we order by id ASC so the result is deterministic; the
+  // home-page `getArtworks` query is unordered today, so this picks a stable
+  // candidate even if Postgres' natural row order shifts. Used for the LCP
+  // image preload tag injected into the `/` HTML response. (#560)
+  async getHomeHeroSlide0(): Promise<{ id: string; imageUrl: string } | null> {
+    const rows = await db
+      .select({
+        id: artworks.id,
+        imageUrl: artworks.imageUrl,
+        description: artworks.description,
+        isInGallery: artworks.isInGallery,
+      })
+      .from(artworks)
+      .where(eq(artworks.isPublished, true))
+      .orderBy(asc(artworks.id));
+
+    if (rows.length === 0) return null;
+
+    const featured = rows.find((r) => r.description?.includes("#featured"));
+    if (featured) return { id: featured.id, imageUrl: featured.imageUrl };
+
+    const inGallery = rows.find((r) => r.isInGallery === true);
+    if (inGallery) return { id: inGallery.id, imageUrl: inGallery.imageUrl };
+
+    return { id: rows[0].id, imageUrl: rows[0].imageUrl };
   }
 
   async createArtwork(insertArtwork: InsertArtwork): Promise<Artwork> {


### PR DESCRIPTION
Closes #560. Final piece of #551's perf workstream.

## Why

After #559 (route code-split), Lighthouse 12 mobile measurements showed home LCP gated by a **77% Load Delay phase** (~10.8s out of 13.5s LCP). The carousel hero `<img>` is rendered by client-side React, so the browser's preload scanner can't see it in `index.html` and the image fetch is blocked behind: HTML → entry chunk → home-*.js chunk → React render → `<img>` in DOM → image request.

Compression (#552), HTTP/2 (#557), and code-splitting (#559) addressed every JS-side lever; the home page hit the LCP-image-not-discoverable wall that no bundle work can fix.

## What

Server-side: query for the artwork the carousel will render as slide 0, inject `<link rel="preload" as="image" href="..." fetchpriority="high">` into the `/` response head. The browser preload-scans it and starts the image download in parallel with the JS bundles; when React eventually renders `<img src=...>`, the image is already in the browser cache (preload + img on the same URL get de-duplicated).

| Change | Why |
|---|---|
| `IStorage.getHomeHeroSlide0()` mirrors `home.tsx`'s slide-0 picker (`#featured` → `isInGallery` → fallback) | Server picks the same artwork the client carousel will eventually show |
| `getArtworks()` now `ORDER BY id ASC` | Without it, Postgres natural order can shift after vacuum/reindex and the server picker diverges from the client filter — pointing the preload at the wrong URL. Hit this exact bug during dev smoke. |
| `meta.ts` wraps the lookup in a 30s in-memory TTL cache | `/` is the most-hit URL; per-request DB query would be excessive. Cache-miss path on error returns no preload (no regression). |
| `client/index.html` gains `__LCP_IMAGE_PRELOAD__` placeholder | Injection routed through the existing `injectMetaTags` pipeline, which already runs on both dev (`server/vite.ts`) and prod (`server/static.ts`) |
| `escapeHtml` on the URL | Prevents attribute injection if a malicious image URL ever ends up in the DB |

Only `/` gets the preload tag — other routes (`/gallery`, `/artists/:slug`, etc.) are explicitly skipped because their LCP isn't a JS-rendered image.

## Verification (Lighthouse 12 mobile against local dev)

The canonical signals confirm the fix works:

| Audit signal | Before | After |
|---|---|---|
| `lcp-discovery-insight: requestDiscoverable` | **false** | **true** ✅ |
| `prioritize-lcp-image` audit score | 0 (red) | **1 (green) ✅** |
| `prioritize-lcp-image` claimed savings | 3100ms LCP | **0ms** |
| Preload URL vs `/api/artworks[0]` | mismatch | **match ✅** |

Local-dev numeric LCP isn't comparable to staging/prod (Vite dev mode, no minification, no nginx, no compression). Real LCP improvement will show up on staging post-deploy — expected: Load Delay phase drops from ~10.8s to a small fraction of total LCP, putting home LCP under 4s.

## Tests

`npm test` 118 → **134** (16 new across this PR + #559).

8 new tests in `server/__tests__/meta.test.ts`:
- LCP preload populates only on `/`
- Non-root static routes never get the preload
- 30s TTL cache: only one DB call across N `/` requests
- Error path returns null and does NOT cache (next request retries)
- `injectMetaTags` injects the link tag with the right form
- Empty placeholder when no preload is set
- URL is HTML-escaped to prevent attribute injection

Existing storage tests updated for the new `.orderBy(asc(artworks.id))` chain step.

## Risk + rollback

- **Risk: low.** New code on the most-hit URL, but error-wrapped: if `getHomeHeroSlide0` throws, we fall through to the original (no-preload) behavior. The page never breaks.
- **DB cost:** one indexed SELECT every 30s (cached). Negligible.
- **Cache staleness:** 30s window after editing `#featured` tags or `isInGallery` flags. Acceptable; hero changes are rare.
- **Rollback:** revert single PR. No live infra change in this PR.

## Acceptance criteria (from #560)

- [x] `curl -s https://staging.vernis9.art/ | grep -E '<link[^>]*preload[^>]*as="image"'` returns the preload tag (verified locally; staging will confirm post-deploy)
- [x] `lcp-discovery-insight.requestDiscoverable: true`
- [x] `prioritize-lcp-image` audit passes
- [x] No regression on non-`/` routes
- [ ] Home LCP Load Delay < 2.5s on staging (will measure post-merge)
- [ ] LCP value < 4s on staging (will measure post-merge)

## Refs

- #560 (closes)
- #551 (umbrella) — Priority 3, the structural LCP fix
- #559 / #557 / #555 / #552 / #549 — full perf workstream this completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)