### PR TITLE
fix(docker): clean hadolint DL3008 ignore directive (unblocks #577 deploy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ ENV APP_VERSION=$APP_VERSION
 # fontconfig is required for sharp's SVG-text rendering (librsvg uses it to
 # resolve font-family -> file). Bundled brand fonts (Playfair Display, Inter)
 # are installed system-wide so OG card composition produces brand-correct text.
-# hadolint ignore=DL3008 — fontconfig version doesn't matter for our use; pinning
-# would just break on base-image bumps without buying anything.
+# Version pin skipped intentionally: fontconfig is a build-time helper for
+# fc-cache; pinning would just break on Debian package shifts across base-
+# image bumps without any safety benefit. The directive line below must
+# stay clean (no trailing prose) for hadolint to recognise it.
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends fontconfig \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hadolint requires the directive line to be clean. PR #588 had explanatory prose on the same line as the directive, so it was treated as a regular comment and the warning still failed Security gate on main.

This splits the rationale into a preceding comment block. Should let CI go green and unblock staging auto-deploy.