### PR TITLE
docs(specs): user-role workflow diagrams (closes #620)

### DIFF
--- a/specs/architecture/OVERVIEW.md
+++ b/specs/architecture/OVERVIEW.md
@@ -364,6 +364,16 @@ Implemented in `server/replit_integrations/auth/`.
 - HttpOnly/Secure/SameSite=Lax cookies
 - User lookup by stable email key with upsert-on-conflict
 
+### User Roles & Workflows
+
+Three explicit roles (`USER_ROLES` in `shared/models/auth.ts`: `user`, `curator`, `admin`) plus the implicit unauthenticated **visitor**. Mermaid workflow diagrams for each role live in [`workflows/`](./workflows/README.md):
+
+- [Visitor](./workflows/visitor.md) — browse, cart, checkout
+- [Artist](./workflows/artist.md) (`role=user`) — upload, exhibit, sell, fulfill
+- [Curator](./workflows/curator.md) (`role=curator`) — assemble curated galleries across artists
+- [Admin](./workflows/admin.md) (`role=admin`) — user/role management, content moderation, settings
+- [Order lifecycle](./workflows/order-lifecycle.md) — shared state machine
+
 ---
 
 ## 8. MCP Server

--- a/specs/architecture/workflows/README.md
+++ b/specs/architecture/workflows/README.md
@@ -1,0 +1,28 @@
+# User Role Workflows
+
+**Status:** Active
+**Last Updated:** 2026-05-19
+**Owner:** Architecture
+
+Mermaid workflow diagrams for each user role on the ArtVerse platform. Roles map to `USER_ROLES` in `shared/models/auth.ts` (`user`, `curator`, `admin`); the **visitor** role is implicit (unauthenticated public access).
+
+## Diagrams
+
+| Role | Description | File |
+|------|-------------|------|
+| Visitor | Unauthenticated public browsing, cart, checkout | [visitor.md](./visitor.md) |
+| Artist | `role=user` with an artist profile — upload, exhibit, sell, fulfill | [artist.md](./artist.md) |
+| Curator | `role=curator` — assemble curated galleries from exhibition-ready artworks | [curator.md](./curator.md) |
+| Admin | `role=admin` — user/role management, content moderation, settings | [admin.md](./admin.md) |
+
+## Cross-cutting
+
+| Topic | Description | File |
+|-------|-------------|------|
+| Order lifecycle | State machine shared by visitor checkout and artist fulfillment | [order-lifecycle.md](./order-lifecycle.md) |
+
+## Conventions
+
+- Diagrams use `flowchart TD` for journeys and `stateDiagram-v2` for lifecycles.
+- Each file links to the relevant route handlers (`server/routes.ts`) and pages (`client/src/pages/`) so the diagram and code stay traceable.
+- Update the diagram in the same PR as the role/route change that affects it. The Documentation Agent (`specs/DOC-AGENT-SPEC.md`) enforces this.

--- a/specs/architecture/workflows/admin.md
+++ b/specs/architecture/workflows/admin.md
@@ -1,0 +1,51 @@
+# Admin Workflow
+
+**Status:** Active
+**Last Updated:** 2026-05-19
+**Owner:** Architecture
+
+An admin is an authenticated user with `role=admin`. Admins have platform-wide control: manage users and roles, moderate content, configure site-wide settings, and inspect logs. There is no self-service signup for admins — roles are assigned by another admin.
+
+## Journey
+
+```mermaid
+flowchart TD
+    A[Sign in as admin] --> B[Admin panel /admin]
+    B --> C{What to do?}
+
+    C -->|Users| D[List all users]
+    D --> D1[Assign role:<br/>user / curator / admin]
+    D --> D2[Delete user →<br/>cascades to<br/>artist profile]
+
+    C -->|Artworks| E[Browse all artworks<br/>across artists]
+    E --> E1[Delete inappropriate<br/>artwork]
+
+    C -->|Blog| F[List all blog posts]
+    F --> F1[Delete posts]
+
+    C -->|Exhibitions| G[List exhibitions<br/>API only — no UI]
+    G --> G1[Delete<br/>creation via MCP]
+
+    C -->|Settings| H[Site settings]
+    H --> H1[Default gallery<br/>template:<br/>contemporary,<br/>minimalist, etc.]
+
+    C -->|Logs| I[Structured log viewer]
+    I --> I1[Filter by level,<br/>module, time<br/>full-text search]
+
+    C -->|Newsletter| J[Subscriber list]
+    J --> J1[Unsubscribe users]
+```
+
+## Key entry points
+
+- Admin page: `client/src/pages/admin.tsx`
+- Routes: `server/routes.ts` — `/api/admin/*` guarded by `isAdmin` middleware
+- User role updates: cascade nothing beyond the role column; user-deletion cascades to the artist profile
+- Logs: streaming view backed by the structured logger (`server/index.ts` integration)
+- MCP exhibition creation: `server/mcp.ts` exposes exhibition tools (admin path)
+
+## Authorization
+
+- Only `isAdmin` is permitted on `/api/admin/*` and the `/admin` UI route.
+- Admins are **not** automatically artists. To upload artwork as an admin, a separate artist profile would be required — but the platform treats admin actions as moderation, not authoring.
+- There is no audit log of admin actions today; structured logs capture the requests but not a curated history. Consider an ADR if this becomes a compliance requirement.

--- a/specs/architecture/workflows/artist.md
+++ b/specs/architecture/workflows/artist.md
@@ -1,0 +1,62 @@
+# Artist Workflow
+
+**Status:** Active
+**Last Updated:** 2026-05-19
+**Owner:** Architecture
+
+An artist is an authenticated user with `role=user` and an associated record in the `artists` table. Artist profiles are auto-created on first login. Artists upload, exhibit, and sell their own artworks, and fulfill incoming orders.
+
+## Journey
+
+```mermaid
+flowchart TD
+    A[Sign in:<br/>Google OIDC or<br/>email/password] --> B[User + artist<br/>auto-created on<br/>first login]
+    B --> C[Artist dashboard]
+
+    C --> D{What to do?}
+
+    D -->|Profile| E[Edit profile:<br/>avatar, bio, country,<br/>specialization, socials]
+
+    D -->|Artwork| F[Upload artwork]
+    F --> F1[Set title, medium,<br/>dimensions, price]
+    F1 --> F2[Upload image:<br/>variants generated<br/>server-side]
+    F2 --> F3{Publish?}
+    F3 -->|No| F4[Draft — hidden]
+    F3 -->|Yes| F5[Published —<br/>visible in store]
+    F5 --> F6{Ready for<br/>exhibition?}
+    F6 -->|Yes| F7[Set wall order →<br/>3D maze regenerated]
+    F6 -->|No| F5
+
+    D -->|Auction| G[Start auction:<br/>set reserve + end date]
+    G --> G1[Bids come in]
+    G1 --> G2[Auction ends →<br/>winner notified]
+
+    D -->|Blog| H[Create post:<br/>cover, content, publish]
+    H --> H1[Visible on<br/>artist profile blog]
+
+    D -->|Orders| I[View incoming orders]
+    I --> I1[Transition status:<br/>pending → communicating<br/>→ sending → closed]
+    I1 --> I2[Or cancel at any<br/>non-closed state]
+    I --> J[See order-lifecycle.md]
+
+    D -->|Share| K[Copy public<br/>profile URL]
+```
+
+## Key entry points
+
+- Dashboard: `client/src/pages/artist-dashboard.tsx`
+- Auth: `server/replit_integrations/auth/` (Passport + OIDC + local)
+- Routes: `server/routes.ts` — artwork CRUD, auction creation, order status transitions
+- Storage layer: `server/storage.ts` (`DatabaseStorage`)
+- Image variants: `server/lib/artwork-image.ts`, `script/backfill-artwork-variants.ts`
+- Gallery layout regeneration: triggered when `isReadyForExhibition` toggles on any artwork
+
+## Ownership rules
+
+- Artists may only modify their **own** artworks, auctions, blog posts, and orders. Ownership is checked in route handlers (`server/routes.ts`).
+- Curators (`role=curator`) **cannot** have an artist profile — creating one returns 403 (`server/routes.ts:406`).
+- Artists cannot self-promote to curator or admin — only an admin can change roles.
+
+## Order fulfillment
+
+See [`order-lifecycle.md`](./order-lifecycle.md) for the full state machine. The artist owns the transition from `pending` onward; visitors only create orders in the `pending` state.

--- a/specs/architecture/workflows/curator.md
+++ b/specs/architecture/workflows/curator.md
@@ -1,0 +1,57 @@
+# Curator Workflow
+
+**Status:** Active
+**Last Updated:** 2026-05-19
+**Owner:** Architecture
+
+A curator is an authenticated user with `role=curator`. Curators assemble **curated galleries** from existing exhibition-ready artworks across all artists. They do not own artworks and cannot have an artist profile.
+
+Curators are appointed by an admin. See [ADR-0008](../ADR/) for the RBAC design.
+
+## Journey
+
+```mermaid
+flowchart TD
+    A[Sign in:<br/>email/password or<br/>Google OIDC] --> B[Curator dashboard]
+    B --> C[No artist profile<br/>created — 403 if<br/>attempted]
+
+    B --> D{What to do?}
+
+    D -->|Profile| E[Edit name only<br/>no artist fields]
+
+    D -->|Browse| F[List exhibition-ready<br/>artworks across<br/>all artists]
+    F --> F1[/api/curator/<br/>artworks/available/]
+
+    D -->|Curate| G[Create curated gallery]
+    G --> G1[Set name, description,<br/>start/end dates]
+    G1 --> G2[Add artworks from<br/>available pool]
+    G2 --> G3[Server regenerates<br/>curated maze layout]
+    G3 --> G4{Publish?}
+    G4 -->|No| G5[Draft — hidden]
+    G4 -->|Yes| G6[Public: appears in<br/>hallway under<br/>curated exhibitions]
+
+    D -->|Manage| H[List own curated<br/>galleries]
+    H --> H1[Edit / unpublish /<br/>delete]
+```
+
+## Key entry points
+
+- Routes: `server/routes.ts` — `/api/curator/*` guarded by `isCurator` middleware
+- Available artworks endpoint: `/api/curator/artworks/available` — returns all published artworks marked `isReadyForExhibition=true`
+- Curated gallery storage: persists as records with cross-artist artwork references; layout JSON cached server-side
+- Public surface: curated galleries surface in `client/src/components/hallway-gallery-3d.tsx` alongside artist rooms
+
+## Ownership rules
+
+- Curators may only modify **their own** curated galleries.
+- Curators cannot edit artworks (only artists and admins can).
+- Curators cannot have an artist profile — `POST /api/artists/me` returns 403 for `role=curator` (`server/routes.ts:406`).
+
+## Relationship to artist exhibitions
+
+| Concept | Owner | Scope |
+|---------|-------|-------|
+| Artist exhibition | Artist | Single artist's own artworks in their maze room |
+| Curated gallery | Curator | Selected artworks across many artists in a shared themed maze |
+
+Both are rendered by `components/maze-gallery-3d.tsx` and listed in the main hallway, but the data sources and permission checks are distinct.

--- a/specs/architecture/workflows/order-lifecycle.md
+++ b/specs/architecture/workflows/order-lifecycle.md
@@ -1,0 +1,47 @@
+# Order Lifecycle
+
+**Status:** Active
+**Last Updated:** 2026-05-19
+**Owner:** Architecture
+
+The order status state machine, shared by the visitor checkout path and the artist fulfillment path. Defined in `CLAUDE.md` and enforced by `server/routes.ts`.
+
+## State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending: Visitor places order
+    pending --> communicating: Artist contacts buyer
+    communicating --> sending: Artist ships artwork
+    sending --> closed: Buyer receives / fulfilled
+
+    pending --> canceled: Cancel
+    communicating --> canceled: Cancel
+    sending --> canceled: Cancel
+
+    closed --> [*]
+    canceled --> [*]
+```
+
+## States
+
+| State | Meaning | Who triggers entry |
+|-------|---------|--------------------|
+| `pending` | Order created, awaiting artist outreach | Visitor (checkout) |
+| `communicating` | Artist has begun coordinating delivery with buyer | Artist |
+| `sending` | Artwork has shipped | Artist |
+| `closed` | Fulfilled and finalized | Artist |
+| `canceled` | Aborted at any non-closed state | Artist (or buyer on request) |
+
+## Rules
+
+- `closed` is terminal — no further transitions.
+- `canceled` is reachable from `pending`, `communicating`, or `sending`. Once an order is `closed`, it cannot be canceled.
+- Transitions are linear (no skipping forward): `pending → communicating → sending → closed`. Each step requires the prior step.
+- Status changes are restricted to the **owning artist** and **admins** by route guards in `server/routes.ts`.
+- Buyers (visitors) do not have a UI to transition status — cancellation is handled artist-side after buyer contact.
+
+## Related workflows
+
+- [`visitor.md`](./visitor.md) — how an order enters `pending`.
+- [`artist.md`](./artist.md) — how an artist moves an order through the remaining states.

--- a/specs/architecture/workflows/visitor.md
+++ b/specs/architecture/workflows/visitor.md
@@ -1,0 +1,55 @@
+# Visitor Workflow
+
+**Status:** Active
+**Last Updated:** 2026-05-19
+**Owner:** Architecture
+
+The visitor is an unauthenticated public user. They can browse all published content, build a cart, and check out as a guest. No account required.
+
+## Journey
+
+```mermaid
+flowchart TD
+    A[Land on home page] --> B{What to do?}
+    B -->|Browse| C[Hallway 3D / 2D gallery]
+    B -->|Search| D[Store: filter artworks]
+    B -->|Read| E[Blog posts]
+
+    C --> F[Enter artist room]
+    D --> G[View artwork detail]
+    F --> G
+    E --> H[View artist profile]
+    H --> F
+
+    G --> I{Action?}
+    I -->|Add to cart| J[Cart updated<br/>localStorage via Zustand]
+    I -->|Bid| K{Authenticated?}
+    I -->|Share| L[Share buttons:<br/>copy link, social]
+
+    K -->|No| M[Sign in prompt]
+    K -->|Yes| N[Place bid]
+
+    J --> O[Continue browsing or checkout]
+    O --> P[Checkout page]
+    P --> Q[Enter buyer name,<br/>email, address]
+    Q --> R[Place order]
+    R --> S[Order confirmation email<br/>via Resend]
+    S --> T[Order status: pending]
+```
+
+## Key entry points
+
+- Home: `client/src/pages/home.tsx`
+- Gallery hallway: `client/src/pages/gallery.tsx` → `components/hallway-gallery-3d.tsx`
+- Store: `client/src/pages/store.tsx`
+- Artwork detail: `client/src/pages/artwork-detail.tsx`
+- Artist profile: `client/src/pages/artist-profile.tsx` → `components/maze-gallery-3d.tsx`
+- Blog: `client/src/pages/blog.tsx`, `client/src/pages/blog-post.tsx`
+- Checkout: `client/src/pages/checkout.tsx`
+
+## Notes
+
+- Cart is persisted to `localStorage` (`client/src/lib/cart-store.ts`) — survives navigation and page reloads.
+- Guest checkout is supported: order creation accepts buyer details without an authenticated session.
+- Bidding requires authentication (`isAuthenticated` middleware on `POST /api/auctions/:id/bids`).
+- Sharing artworks generates Open Graph cards server-side; analytics are logged via `share_events` (#503).


### PR DESCRIPTION
## Summary

- New `specs/architecture/workflows/` directory with one mermaid diagram per user role: **visitor**, **artist** (`role=user`), **curator** (`role=curator`), **admin** (`role=admin`).
- Separate **order lifecycle** state diagram (`pending → communicating → sending → closed`, with `canceled` reachable from non-closed states).
- `README.md` indexes the set. `specs/architecture/OVERVIEW.md` §7 cross-links into it.

Closes #620.

## Test plan

- [ ] Diagrams render on GitHub (mermaid is supported in markdown previews)
- [ ] Cross-links from `OVERVIEW.md` resolve
- [ ] No DECISION-LOG entry needed — pure documentation
- [ ] Doc Agent CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)