### PR TITLE
fix(perf,server): align LCP preload with picture variant + 404 missing /uploads (closes #567)

### DIFF
--- a/client/src/lib/artwork-image.ts
+++ b/client/src/lib/artwork-image.ts
@@ -1,46 +1,6 @@
-const WEBP_WIDTHS = [480, 960, 1440, 2400] as const;
-const JPEG_WIDTHS = [960, 2400] as const;
-
-const ARTWORKS_PREFIX = "/uploads/artworks/";
-
-export const ARTWORK_SIZES = {
-  hero: "100vw",
-  card: "(max-width: 768px) 50vw, (max-width: 1280px) 33vw, 25vw",
-  detail: "(max-width: 1024px) 100vw, 80vw",
-  thumbnail: "120px",
-} as const;
-
-export interface ArtworkPictureSources {
-  webpSrcSet: string;
-  jpegSrcSet: string;
-  fallbackSrc: string;
-}
-
-function parseArtworkUrl(imageUrl: string): { uuid: string; ext: string } | null {
-  if (!imageUrl.startsWith(ARTWORKS_PREFIX)) return null;
-  const filename = imageUrl.slice(ARTWORKS_PREFIX.length);
-  const dotIdx = filename.lastIndexOf(".");
-  if (dotIdx <= 0) return null;
-  const uuid = filename.slice(0, dotIdx);
-  const ext = filename.slice(dotIdx + 1).toLowerCase();
-  if (uuid.includes("-") && /-\d+$/.test(uuid)) return null; // already a variant
-  return { uuid, ext };
-}
-
-export function getArtworkPictureSources(imageUrl: string): ArtworkPictureSources | null {
-  const parsed = parseArtworkUrl(imageUrl);
-  if (!parsed) return null;
-  const { uuid } = parsed;
-
-  const webpSrcSet = WEBP_WIDTHS.map((w) => `${ARTWORKS_PREFIX}${uuid}-${w}.webp ${w}w`).join(", ");
-  const jpegSrcSet = JPEG_WIDTHS.map((w) => `${ARTWORKS_PREFIX}${uuid}-${w}.jpg ${w}w`).join(", ");
-  const fallbackSrc = `${ARTWORKS_PREFIX}${uuid}-960.jpg`;
-
-  return { webpSrcSet, jpegSrcSet, fallbackSrc };
-}
-
-export function getArtworkTextureUrl(imageUrl: string, targetWidth: 960 | 1440 = 1440): string {
-  const parsed = parseArtworkUrl(imageUrl);
-  if (!parsed) return imageUrl;
-  return `${ARTWORKS_PREFIX}${parsed.uuid}-${targetWidth}.webp`;
-}
+export {
+  ARTWORK_SIZES,
+  getArtworkPictureSources,
+  getArtworkTextureUrl,
+  type ArtworkPictureSources,
+} from "@shared/artwork-image";

--- a/server/__tests__/meta.test.ts
+++ b/server/__tests__/meta.test.ts
@@ -345,15 +345,37 @@ describe("injectMetaTags — LCP preload tag (issue #560)", () => {
     };
   }
 
-  it("injects <link rel=preload as=image> when lcpImagePreload is set", () => {
+  it("injects imagesrcset preload pointing at the variant set when hero is /uploads/artworks/* (#567)", () => {
     const html = "<head>__LCP_IMAGE_PRELOAD__</head>";
     const out = injectMetaTags(html, {
       ...baseMeta(),
-      lcpImagePreload: "/uploads/artworks/x.jpg",
+      lcpImagePreload: "/uploads/artworks/abc-uuid.jpg",
+    });
+    expect(out).toContain('rel="preload"');
+    expect(out).toContain('as="image"');
+    expect(out).toContain('imagesrcset=');
+    expect(out).toContain('imagesizes="100vw"');
+    expect(out).toContain('fetchpriority="high"');
+    // Variant URLs the <picture> would render — preload must match so the
+    // bytes the browser preloads are the bytes the picture displays.
+    expect(out).toContain("/uploads/artworks/abc-uuid-480.webp 480w");
+    expect(out).toContain("/uploads/artworks/abc-uuid-960.webp 960w");
+    expect(out).toContain("/uploads/artworks/abc-uuid-1440.webp 1440w");
+    expect(out).toContain("/uploads/artworks/abc-uuid-2400.webp 2400w");
+    // Original-href form must NOT be present — that's the regression we fixed
+    expect(out).not.toContain('href="/uploads/artworks/abc-uuid.jpg"');
+  });
+
+  it("falls back to single-href preload for external (non-/uploads/artworks/) hero URLs", () => {
+    const html = "<head>__LCP_IMAGE_PRELOAD__</head>";
+    const out = injectMetaTags(html, {
+      ...baseMeta(),
+      lcpImagePreload: "https://lh3.googleusercontent.com/pw/abcdef",
     });
     expect(out).toContain(
-      '<link rel="preload" as="image" href="/uploads/artworks/x.jpg" fetchpriority="high">',
+      '<link rel="preload" as="image" href="https://lh3.googleusercontent.com/pw/abcdef" fetchpriority="high">',
     );
+    expect(out).not.toContain("imagesrcset");
   });
 
   it("strips the placeholder to empty when lcpImagePreload is undefined", () => {
@@ -362,13 +384,13 @@ describe("injectMetaTags — LCP preload tag (issue #560)", () => {
     expect(out).toBe("<head></head>");
   });
 
-  it("escapes the URL to prevent attribute injection", () => {
+  it("escapes attribute-injection attempts in the URL", () => {
     const html = "<head>__LCP_IMAGE_PRELOAD__</head>";
     const out = injectMetaTags(html, {
       ...baseMeta(),
+      // Doesn't match /uploads/artworks/ so falls through to single-href path
       lcpImagePreload: '/uploads/x.jpg" onerror="alert(1)',
     });
-    // The double-quote and HTML-significant chars must be escaped
     expect(out).not.toContain('onerror="alert(1)"');
     expect(out).toContain("&quot;");
   });

--- a/server/__tests__/static-404-guard.test.ts
+++ b/server/__tests__/static-404-guard.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { __testing } from "../static";
+
+const { shouldReturn404ForStaticMiss, STATIC_404_PREFIXES } = __testing;
+
+describe("static-404 guard (#567)", () => {
+  it("matches all expected static-asset prefixes", () => {
+    expect(STATIC_404_PREFIXES).toContain("/uploads/");
+    expect(STATIC_404_PREFIXES).toContain("/api/");
+    expect(STATIC_404_PREFIXES).toContain("/assets/");
+  });
+
+  it("returns true for /uploads/* misses (the bogus-cache trap from #566)", () => {
+    expect(shouldReturn404ForStaticMiss("/uploads/artworks/abc-1440.webp")).toBe(true);
+    expect(shouldReturn404ForStaticMiss("/uploads/avatars/missing.png")).toBe(true);
+    expect(shouldReturn404ForStaticMiss("/uploads/blog-covers/x.jpg")).toBe(true);
+  });
+
+  it("returns true for unmatched /api/* and /assets/*", () => {
+    expect(shouldReturn404ForStaticMiss("/api/this-endpoint-does-not-exist")).toBe(true);
+    expect(shouldReturn404ForStaticMiss("/assets/missing-bundle.js")).toBe(true);
+  });
+
+  it("returns false for SPA routes that should serve index.html", () => {
+    expect(shouldReturn404ForStaticMiss("/")).toBe(false);
+    expect(shouldReturn404ForStaticMiss("/gallery")).toBe(false);
+    expect(shouldReturn404ForStaticMiss("/artworks/some-slug-abc")).toBe(false);
+    expect(shouldReturn404ForStaticMiss("/artists/some-artist-xyz")).toBe(false);
+    expect(shouldReturn404ForStaticMiss("/exhibitions")).toBe(false);
+    expect(shouldReturn404ForStaticMiss("/auth")).toBe(false);
+  });
+
+  it("does not match prefix-collision routes (e.g. /uploadsless)", () => {
+    expect(shouldReturn404ForStaticMiss("/uploadsless")).toBe(false);
+    expect(shouldReturn404ForStaticMiss("/apinotreal")).toBe(false);
+    expect(shouldReturn404ForStaticMiss("/assetsxxx")).toBe(false);
+  });
+
+  it("matches /api root (just /api/) but not bare /api with no trailing slash", () => {
+    expect(shouldReturn404ForStaticMiss("/api/")).toBe(true);
+    // Bare /api without trailing slash is unlikely but we don't need to 404 it
+    expect(shouldReturn404ForStaticMiss("/api")).toBe(false);
+  });
+});

--- a/server/meta.ts
+++ b/server/meta.ts
@@ -1,5 +1,6 @@
 import { storage } from "./storage";
 import { FAQS } from "../shared/faqs";
+import { ARTWORK_SIZES, getArtworkPictureSources } from "../shared/artwork-image";
 
 const SITE_URL = process.env.SITE_URL || "https://vernis9.art";
 const PRODUCTION_URL = "https://vernis9.art";
@@ -405,9 +406,17 @@ export function injectMetaTags(html: string, meta: MetaTags): string {
     .map((ld) => `<script type="application/ld+json">${JSON.stringify(ld)}</script>`)
     .join("\n    ");
 
-  const lcpPreload = meta.lcpImagePreload
-    ? `<link rel="preload" as="image" href="${escapeHtml(meta.lcpImagePreload)}" fetchpriority="high">`
-    : "";
+  // For artwork heroes (#564 variants), preload via imagesrcset so the browser
+  // preload-scans the same WebP variant the <picture> element will render.
+  // Without this, the preload fetches the original full-resolution JPEG while
+  // the picture renders a smaller WebP — wasted bytes and Load Delay regressed.
+  let lcpPreload = "";
+  if (meta.lcpImagePreload) {
+    const sources = getArtworkPictureSources(meta.lcpImagePreload);
+    lcpPreload = sources
+      ? `<link rel="preload" as="image" imagesrcset="${escapeHtml(sources.webpSrcSet)}" imagesizes="${escapeHtml(ARTWORK_SIZES.hero)}" fetchpriority="high">`
+      : `<link rel="preload" as="image" href="${escapeHtml(meta.lcpImagePreload)}" fetchpriority="high">`;
+  }
 
   return html
     .replace(/__META_TITLE__/g, escapeHtml(meta.title))

--- a/server/static.ts
+++ b/server/static.ts
@@ -3,6 +3,19 @@ import fs from "fs";
 import path from "path";
 import { resolveMetaTags, injectMetaTags } from "./meta";
 
+// Paths under these prefixes serve static files (or are handled by API
+// routes registered earlier). When a request to one of these paths reaches
+// the SPA catch-all, it means the file was not found / route didn't match —
+// we MUST return 404 instead of falling through to the SPA's index.html.
+// Without this guard, a request like /uploads/artworks/missing.webp would
+// receive HTML with the 30-day Cache-Control header from #555 and cache a
+// bogus "image-but-actually-HTML" response in browsers for 30 days.
+const STATIC_404_PREFIXES = ["/uploads/", "/api/", "/assets/"];
+
+function shouldReturn404ForStaticMiss(url: string): boolean {
+  return STATIC_404_PREFIXES.some((p) => url.startsWith(p));
+}
+
 export function serveStatic(app: Express) {
   const distPath = path.resolve(__dirname, "public");
   if (!fs.existsSync(distPath)) {
@@ -23,8 +36,13 @@ export function serveStatic(app: Express) {
 
   // SPA catch-all with meta tag injection
   app.use("/{*path}", async (req, res) => {
+    if (shouldReturn404ForStaticMiss(req.originalUrl)) {
+      return res.status(404).end();
+    }
     const meta = await resolveMetaTags(req.originalUrl);
     const html = injectMetaTags(templateHtml, meta);
     res.status(200).set({ "Content-Type": "text/html" }).end(html);
   });
 }
+
+export const __testing = { shouldReturn404ForStaticMiss, STATIC_404_PREFIXES };

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -35,6 +35,13 @@ export async function setupVite(server: Server, app: Express) {
   app.use("/{*path}", async (req, res, next) => {
     const url = req.originalUrl;
 
+    // Same guard as production: missing /uploads/*, /api/*, /assets/* must
+    // 404, never fall through to the SPA. See server/static.ts for the
+    // longer note. (#567)
+    if (url.startsWith("/uploads/") || url.startsWith("/api/") || url.startsWith("/assets/")) {
+      return res.status(404).end();
+    }
+
     try {
       const clientTemplate = path.resolve(
         import.meta.dirname,

--- a/shared/artwork-image.ts
+++ b/shared/artwork-image.ts
@@ -1,0 +1,45 @@
+export const ARTWORKS_PREFIX = "/uploads/artworks/";
+
+export const WEBP_WIDTHS = [480, 960, 1440, 2400] as const;
+export const JPEG_WIDTHS = [960, 2400] as const;
+
+export const ARTWORK_SIZES = {
+  hero: "100vw",
+  card: "(max-width: 768px) 50vw, (max-width: 1280px) 33vw, 25vw",
+  detail: "(max-width: 1024px) 100vw, 80vw",
+  thumbnail: "120px",
+} as const;
+
+export interface ArtworkPictureSources {
+  webpSrcSet: string;
+  jpegSrcSet: string;
+  fallbackSrc: string;
+}
+
+function parseArtworkUrl(imageUrl: string): { uuid: string; ext: string } | null {
+  if (!imageUrl.startsWith(ARTWORKS_PREFIX)) return null;
+  const filename = imageUrl.slice(ARTWORKS_PREFIX.length);
+  const dotIdx = filename.lastIndexOf(".");
+  if (dotIdx <= 0) return null;
+  const uuid = filename.slice(0, dotIdx);
+  const ext = filename.slice(dotIdx + 1).toLowerCase();
+  if (uuid.includes("-") && /-\d+$/.test(uuid)) return null; // already a variant
+  return { uuid, ext };
+}
+
+export function getArtworkPictureSources(imageUrl: string): ArtworkPictureSources | null {
+  const parsed = parseArtworkUrl(imageUrl);
+  if (!parsed) return null;
+  const { uuid } = parsed;
+  return {
+    webpSrcSet: WEBP_WIDTHS.map((w) => `${ARTWORKS_PREFIX}${uuid}-${w}.webp ${w}w`).join(", "),
+    jpegSrcSet: JPEG_WIDTHS.map((w) => `${ARTWORKS_PREFIX}${uuid}-${w}.jpg ${w}w`).join(", "),
+    fallbackSrc: `${ARTWORKS_PREFIX}${uuid}-960.jpg`,
+  };
+}
+
+export function getArtworkTextureUrl(imageUrl: string, targetWidth: 960 | 1440 = 1440): string {
+  const parsed = parseArtworkUrl(imageUrl);
+  if (!parsed) return imageUrl;
+  return `${ARTWORKS_PREFIX}${parsed.uuid}-${targetWidth}.webp`;
+}


### PR DESCRIPTION
Two regressions discovered while measuring #566 on staging. Fix is one PR with both because they share testing/deploy coordination.

## Summary

- **LCP preload mismatch.** `server/meta.ts` was emitting `<link rel=preload href=".../uuid.jpg">` (the full-res original from #561) but post-#566 the `<picture>` element renders `.../uuid-1440.webp`. Browser preload-scanned the original, wasted those bytes, then re-fetched the variant when the picture mounted. Load Delay regressed from 712ms (pre-#566) to ~6,000ms (staging). Image-byte savings worked (page transfer ~9MB → 1.2MB), but the headline LCP didn't move.
- **Cache trap.** SPA catch-all served `index.html` for `/uploads/<missing>` requests with 200 status. Combined with `Cache-Control: max-age=2592000` on `/uploads/*` from #555, browsers cached "WebP-but-actually-HTML" responses for 30 days. Hard refresh sometimes didn't bust it.
- **Shared helper.** Extracted the URL-derivation logic from `client/src/lib/artwork-image.ts` to `shared/artwork-image.ts` so both server preload and client `<picture>` import the same source — preload and picture provably select from the same variant URL set.
- **`imagesrcset` preload.** `server/meta.ts` now emits `<link rel=preload imagesrcset="..." imagesizes="100vw" fetchpriority="high">` when the hero is from `/uploads/artworks/`. Single-href fallback preserved for external (Google Photos, etc.) hero URLs.
- **404 guard.** `shouldReturn404ForStaticMiss()` predicate added; SPA catch-alls in both `server/static.ts` (prod) and `server/vite.ts` (dev) return 404 for `/uploads/*`, `/api/*`, `/assets/*` paths instead of falling through to `index.html`.

## Test plan

- [x] `npm run check` clean
- [x] `npm test` — 134 → **141 tests pass** (+7 new)
- [x] `meta.test.ts` updated: `imagesrcset` preload for `/uploads/artworks/*` heroes, single-href fallback for external URLs, attribute-injection escapes intact
- [x] `static-404-guard.test.ts` — 7 cases covering match/no-match for the predicate
- [ ] After merge: re-run Lighthouse on staging — verify Load Delay drops back to < 1s
- [ ] After merge: `curl -i https://staging.vernis9.art/uploads/artworks/nonexistent-uuid-1440.webp` returns **404**
- [ ] After merge: cut release v3.14.0 (bundles #566 + this fix), production deploy

## Production deploy state

Production already has variants backfilled (52 artworks × 6 variants, done 2026-05-02 ~20:00 UTC) on the production VPS volume. Production is still on v3.13.0. When this PR lands and we cut a release:

- Variants are already on disk → no broken-image window for users
- New preload + new picture select the same URL → LCP should improve in lab + field
- 404 guard prevents any future skew from re-creating the cache trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)