### PR TITLE
fix(ui): preserve newlines in artist bio rendering (closes #570)

### DIFF
--- a/client/src/components/maze-gallery-3d.tsx
+++ b/client/src/components/maze-gallery-3d.tsx
@@ -1977,7 +1977,7 @@ export function MazeGallery3D({ artworks, layout = defaultLayout, whiteRoom = fa
               <div className="space-y-6 py-4">
                 <div>
                   <h4 className="font-semibold mb-2">About</h4>
-                  <p className="text-sm text-muted-foreground leading-relaxed">
+                  <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
                     {artist.bio}
                   </p>
                 </div>

--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -1360,7 +1360,7 @@ export default function ArtistDashboard() {
                       </p>
                     )}
                     {profileForm.bio ? (
-                      <p className="text-sm leading-relaxed" data-testid="text-profile-bio">{profileForm.bio}</p>
+                      <p className="text-sm leading-relaxed whitespace-pre-wrap" data-testid="text-profile-bio">{profileForm.bio}</p>
                     ) : (
                       <p className="text-sm text-muted-foreground italic">No bio added yet</p>
                     )}

--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -181,7 +181,7 @@ export default function ArtistProfile() {
                     </Badge>
                   )}
                 </div>
-                <p className="text-muted-foreground leading-relaxed">{artist.bio}</p>
+                <p className="text-muted-foreground leading-relaxed whitespace-pre-wrap">{artist.bio}</p>
                 {artist.socialLinks && Object.values(artist.socialLinks as Record<string, string>).some(Boolean) && (
                   <div className="flex flex-wrap items-center gap-2 mt-3" data-testid="social-links">
                     {Object.entries(artist.socialLinks as Record<string, string>).map(([key, url]) => {

--- a/client/src/pages/artists.tsx
+++ b/client/src/pages/artists.tsx
@@ -189,7 +189,7 @@ export default function Artists() {
                 <div className="space-y-6 py-4">
                   <div>
                     <h4 className="font-semibold mb-2">About</h4>
-                    <p className="text-sm text-muted-foreground leading-relaxed">
+                    <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
                       {selectedArtist.bio}
                     </p>
                   </div>

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -391,7 +391,7 @@ export default function Gallery() {
                     {currentArtwork.artist.bio && (
                       <div className="pt-4 border-t">
                         <h4 className="font-serif font-semibold mb-2">About the Artist</h4>
-                        <p className="text-sm text-muted-foreground leading-relaxed">{currentArtwork.artist.bio}</p>
+                        <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">{currentArtwork.artist.bio}</p>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

Artist bio is entered in a plain `<Textarea>` so the saved text contains real `\n` newlines and blank lines. Every viewer-side render used `<p>{bio}</p>`, which collapses whitespace by default — so paragraphs the artist intentionally added were invisible to readers.

Fix is one Tailwind class — `whitespace-pre-wrap` — at the five DOM render sites:

- `client/src/pages/artist-profile.tsx` — public profile
- `client/src/pages/artist-dashboard.tsx` — dashboard preview
- `client/src/pages/gallery.tsx` — immersive gallery info panel
- `client/src/pages/artists.tsx` — artist detail dialog (the modal that triggered the bug report)
- `client/src/components/maze-gallery-3d.tsx` — in-maze info dialog

`whitespace-pre-wrap` preserves newlines and blank lines while still wrapping long lines at word boundaries.

## Out of scope

- `artists.tsx` card preview (uses `line-clamp` truncation; adding `whitespace-pre-wrap` would make card heights inconsistent). Card height is controlled by the truncation, not the source text.
- 3D gallery canvas-rendered bio labels in `hallway-gallery-3d.tsx` — canvas text needs explicit `fillText` line-breaking, a separate problem.

## Test plan

- [x] `npm run check` — clean
- [x] Manual dev test: edited bio with multi-paragraph entry; confirmed paragraphs and blank lines preserved on public profile, dashboard preview, immersive-gallery info panel, AND the artist detail dialog (the one originally reported broken)
- [x] No XSS surface — text remains text; no HTML interpretation
- [x] No backend, schema, or migration change

🤖 Generated with [Claude Code](https://claude.com/claude-code)