### PR TITLE
fix(gallery): default to 2D and unify view-toggle UI (closes #576)

### DIFF
--- a/client/src/components/view-mode-toggle.tsx
+++ b/client/src/components/view-mode-toggle.tsx
@@ -1,0 +1,27 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Box, Frame } from "lucide-react";
+
+export type ViewMode = "3d" | "classic";
+
+interface ViewModeToggleProps {
+  value: ViewMode;
+  onValueChange: (value: ViewMode) => void;
+  className?: string;
+}
+
+export function ViewModeToggle({ value, onValueChange, className }: ViewModeToggleProps) {
+  return (
+    <Tabs value={value} onValueChange={(v) => onValueChange(v as ViewMode)} className={className}>
+      <TabsList>
+        <TabsTrigger value="classic" className="gap-1" data-testid="tab-2d-view">
+          <Frame className="h-4 w-4" />
+          2D
+        </TabsTrigger>
+        <TabsTrigger value="3d" className="gap-1" data-testid="tab-3d-view">
+          <Box className="h-4 w-4" />
+          3D
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -32,7 +32,9 @@ import { FaLinkedin } from "react-icons/fa6";
 import { useCartStore } from "@/lib/cart-store";
 import { formatPrice } from "@/lib/utils";
 import { MazeGallery3D } from "@/components/maze-gallery-3d";
+import { ArtworkCard } from "@/components/artwork-card";
 import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
+import { ViewModeToggle, type ViewMode } from "@/components/view-mode-toggle";
 import type { Artist, ArtworkWithArtist, BlogPostWithArtist, MazeLayout } from "@shared/schema";
 
 interface GalleryData {
@@ -69,6 +71,8 @@ export default function ArtistProfile() {
       ? "portfolio"
       : "gallery";
   const [activeTab, setActiveTab] = useState(initialTab);
+  const initialViewMode: ViewMode = initialQuery.get("view") === "3d" ? "3d" : "classic";
+  const [galleryViewMode, setGalleryViewMode] = useState<ViewMode>(initialViewMode);
   const { isImmersive, toggleImmersive } = useImmersiveMode();
 
   const { data: artistPayload, isLoading: artistLoading } = useQuery<{ artist: Artist }>({
@@ -267,17 +271,37 @@ export default function ArtistProfile() {
             {galleryLoading ? (
               <Skeleton className="h-[500px] rounded-md" />
             ) : galleryArtworks.length > 0 && galleryLayout ? (
-              <div data-testid="artist-gallery-3d">
-                <MazeGallery3D
-                  artworks={galleryArtworks}
-                  layout={galleryLayout}
-                  galleryTemplate={artist.galleryTemplate || "contemporary"}
-                  artist={artist}
-                  onExitGallery={() => setActiveTab("portfolio")}
-                  isImmersive={isImmersive}
-                  onRequestImmersive={toggleImmersive}
-                />
-              </div>
+              <>
+                <div className="flex justify-end">
+                  <ViewModeToggle value={galleryViewMode} onValueChange={setGalleryViewMode} />
+                </div>
+                {galleryViewMode === "3d" ? (
+                  <div data-testid="artist-gallery-3d">
+                    <MazeGallery3D
+                      artworks={galleryArtworks}
+                      layout={galleryLayout}
+                      galleryTemplate={artist.galleryTemplate || "contemporary"}
+                      artist={artist}
+                      onExitGallery={() => setActiveTab("portfolio")}
+                      isImmersive={isImmersive}
+                      onRequestImmersive={toggleImmersive}
+                    />
+                  </div>
+                ) : (
+                  <div
+                    className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4"
+                    data-testid="artist-gallery-2d"
+                  >
+                    {galleryArtworks.map((artwork) => (
+                      <ArtworkCard
+                        key={artwork.id}
+                        artwork={artwork}
+                        onViewDetails={() => setSelectedArtwork(artwork)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
             ) : (
               <div className="text-center py-16">
                 <Box className="h-12 w-12 mx-auto text-muted-foreground mb-4" />

--- a/client/src/pages/curator-gallery.tsx
+++ b/client/src/pages/curator-gallery.tsx
@@ -6,22 +6,24 @@ import { ArtworkCard } from "@/components/artwork-card";
 import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Box, X, Frame } from "lucide-react";
+import { Box, X } from "lucide-react";
 import { useImmersiveMode } from "@/hooks/use-immersive-mode";
 import { ShareButtons } from "@/components/share-buttons";
 import { getCanonicalShareUrl } from "@/lib/share-urls";
 import { useArtworkModalFromQuery } from "@/hooks/use-modal-from-query";
+import { ViewModeToggle, type ViewMode } from "@/components/view-mode-toggle";
 import type { ArtworkWithArtist, CuratorGalleryWithArtworks, MazeLayout } from "@shared/schema";
-
-type ViewMode = "3d" | "classic";
 
 export default function CuratorGalleryPage() {
   const [, params] = useRoute("/curator-gallery/:id");
   const galleryId = params?.id;
   const { isImmersive, toggleImmersive } = useImmersiveMode();
-  const isMobile = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
-  const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? "classic" : "3d");
+  const initialView: ViewMode = (() => {
+    if (typeof window === "undefined") return "classic";
+    const requested = new URLSearchParams(window.location.search).get("view");
+    return requested === "3d" ? "3d" : "classic";
+  })();
+  const [viewMode, setViewMode] = useState<ViewMode>(initialView);
   const [selectedArtwork, setSelectedArtwork] = useState<ArtworkWithArtist | null>(null);
 
   const { data: gallery, isLoading, error } = useQuery<CuratorGalleryWithArtworks>({
@@ -103,12 +105,7 @@ export default function CuratorGalleryPage() {
               imageUrl={gallery.artworks[0]?.imageUrl}
             />
             {gallery.artworks.length > 0 && layout && (
-              <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)}>
-                <TabsList>
-                  <TabsTrigger value="3d"><Box className="h-4 w-4 mr-1" /> 3D</TabsTrigger>
-                  <TabsTrigger value="classic"><Frame className="h-4 w-4 mr-1" /> 2D</TabsTrigger>
-                </TabsList>
-              </Tabs>
+              <ViewModeToggle value={viewMode} onValueChange={setViewMode} />
             )}
           </div>
         </div>

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -6,7 +6,6 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   ChevronLeft,
   ChevronRight,
@@ -17,7 +16,6 @@ import {
   ShoppingCart,
   X,
   Box,
-  Frame,
 } from "lucide-react";
 import { useImmersiveMode } from "@/hooks/use-immersive-mode";
 import type { ArtworkWithArtist } from "@shared/schema";
@@ -29,8 +27,7 @@ import { useToast } from "@/hooks/use-toast";
 import { HallwayGallery3D } from "@/components/hallway-gallery-3d";
 import { ArtworkDetailDialog } from "@/components/artwork-detail-dialog";
 import { useArtworkModalFromQuery } from "@/hooks/use-modal-from-query";
-
-type ViewMode = "3d" | "classic";
+import { ViewModeToggle, type ViewMode } from "@/components/view-mode-toggle";
 
 interface ArtistRoom {
   artist: { id: string; name: string; avatarUrl: string | null; specialization: string | null };
@@ -38,10 +35,12 @@ interface ArtistRoom {
 }
 
 export default function Gallery() {
-  const isMobile = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
-  const searchParams = new URLSearchParams(window.location.search);
-  const requestedView = searchParams.get("view");
-  const [viewMode, setViewMode] = useState<ViewMode>(requestedView === "classic" ? "classic" : isMobile ? "classic" : "3d");
+  const initialView: ViewMode = (() => {
+    if (typeof window === "undefined") return "classic";
+    const requested = new URLSearchParams(window.location.search).get("view");
+    return requested === "3d" ? "3d" : "classic";
+  })();
+  const [viewMode, setViewMode] = useState<ViewMode>(initialView);
   const { isImmersive, toggleImmersive } = useImmersiveMode();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [zoom, setZoom] = useState(1);
@@ -197,18 +196,7 @@ export default function Gallery() {
           </p>
         </div>
         <div className="flex items-center gap-4">
-          <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)}>
-            <TabsList>
-              <TabsTrigger value="3d" className="gap-2" data-testid="tab-3d-view">
-                <Box className="h-4 w-4" />
-                <span className="hidden sm:inline">3D Museum</span>
-              </TabsTrigger>
-              <TabsTrigger value="classic" className="gap-2" data-testid="tab-classic-view">
-                <Frame className="h-4 w-4" />
-                <span className="hidden sm:inline">Classic</span>
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <ViewModeToggle value={viewMode} onValueChange={setViewMode} />
           {viewMode === "classic" && (
             <Button
               variant="ghost"


### PR DESCRIPTION
## Summary
- 2D is now the default view across museum gallery, curated exhibitions, and artist exhibitions (desktop + mobile)
- New shared `ViewModeToggle` component (`[Frame] 2D` / `[Box] 3D`) replaces the inline Tabs on every surface — labels, icons, and order are now consistent
- Artist profile's Gallery tab gains a 2D `ArtworkCard` grid (was 3D-only). Clicking opens the existing artwork detail dialog.
- Existing museum-gallery 2D carousel UX is preserved — only the label/default changed
- All three pages honor `?view=3d` for deep-linking into 3D

Closes #576.

## Test plan
- [x] `npm run check` clean
- [x] Local dev: `/gallery`, `/curator-gallery/<id>`, and `/artists/<slug>` all land in 2D
- [x] Toggle switches to 3D on each surface
- [x] `?view=3d` deep-links into 3D view on all three pages
- [x] Artist gallery 2D grid → ArtworkCard click opens detail dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)