### PR TITLE
fix(artist-profile): wrap specialization badge instead of truncating (closes #609)

### DIFF
--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -197,9 +197,12 @@ export default function ArtistProfile() {
                     </span>
                   )}
                   {artist.specialization && (
-                    <Badge variant="outline">
-                      <Palette className="h-3 w-3 mr-1" />
-                      {artist.specialization}
+                    <Badge
+                      variant="outline"
+                      className="max-w-full whitespace-normal items-start text-left"
+                    >
+                      <Palette className="h-3 w-3 mr-1 mt-0.5 shrink-0" />
+                      <span>{artist.specialization}</span>
                     </Badge>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Follow-up to #611. The truncation pattern is right for the **listing card** (compact tag, multiple cards per row) but wrong for the **artist profile header** — the full specialization should be readable there.
- Profile-page badge: override `whitespace-nowrap` with `whitespace-normal`, pin the icon top-left (`items-start` + `mt-0.5` on the icon), keep `max-w-full` so it stays inside the card on narrow viewports.
- Listing card behaviour from #611 is unchanged.

Closes #609

## Why two different treatments
- Listing card: tight horizontal budget (4 cards per row on desktop, 2 on tablet, 1 on mobile). A multi-line badge would push the card height out of grid alignment. Truncation + word-boundary + `title` tooltip is the right trade.
- Profile header: single artist, plenty of vertical room. Hiding info behind a tooltip on mobile (which doesn't fire on tap) was the wrong call — full visibility wins.

## Test plan
- [x] `npm run check` passes
- [x] Local dev, mobile viewport (~375px): long specialization wraps inside the badge, stays inside the card, icon top-left aligned with first line
- [x] Local dev, desktop: short specialization renders as a normal single-line tag inline with country
- [ ] Staging smoke after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)