### PR TITLE
fix(ci): trivyignore 5 new Go stdlib CVEs in drizzle-kit esbuild (closes #612)

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -8,7 +8,7 @@
 # affects every copy of the vulnerable library in the image. Every entry
 # MUST have a `statement` and `expired_at` so review is forced.
 #
-# Last reviewed: 2026-04-23 (issue #540)
+# Last reviewed: 2026-05-13 (issue #612)
 
 vulnerabilities:
   # ─── npm bundled dependencies (node:25-bookworm-slim) ───────────
@@ -116,4 +116,44 @@ vulnerabilities:
     paths:
       - "app/node_modules/drizzle-kit/node_modules/@esbuild/linux-x64/bin/esbuild"
     statement: "Not runtime-reachable: drizzle-kit internal build tool, no TLS surface. Fix requires drizzle-kit to bump esbuild >= 0.26."
+    expired_at: 2026-10-23
+
+  # ─── NEW: Go 1.23.12 stdlib batch in drizzle-kit esbuild (issue #612) ─
+  # Five HIGH CVEs disclosed against Go 1.23.12 between 2026-04-23 and
+  # 2026-05-13, all flagged on the same drizzle-kit-bundled esbuild
+  # binary. Same reachability argument as the #540 entries above: this
+  # binary is invoked only at build / migration time, has no inbound
+  # network surface, parses no attacker-controlled email/DNS/HTTP input,
+  # and runs only on Linux. Suppressions are path-scoped, time-boxed,
+  # and revisited together with the #540 batch when drizzle-kit bumps
+  # esbuild >= 0.26.
+
+  - id: CVE-2026-33811
+    paths:
+      - "app/node_modules/drizzle-kit/node_modules/@esbuild/linux-x64/bin/esbuild"
+    statement: "Not runtime-reachable: drizzle-kit internal build tool, no DNS surface. Fix requires drizzle-kit to bump esbuild >= 0.26."
+    expired_at: 2026-10-23
+
+  - id: CVE-2026-33814
+    paths:
+      - "app/node_modules/drizzle-kit/node_modules/@esbuild/linux-x64/bin/esbuild"
+    statement: "Not runtime-reachable: drizzle-kit internal build tool, no HTTP/2 surface. Fix requires drizzle-kit to bump esbuild >= 0.26."
+    expired_at: 2026-10-23
+
+  - id: CVE-2026-39820
+    paths:
+      - "app/node_modules/drizzle-kit/node_modules/@esbuild/linux-x64/bin/esbuild"
+    statement: "Not runtime-reachable: drizzle-kit internal build tool, no mail-parser surface. Fix requires drizzle-kit to bump esbuild >= 0.26."
+    expired_at: 2026-10-23
+
+  - id: CVE-2026-39836
+    paths:
+      - "app/node_modules/drizzle-kit/node_modules/@esbuild/linux-x64/bin/esbuild"
+    statement: "Not runtime-reachable: Linux-only image (Windows-specific Dial/LookupPort panic) and drizzle-kit internal build tool has no attacker-controlled hostname input. Fix requires drizzle-kit to bump esbuild >= 0.26."
+    expired_at: 2026-10-23
+
+  - id: CVE-2026-42499
+    paths:
+      - "app/node_modules/drizzle-kit/node_modules/@esbuild/linux-x64/bin/esbuild"
+    statement: "Not runtime-reachable: drizzle-kit internal build tool, no mail-parser surface. Fix requires drizzle-kit to bump esbuild >= 0.26."
     expired_at: 2026-10-23


### PR DESCRIPTION
## Summary
- Trivy started failing post-merge on `main` (2026-05-13) on 5 newly-disclosed HIGH Go stdlib CVEs flagged against `drizzle-kit`'s bundled esbuild binary. Same pattern as resolved #540.
- Adds 5 path-scoped entries to `.trivyignore.yaml` covering CVE-2026-33811, -33814, -39820, -39836, -42499.
- Each entry has a per-CVE `statement` explaining why the surface (DNS / HTTP/2 / mail-parser / Windows-only / mail-parser) is not reachable from this binary.
- All entries `expired_at: 2026-10-23` to force a co-located review with the #540 batch.
- Updates "Last reviewed" header from `2026-04-23 (issue #540)` to `2026-05-13 (issue #612)`.

Closes #612 · refs #540

## Test plan
- [x] YAML parses (`python3 -c "yaml.safe_load(...)"`)
- [x] All 5 CVE IDs present in the parsed list
- [ ] Post-merge `Trivy Container Scan` job exits 0
- [ ] Post-merge `Deploy to Staging` no longer skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)