### PR TITLE
fix(blog): link artist profile blog cards to /blog/:id (closes #582)

### DIFF
--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -391,41 +391,39 @@ export default function ArtistProfile() {
             ) : publishedPosts.length > 0 ? (
               <div className="space-y-6">
                 {publishedPosts.map((post) => (
-                  <Card 
-                    key={post.id} 
-                    className="overflow-hidden"
+                  <Link
+                    key={post.id}
+                    href={`/blog/${post.id}`}
+                    className="block"
                     data-testid={`card-profile-blog-${post.id}`}
                   >
-                    {post.coverImageUrl && (
-                      <div className="aspect-3/1 overflow-hidden">
-                        <ResponsiveImage
-                          src={post.coverImageUrl}
-                          alt={post.title}
-                          sizes={BLOG_SIZES.listCard}
-                          loading="lazy"
-                          decoding="async"
-                          className="w-full h-full object-cover"
-                        />
-                      </div>
-                    )}
-                    <CardHeader>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
-                        <Calendar className="h-4 w-4" />
-                        {formatDate(post.createdAt)}
-                      </div>
-                      <CardTitle className="font-serif text-2xl">{post.title}</CardTitle>
-                      {post.excerpt && (
-                        <CardDescription className="text-base">
-                          {post.excerpt}
-                        </CardDescription>
+                    <Card className="overflow-hidden hover-elevate cursor-pointer">
+                      {post.coverImageUrl && (
+                        <div className="aspect-3/1 overflow-hidden">
+                          <ResponsiveImage
+                            src={post.coverImageUrl}
+                            alt={post.title}
+                            sizes={BLOG_SIZES.listCard}
+                            loading="lazy"
+                            decoding="async"
+                            className="w-full h-full object-cover"
+                          />
+                        </div>
                       )}
-                    </CardHeader>
-                    <CardContent>
-                      <div className="prose prose-sm dark:prose-invert max-w-none">
-                        <p className="whitespace-pre-wrap">{post.content}</p>
-                      </div>
-                    </CardContent>
-                  </Card>
+                      <CardHeader>
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
+                          <Calendar className="h-4 w-4" />
+                          {formatDate(post.createdAt)}
+                        </div>
+                        <CardTitle className="font-serif text-2xl">{post.title}</CardTitle>
+                        {post.excerpt && (
+                          <CardDescription className="text-base">
+                            {post.excerpt}
+                          </CardDescription>
+                        )}
+                      </CardHeader>
+                    </Card>
+                  </Link>
                 ))}
               </div>
             ) : (

--- a/specs/features/blog/CHANGELOG.md
+++ b/specs/features/blog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Blog — Changelog
 
+## 2026-05-04 — Artist profile Blog tab links to detail page (#582)
+
+- Each blog card on `/artists/:slug` Blog tab is now wrapped in `<Link href="/blog/:id">` (previously plain text title with full body inline → no path to the detail page or its share buttons).
+- Dropped the inline `<p>{post.content}</p>` from the artist tab — the tab is now a teaser list (cover + title + excerpt + date). Detail page is the single source of truth for full post + share. Side benefit: removes a duplicate-content SEO penalty (same body was rendered on both `/artists/:slug` and `/blog/:id`).
+
 ## 2026-02 (Initial)
 - Blog list page (`/blog`) with 3-column grid
 - Post detail page (`/blog/:id`) with cover image and artist link

--- a/specs/features/blog/SPEC.md
+++ b/specs/features/blog/SPEC.md
@@ -23,7 +23,7 @@ As an artist, I want to write and publish blog posts, so that I can share my tho
 - [x] Draft posts hidden from public `/blog` but visible in dashboard
 - [x] Cover images optional (fallback icon if missing)
 - [x] `updatedAt` auto-set on edits
-- [x] Artist profile blog tab shows only published posts
+- [x] Artist profile blog tab shows only published posts (teaser cards: cover + title + excerpt + date) and each card links to `/blog/:id` for the full content + share
 
 ## Technical Design
 


### PR DESCRIPTION
## Summary

- Wraps each blog `<Card>` on `/artists/:slug` Blog tab in `<Link href="/blog/:id">` so readers can reach the per-post detail page (and the share buttons that live there per #569).
- Drops the inline full-body render; the tab is now a teaser list (cover + title + excerpt + date), matching the `/blog` list pattern.
- Side benefit: removes a duplicate-content SEO penalty (same body was on both `/artists/:slug` and `/blog/:id`).
- Spec + changelog updated.

Closes #582. Follow-up to #569.

## Test plan

- [x] `npm run check` passes
- [x] Manual dev test: artist profile → Blog tab → click card → lands on `/blog/<id>`; teaser layout looks correct; hover state present — confirmed by user
- [ ] CI green (lint + types + tests + build + docker)
- [ ] Staging deploys cleanly and the same scenario works on `https://staging.vernis9.art`

🤖 Generated with [Claude Code](https://claude.com/claude-code)