### PR TITLE
docs(changelog): drop #616 entry from v3.18.0 (no code shipped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ _Nothing yet — all recent work included in v3.18.0 below._
 
 ### Added
 - perf: shrink 744 KB shared initial chunk (#551 P1.3 follow-up) ([#622](https://github.com/ilv78/Art-World-Hub/issues/622))
-- Companion - e-ink display ([#616](https://github.com/ilv78/Art-World-Hub/issues/616))
 
 ## [3.17.1] - 2026-05-13
 


### PR DESCRIPTION
## Summary

The release workflow auto-included #616 ("Companion - e-ink display") in the v3.18.0 CHANGELOG because the issue was labeled `release: next`, but no code for it actually landed in main — it was an issue-only placeholder. The implementation work continues in #617.

Removed the misleading line from CHANGELOG.md so the source of truth matches what's deployed. GitHub Release notes for v3.18.0 already edited separately.

## Test plan

- [x] Docs-only change, no runtime impact
- [ ] After merge: the staging Docker rebuild will bake in the corrected CHANGELOG; production deploy of v3.18.0 should target this commit's SHA so prod also serves the corrected info

🤖 Generated with [Claude Code](https://claude.com/claude-code)