### PR TITLE
fix(blog): blog post back button returns to actual referrer (closes #586)

### DIFF
--- a/client/src/pages/blog-post.tsx
+++ b/client/src/pages/blog-post.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
@@ -11,9 +11,24 @@ import { ShareButtons } from "@/components/share-buttons";
 import { getCanonicalShareUrl } from "@/lib/share-urls";
 
 export default function BlogPost({ params }: { params: { id: string } }) {
+  const [, setLocation] = useLocation();
   const { data: post, isLoading } = useQuery<BlogPostWithArtist>({
     queryKey: [`/api/blog/${params.id}`],
   });
+
+  // Smart back: walk one step up the session history when the user has any
+  // prior entry (any in-SPA navigation grows history.length via pushState),
+  // so they return to the artist profile / /blog list / search / wherever
+  // they came from. Cold landings (shared link, bookmark, search engine, new
+  // tab) have history.length === 1 and fall back to the global /blog index.
+  // (document.referrer is not reliable here — SPA navigation never updates it.)
+  const handleBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      window.history.back();
+    } else {
+      setLocation("/blog");
+    }
+  };
 
   if (isLoading) {
     return (
@@ -46,11 +61,9 @@ export default function BlogPost({ params }: { params: { id: string } }) {
   return (
     <div className="min-h-screen p-6 max-w-3xl mx-auto space-y-6">
       <Helmet><title>{`${post.title} — Vernis9 Blog`}</title></Helmet>
-      <Button asChild variant="ghost" size="sm">
-        <Link href="/blog">
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Blog
-        </Link>
+      <Button variant="ghost" size="sm" onClick={handleBack}>
+        <ArrowLeft className="h-4 w-4 mr-2" />
+        Back
       </Button>
 
       {post.coverImageUrl && (

--- a/specs/features/blog/CHANGELOG.md
+++ b/specs/features/blog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Blog — Changelog
 
+## 2026-05-04 — Blog post back button returns to actual referrer (#586)
+
+- `/blog/:id` "Back to Blog" hardcoded `<Link href="/blog">` replaced with a smart back handler. Label is now neutral `"Back"`. Behavior: walk one step up `window.history` when there is any prior session entry (so the user returns to the artist profile / `/blog` list / search / wherever they came from inside the SPA); fall back to navigating to `/blog` only on cold landings (`history.length === 1` — shared link, bookmark, search engine, new tab).
+- `document.referrer` was considered first but is unreliable for SPA navigation (wouter uses `pushState` — `referrer` only updates on full page loads).
+
 ## 2026-05-04 — Artist profile Blog tab links to detail page (#582)
 
 - Each blog card on `/artists/:slug` Blog tab is now wrapped in `<Link href="/blog/:id">` (previously plain text title with full body inline → no path to the detail page or its share buttons).


### PR DESCRIPTION
## Summary

- `/blog/:id` "Back to Blog" replaced with smart back. Label is now neutral `"Back"`.
- Behavior: `window.history.back()` when there's any prior session entry (in-SPA navigation grows the count via `pushState`); fall back to `/blog` only on cold landings (`history.length === 1`).
- `document.referrer` was tried first but is unreliable for SPA navigation — wouter uses `pushState`, so it only reflects the page load, not in-SPA paths. User confirmed the referrer-based version did not work; the history-length version does.

Closes #586. Follow-up to #582.

## Test plan

- [x] `npm run check` passes
- [x] Manual dev test: artist profile → Blog tab → click post → Back returns to artist profile (Blog tab still active); cold-tab open of /blog/:id → Back falls back to /blog — confirmed by user
- [ ] CI green (lint + types + tests + build + docker)
- [ ] Staging deploys cleanly and same scenario works on `https://staging.vernis9.art`

🤖 Generated with [Claude Code](https://claude.com/claude-code)