### PR TITLE
feat(ar): Phase 0 — structured artwork dimensions (refs #634)

### DIFF
--- a/client/src/pages/artist-dashboard.tsx
+++ b/client/src/pages/artist-dashboard.tsx
@@ -136,6 +136,9 @@ export default function ArtistDashboard() {
     price: "",
     medium: "",
     dimensions: "",
+    widthCm: "",
+    heightCm: "",
+    dimensionUnit: "cm",
     year: new Date().getFullYear().toString(),
     category: "painting",
     isPublished: false,
@@ -369,6 +372,9 @@ export default function ArtistDashboard() {
       price: "",
       medium: "",
       dimensions: "",
+      widthCm: "",
+      heightCm: "",
+      dimensionUnit: "cm",
       year: new Date().getFullYear().toString(),
       category: "painting",
       isPublished: false,
@@ -399,6 +405,9 @@ export default function ArtistDashboard() {
       price: artworkForm.price,
       medium: artworkForm.medium || "",
       dimensions: artworkForm.dimensions || null,
+      widthCm: artworkForm.widthCm.trim() ? artworkForm.widthCm.trim() : null,
+      heightCm: artworkForm.heightCm.trim() ? artworkForm.heightCm.trim() : null,
+      dimensionUnit: artworkForm.dimensionUnit || "cm",
       year: artworkForm.year ? parseInt(artworkForm.year) : null,
       category: artworkForm.category || "painting",
       isPublished: artworkForm.isPublished,
@@ -442,6 +451,9 @@ export default function ArtistDashboard() {
       price: artwork.price,
       medium: artwork.medium || "",
       dimensions: artwork.dimensions || "",
+      widthCm: artwork.widthCm?.toString() || "",
+      heightCm: artwork.heightCm?.toString() || "",
+      dimensionUnit: artwork.dimensionUnit || "cm",
       year: artwork.year?.toString() || "",
       category: artwork.category || "painting",
       isPublished: artwork.isPublished ?? false,
@@ -803,7 +815,7 @@ export default function ArtistDashboard() {
                       />
                     </div>
                     <div className="grid gap-2">
-                      <Label htmlFor="dimensions">Dimensions (cm)</Label>
+                      <Label htmlFor="dimensions">Dimensions (label)</Label>
                       <Input
                         id="dimensions"
                         value={artworkForm.dimensions}
@@ -812,6 +824,44 @@ export default function ArtistDashboard() {
                         data-testid="input-artwork-dimensions"
                       />
                     </div>
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Exact size — enables "View in my room" (AR)</Label>
+                    <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        inputMode="decimal"
+                        value={artworkForm.widthCm}
+                        onChange={(e) => setArtworkForm({ ...artworkForm, widthCm: e.target.value })}
+                        placeholder="Width"
+                        data-testid="input-artwork-width"
+                      />
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        inputMode="decimal"
+                        value={artworkForm.heightCm}
+                        onChange={(e) => setArtworkForm({ ...artworkForm, heightCm: e.target.value })}
+                        placeholder="Height"
+                        data-testid="input-artwork-height"
+                      />
+                      <select
+                        className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                        value={artworkForm.dimensionUnit}
+                        onChange={(e) => setArtworkForm({ ...artworkForm, dimensionUnit: e.target.value })}
+                        data-testid="select-artwork-dimension-unit"
+                      >
+                        <option value="cm">cm</option>
+                        <option value="mm">mm</option>
+                        <option value="in">in</option>
+                      </select>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Used to scale the artwork realistically when a buyer previews it on their wall.
+                    </p>
                   </div>
                   <div className="grid gap-2">
                     <Label htmlFor="description">Description</Label>

--- a/migrations/0013_ar_dimensions.sql
+++ b/migrations/0013_ar_dimensions.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "artworks" ADD COLUMN IF NOT EXISTS "width_cm" numeric(7, 2);--> statement-breakpoint
+ALTER TABLE "artworks" ADD COLUMN IF NOT EXISTS "height_cm" numeric(7, 2);--> statement-breakpoint
+ALTER TABLE "artworks" ADD COLUMN IF NOT EXISTS "dimension_unit" text DEFAULT 'cm';--> statement-breakpoint
+
+-- Backfill structured size from the legacy free-text `dimensions` column (#634).
+-- Matches "<w> [x|×|*] <h>" with optional spaces and an optional unit token,
+-- mirroring shared/dimensions.ts. Only rows still NULL are touched, so this is
+-- safe to re-run. Unit conversion: in -> *2.54, mm -> *0.1, default cm.
+UPDATE "artworks" SET
+  "width_cm" = ROUND(replace((regexp_match(btrim("dimensions"), '^([0-9]+(?:[.,][0-9]+)?)\s*(?:x|×|X|\*|by)\s*([0-9]+(?:[.,][0-9]+)?)\s*(cm|mm|in|inch|inches|"|”)?$', 'i'))[1], ',', '.')::numeric
+                      * CASE lower(coalesce((regexp_match(btrim("dimensions"), '(cm|mm|in|inch|inches|"|”)$', 'i'))[1], 'cm'))
+                          WHEN 'mm' THEN 0.1 WHEN 'in' THEN 2.54 WHEN 'inch' THEN 2.54 WHEN 'inches' THEN 2.54 WHEN '"' THEN 2.54 WHEN '”' THEN 2.54 ELSE 1 END, 2),
+  "height_cm" = ROUND(replace((regexp_match(btrim("dimensions"), '^([0-9]+(?:[.,][0-9]+)?)\s*(?:x|×|X|\*|by)\s*([0-9]+(?:[.,][0-9]+)?)\s*(cm|mm|in|inch|inches|"|”)?$', 'i'))[2], ',', '.')::numeric
+                      * CASE lower(coalesce((regexp_match(btrim("dimensions"), '(cm|mm|in|inch|inches|"|”)$', 'i'))[1], 'cm'))
+                          WHEN 'mm' THEN 0.1 WHEN 'in' THEN 2.54 WHEN 'inch' THEN 2.54 WHEN 'inches' THEN 2.54 WHEN '"' THEN 2.54 WHEN '”' THEN 2.54 ELSE 1 END, 2)
+WHERE "width_cm" IS NULL
+  AND "dimensions" IS NOT NULL
+  AND btrim("dimensions") ~* '^[0-9]+(?:[.,][0-9]+)?\s*(?:x|×|X|\*|by)\s*[0-9]+(?:[.,][0-9]+)?\s*(?:cm|mm|in|inch|inches|"|”)?$';

--- a/migrations/meta/0013_snapshot.json
+++ b/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1287 @@
+{
+  "id": "9310133c-9893-49d3-8d01-9b5e9115648a",
+  "prevId": "01da1ce7-d971-4cc2-b4f3-e9bafa58b1b5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.artist_slug_history": {
+      "name": "artist_slug_history",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_slug_history_artist_id_artists_id_fk": {
+          "name": "artist_slug_history_artist_id_artists_id_fk",
+          "tableFrom": "artist_slug_history",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialization": {
+          "name": "specialization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gallery_layout": {
+          "name": "gallery_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gallery_template": {
+          "name": "gallery_template",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'contemporary'"
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_slug_unique": {
+          "name": "artists_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artworks": {
+      "name": "artworks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medium": {
+          "name": "medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width_cm": {
+          "name": "width_cm",
+          "type": "numeric(7, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_cm": {
+          "name": "height_cm",
+          "type": "numeric(7, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension_unit": {
+          "name": "dimension_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cm'"
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_for_sale": {
+          "name": "is_for_sale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_in_gallery": {
+          "name": "is_in_gallery",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_ready_for_exhibition": {
+          "name": "is_ready_for_exhibition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "exhibition_order": {
+          "name": "exhibition_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artworks_artist_id_artists_id_fk": {
+          "name": "artworks_artist_id_artists_id_fk",
+          "tableFrom": "artworks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artworks_slug_unique": {
+          "name": "artworks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auctions": {
+      "name": "auctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting_price": {
+          "name": "starting_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_bid": {
+          "name": "current_bid",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_increment": {
+          "name": "minimum_increment",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "winner_name": {
+          "name": "winner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auctions_artwork_id_artworks_id_fk": {
+          "name": "auctions_artwork_id_artworks_id_fk",
+          "tableFrom": "auctions",
+          "tableTo": "artworks",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bids": {
+      "name": "bids",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auction_id": {
+          "name": "auction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bidder_name": {
+          "name": "bidder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_auction_id_auctions_id_fk": {
+          "name": "bids_auction_id_auctions_id_fk",
+          "tableFrom": "bids",
+          "tableTo": "auctions",
+          "columnsFrom": [
+            "auction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_posts_artist_id_artists_id_fk": {
+          "name": "blog_posts_artist_id_artists_id_fk",
+          "tableFrom": "blog_posts",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curator_galleries": {
+      "name": "curator_galleries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "curator_id": {
+          "name": "curator_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gallery_layout": {
+          "name": "gallery_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gallery_template": {
+          "name": "gallery_template",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'contemporary'"
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curator_gallery_artworks": {
+      "name": "curator_gallery_artworks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gallery_id": {
+          "name": "gallery_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "curator_gallery_artworks_gallery_id_curator_galleries_id_fk": {
+          "name": "curator_gallery_artworks_gallery_id_curator_galleries_id_fk",
+          "tableFrom": "curator_gallery_artworks",
+          "tableTo": "curator_galleries",
+          "columnsFrom": [
+            "gallery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curator_gallery_artworks_artwork_id_artworks_id_fk": {
+          "name": "curator_gallery_artworks_artwork_id_artworks_id_fk",
+          "tableFrom": "curator_gallery_artworks",
+          "tableTo": "artworks",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exhibition_artworks": {
+      "name": "exhibition_artworks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exhibition_id": {
+          "name": "exhibition_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wall_id": {
+          "name": "wall_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exhibition_artworks_exhibition_id_exhibitions_id_fk": {
+          "name": "exhibition_artworks_exhibition_id_exhibitions_id_fk",
+          "tableFrom": "exhibition_artworks",
+          "tableTo": "exhibitions",
+          "columnsFrom": [
+            "exhibition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exhibition_artworks_artwork_id_artworks_id_fk": {
+          "name": "exhibition_artworks_artwork_id_artworks_id_fk",
+          "tableFrom": "exhibition_artworks",
+          "tableTo": "artworks",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exhibitions": {
+      "name": "exhibitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyer_name": {
+          "name": "buyer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyer_email": {
+          "name": "buyer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_artwork_id_artworks_id_fk": {
+          "name": "orders_artwork_id_artworks_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "artworks",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_events": {
+      "name": "share_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent_class": {
+          "name": "user_agent_class",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_share_events_item": {
+          "name": "IDX_share_events_item",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_share_events_created_at": {
+          "name": "IDX_share_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_share_events_platform": {
+          "name": "IDX_share_events_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "gallery_template": {
+          "name": "gallery_template",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contemporary'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "magic_links_token_unique": {
+          "name": "magic_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_session_expire": {
+          "name": "IDX_session_expire",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777794660670,
       "tag": "0012_add_share_events",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1780249273131,
+      "tag": "0013_ar_dimensions",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/dimensions.test.ts
+++ b/server/__tests__/dimensions.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { parseDimensions } from "@shared/dimensions";
+
+describe("parseDimensions", () => {
+  it("parses plain 'W x H' with spaces", () => {
+    expect(parseDimensions("30 x 21")).toEqual({ widthCm: 30, heightCm: 21, unit: "cm" });
+  });
+
+  it("parses compact 'WxH' without spaces", () => {
+    expect(parseDimensions("30x40")).toEqual({ widthCm: 30, heightCm: 40, unit: "cm" });
+  });
+
+  it("tolerates trailing whitespace (real production data)", () => {
+    expect(parseDimensions("30 x 21 ")).toEqual({ widthCm: 30, heightCm: 21, unit: "cm" });
+    expect(parseDimensions("100 x 100 ")).toEqual({ widthCm: 100, heightCm: 100, unit: "cm" });
+  });
+
+  it("parses large dimensions", () => {
+    expect(parseDimensions("200 x 100")).toEqual({ widthCm: 200, heightCm: 100, unit: "cm" });
+  });
+
+  it("handles the × unicode multiplication sign and 'by'", () => {
+    expect(parseDimensions("40 × 60")).toEqual({ widthCm: 40, heightCm: 60, unit: "cm" });
+    expect(parseDimensions("40 by 60")).toEqual({ widthCm: 40, heightCm: 60, unit: "cm" });
+  });
+
+  it("converts inches to cm", () => {
+    expect(parseDimensions('10 x 20 in')).toEqual({ widthCm: 25.4, heightCm: 50.8, unit: "in" });
+    expect(parseDimensions('10x20"')).toEqual({ widthCm: 25.4, heightCm: 50.8, unit: "in" });
+  });
+
+  it("converts mm to cm", () => {
+    expect(parseDimensions("600 x 800 mm")).toEqual({ widthCm: 60, heightCm: 80, unit: "mm" });
+  });
+
+  it("handles decimal and comma-decimal values", () => {
+    expect(parseDimensions("30.5 x 21")).toEqual({ widthCm: 30.5, heightCm: 21, unit: "cm" });
+    expect(parseDimensions("30,5 x 21")).toEqual({ widthCm: 30.5, heightCm: 21, unit: "cm" });
+  });
+
+  it("returns null for unparseable / empty input", () => {
+    expect(parseDimensions(null)).toBeNull();
+    expect(parseDimensions(undefined)).toBeNull();
+    expect(parseDimensions("")).toBeNull();
+    expect(parseDimensions("medium size")).toBeNull();
+    expect(parseDimensions("30")).toBeNull();
+    expect(parseDimensions("0 x 40")).toBeNull();
+  });
+});

--- a/shared/dimensions.ts
+++ b/shared/dimensions.ts
@@ -1,0 +1,65 @@
+// Parsing of the free-text `artworks.dimensions` string into structured
+// physical size for the AR "View in my room" feature (#634).
+//
+// The legacy `dimensions` column is free-form (e.g. "60 x 80", "30x40",
+// "30 x 21 ", "200 x 100"). AR needs numeric width/height in a known unit to
+// place an artwork at believable scale, so we parse what we can and leave the
+// rest null for the artist to fill in via the dashboard.
+
+export type DimensionUnit = "cm" | "mm" | "in";
+
+export interface ParsedDimensions {
+  widthCm: number;
+  heightCm: number;
+  unit: DimensionUnit;
+}
+
+const UNIT_TO_CM: Record<DimensionUnit, number> = {
+  cm: 1,
+  mm: 0.1,
+  in: 2.54,
+};
+
+// Matches "<num> [x|×|X|*|by] <num>" with optional surrounding whitespace and
+// an optional trailing unit token. Decimals and comma-decimals are allowed.
+const DIMENSION_RE =
+  /^\s*([0-9]+(?:[.,][0-9]+)?)\s*(?:x|×|X|\*|by)\s*([0-9]+(?:[.,][0-9]+)?)\s*(cm|mm|in|inch|inches|"|”)?\s*$/i;
+
+function toNumber(raw: string): number {
+  return parseFloat(raw.replace(",", "."));
+}
+
+function normalizeUnit(raw: string | undefined): DimensionUnit {
+  if (!raw) return "cm";
+  const u = raw.toLowerCase();
+  if (u === "mm") return "mm";
+  if (u === "in" || u === "inch" || u === "inches" || u === '"' || u === "”") return "in";
+  return "cm";
+}
+
+/**
+ * Parse a free-text dimensions string into structured cm width/height.
+ * Returns null when the string can't be confidently parsed (so the artist is
+ * prompted to enter dimensions manually rather than us guessing wrong).
+ *
+ * Convention: the first number is width, the second is height (W x H), matching
+ * how the gallery components already read "60 x 80".
+ */
+export function parseDimensions(input: string | null | undefined): ParsedDimensions | null {
+  if (!input) return null;
+  const m = DIMENSION_RE.exec(input);
+  if (!m) return null;
+
+  const rawW = toNumber(m[1]);
+  const rawH = toNumber(m[2]);
+  if (!Number.isFinite(rawW) || !Number.isFinite(rawH) || rawW <= 0 || rawH <= 0) {
+    return null;
+  }
+
+  const unit = normalizeUnit(m[3]);
+  const factor = UNIT_TO_CM[unit];
+  // Round to 2 decimals to fit numeric(7,2) and avoid float noise.
+  const round2 = (n: number) => Math.round(n * factor * 100) / 100;
+
+  return { widthCm: round2(rawW), heightCm: round2(rawH), unit };
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -46,6 +46,13 @@ export const artworks = pgTable("artworks", {
   price: decimal("price", { precision: 10, scale: 2 }).notNull(),
   medium: text("medium").notNull(),
   dimensions: text("dimensions"),
+  // Structured physical size for AR "View in my room" (#634). Nullable —
+  // backfilled from the free-text `dimensions` string where parseable, set
+  // explicitly via the artist dashboard otherwise. Decimal (string-typed,
+  // like `price`) to preserve fractional cm/inch values.
+  widthCm: decimal("width_cm", { precision: 7, scale: 2 }),
+  heightCm: decimal("height_cm", { precision: 7, scale: 2 }),
+  dimensionUnit: text("dimension_unit").default("cm"),
   year: integer("year"),
   isPublished: boolean("is_published").default(false),
   isForSale: boolean("is_for_sale").default(true),


### PR DESCRIPTION
Part of #634 — **Phase 0: structured artwork dimensions** (prerequisite for AR scale).

The legacy `artworks.dimensions` column is free-form text ("60 x 80", "30x40", "30 x 21 "), which can't drive believable AR scale. This PR adds structured physical size.

## Changes
- **Schema**: nullable `width_cm` / `height_cm` (numeric 7,2) + `dimension_unit` (default `cm`) on `artworks`. Nullable so existing rows stay valid and preview's push-mode migration can't break on NOT-NULL-on-existing-rows (#543).
- **Migration 0013**: adds columns (`IF NOT EXISTS`, idempotent) + backfills width/height from the free-text `dimensions` string where parseable, converting in/mm → cm. Backfilled **42/42** parseable rows on local.
- **`shared/dimensions.ts`**: `parseDimensions()` util mirroring the SQL backfill (client+server reuse). Handles spaces/no-spaces, trailing whitespace, ×/by, decimals, comma-decimals, in/mm. **9 unit tests**; parses **42/42** real production dimension strings.
- **Artist dashboard**: Width/Height/unit inputs beside the existing free-text label, wired through create + edit.
- **DATA-MODEL.md** updated per CLAUDE.md.

## Verification
- `tsc` clean · **119/119** tests pass · production build clean.

Targets `v4` (the AR release line), not `main`.
