### PR TITLE
feat(ar): Phase 1b — CV auto-detect of wall scale (refs #634)

### DIFF
--- a/client/src/components/ar/__tests__/ar-scale.test.ts
+++ b/client/src/components/ar/__tests__/ar-scale.test.ts
@@ -19,7 +19,8 @@ describe("clampZoom", () => {
   });
   it("falls back to 1 on non-finite", () => {
     expect(clampZoom(NaN)).toBe(1);
-    expect(clampZoom(Infinity)).toBe(MAX_ZOOM);
+    expect(clampZoom(Infinity)).toBe(1);
+    expect(clampZoom(-Infinity)).toBe(1);
   });
 });
 

--- a/client/src/components/ar/__tests__/wall-estimator.test.ts
+++ b/client/src/components/ar/__tests__/wall-estimator.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  estimateWallWidthCm,
+  REFERENCE_WIDTHS_CM,
+  MIN_WALL_CM,
+  MAX_WALL_CM,
+  type Detection,
+} from "../wall-estimator";
+
+function det(cls: string, score: number, bboxWidth: number): Detection {
+  return { class: cls, score, bbox: [0, 0, bboxWidth, bboxWidth] };
+}
+
+describe("estimateWallWidthCm", () => {
+  it("returns null when no usable detections", () => {
+    expect(estimateWallWidthCm([], 1000)).toBeNull();
+    // unknown class is ignored
+    expect(estimateWallWidthCm([det("banana", 0.9, 100)], 1000)).toBeNull();
+  });
+
+  it("returns null when photo width is non-positive", () => {
+    expect(estimateWallWidthCm([det("couch", 0.9, 200)], 0)).toBeNull();
+  });
+
+  it("ignores detections below the score threshold", () => {
+    expect(estimateWallWidthCm([det("couch", 0.2, 200)], 1000)).toBeNull();
+  });
+
+  it("ignores zero-width bounding boxes", () => {
+    expect(estimateWallWidthCm([det("couch", 0.9, 0)], 1000)).toBeNull();
+  });
+
+  it("computes wall width from a single reference via the ratio", () => {
+    // couch ~200cm wide fills half of a 1000px-wide photo → wall ≈ 400cm.
+    const r = estimateWallWidthCm([det("couch", 0.95, 500)], 1000);
+    expect(r).not.toBeNull();
+    expect(r!.wallWidthCm).toBe(400);
+    expect(r!.reference).toBe("couch");
+    expect(r!.confidence).toBeGreaterThan(0);
+  });
+
+  it("clamps implausible estimates into the slider range", () => {
+    // A couch occupying only 5px of a 1000px photo implies a 40m wall → clamp.
+    const tiny = estimateWallWidthCm([det("couch", 0.95, 5)], 1000);
+    expect(tiny!.wallWidthCm).toBe(MAX_WALL_CM);
+    // A couch wider than the whole photo implies a sub-1m wall → clamp.
+    const huge = estimateWallWidthCm([det("couch", 0.95, 4000)], 1000);
+    expect(huge!.wallWidthCm).toBe(MIN_WALL_CM);
+  });
+
+  it("uses a weighted median so one outlier can't dominate", () => {
+    // Two couches agree on ~400cm; one mis-sized chair disagrees wildly.
+    const r = estimateWallWidthCm(
+      [det("couch", 0.95, 500), det("couch", 0.9, 500), det("chair", 0.9, 5)],
+      1000,
+    );
+    expect(r!.wallWidthCm).toBe(400);
+  });
+
+  it("labels the estimate with the highest-weighted class", () => {
+    const r = estimateWallWidthCm(
+      [det("potted plant", 0.9, 100), det("couch", 0.9, 500)],
+      1000,
+    );
+    expect(r!.reference).toBe("couch");
+  });
+
+  it("keeps every reference width positive and weighted in (0,1]", () => {
+    for (const { widthCm, weight } of Object.values(REFERENCE_WIDTHS_CM)) {
+      expect(widthCm).toBeGreaterThan(0);
+      expect(weight).toBeGreaterThan(0);
+      expect(weight).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/client/src/components/ar/detect-objects.ts
+++ b/client/src/components/ar/detect-objects.ts
@@ -1,0 +1,44 @@
+// TensorFlow.js object detection for AR wall-scale auto-detect (#634, Phase 1b).
+// Isolated in its own module so the heavy model code (tfjs + coco-ssd, several
+// MB) is only pulled in via dynamic import() when the buyer actually opens the
+// AR view — never on initial page load. The pure scale math lives in
+// ./wall-estimator.ts and is what gets unit-tested; this file is the thin,
+// browser-only adapter around the model.
+
+import type { Detection } from "./wall-estimator";
+
+// coco-ssd's ObjectDetection type, kept loose to avoid eagerly importing types.
+type CocoModel = { detect: (img: HTMLImageElement | HTMLCanvasElement) => Promise<Detection[]> };
+
+let modelPromise: Promise<CocoModel> | null = null;
+
+/**
+ * Load (and memoise) the coco-ssd model. The lite_mobilenet_v2 base keeps the
+ * download small and inference fast enough for a one-shot detection on a phone.
+ */
+async function loadModel(): Promise<CocoModel> {
+  if (!modelPromise) {
+    modelPromise = (async () => {
+      // Dynamic imports so the bundler splits these into a lazy chunk.
+      await import("@tensorflow/tfjs");
+      const cocoSsd = await import("@tensorflow-models/coco-ssd");
+      return (await cocoSsd.load({ base: "lite_mobilenet_v2" })) as unknown as CocoModel;
+    })();
+  }
+  return modelPromise;
+}
+
+/**
+ * Run object detection on an already-loaded image element. Returns the raw
+ * coco-ssd detections (class/score/bbox) for ./wall-estimator to interpret.
+ * Never throws to the caller — detection is best-effort; on any failure it
+ * resolves to an empty array so the UI just falls back to the manual slider.
+ */
+export async function detectObjects(img: HTMLImageElement): Promise<Detection[]> {
+  try {
+    const model = await loadModel();
+    return await model.detect(img);
+  } catch {
+    return [];
+  }
+}

--- a/client/src/components/ar/view-in-room-dialog.tsx
+++ b/client/src/components/ar/view-in-room-dialog.tsx
@@ -36,25 +36,59 @@ export function ViewInRoomDialog({ artworkImage, title, widthCm, heightCm }: Vie
   const [open, setOpen] = useState(false);
   const [roomImage, setRoomImage] = useState<string | null>(null);
   const [wallWidthCm, setWallWidthCm] = useState(DEFAULT_WALL_WIDTH_CM);
+  // Phase 1b: scale auto-detected from a reference object in the room photo.
+  const [detecting, setDetecting] = useState(false);
+  const [autoRef, setAutoRef] = useState<string | null>(null);
   const { transform, handlers, reset, setZoom } = usePanZoom();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const surfaceRef = useRef<HTMLDivElement>(null);
 
+  // Best-effort: detect a known-size object in the photo and back out the wall
+  // width from it, replacing the slider default. Fully non-blocking — if the
+  // model fails to load or finds nothing recognisable, the manual slider stays.
+  const autoDetectScale = useCallback(async (objectUrl: string) => {
+    setDetecting(true);
+    setAutoRef(null);
+    try {
+      const [{ detectObjects }, { estimateWallWidthCm }] = await Promise.all([
+        import("./detect-objects"),
+        import("./wall-estimator"),
+      ]);
+      const img = new Image();
+      img.src = objectUrl;
+      await img.decode();
+      const detections = await detectObjects(img);
+      const estimate = estimateWallWidthCm(detections, img.naturalWidth);
+      if (estimate) {
+        setWallWidthCm(estimate.wallWidthCm);
+        setAutoRef(estimate.reference);
+      }
+    } catch {
+      /* detection is optional — fall back to the manual slider */
+    } finally {
+      setDetecting(false);
+    }
+  }, []);
+
   const onPickFile = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    const url = URL.createObjectURL(file);
     setRoomImage((prev) => {
       if (prev) URL.revokeObjectURL(prev);
-      return URL.createObjectURL(file);
+      return url;
     });
     reset();
-  }, [reset]);
+    void autoDetectScale(url);
+  }, [reset, autoDetectScale]);
 
   const clearRoom = useCallback(() => {
     setRoomImage((prev) => {
       if (prev) URL.revokeObjectURL(prev);
       return null;
     });
+    setAutoRef(null);
+    setDetecting(false);
     reset();
   }, [reset]);
 
@@ -145,7 +179,10 @@ export function ViewInRoomDialog({ artworkImage, title, widthCm, heightCm }: Vie
                   max={600}
                   step={10}
                   value={[wallWidthCm]}
-                  onValueChange={(v) => setWallWidthCm(v[0])}
+                  onValueChange={(v) => {
+                    setWallWidthCm(v[0]);
+                    setAutoRef(null); // manual override — drop the auto-detected hint
+                  }}
                   data-testid="slider-wall-width"
                 />
                 <span className="w-12 text-right text-xs tabular-nums text-muted-foreground">{wallWidthCm}cm</span>
@@ -158,7 +195,18 @@ export function ViewInRoomDialog({ artworkImage, title, widthCm, heightCm }: Vie
                 Change photo
               </Button>
             </div>
-            {(!widthCm || !heightCm) && (
+            {detecting && (
+              <p className="flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="ar-detecting">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Measuring your wall from the photo…
+              </p>
+            )}
+            {!detecting && autoRef && (
+              <p className="text-xs text-muted-foreground" data-testid="ar-auto-scale">
+                Scale auto-detected from the {autoRef} in your photo. Adjust the slider if it looks off.
+              </p>
+            )}
+            {!detecting && !autoRef && (!widthCm || !heightCm) && (
               <p className="text-xs text-muted-foreground">
                 This artwork has no exact size set, so scale is approximate. Use the wall-width slider to calibrate.
               </p>

--- a/client/src/components/ar/wall-estimator.ts
+++ b/client/src/components/ar/wall-estimator.ts
@@ -1,0 +1,102 @@
+// Pure wall-scale estimation for the AR "View in my room" composite (#634,
+// Phase 1b). Given objects detected in the room photo (coco-ssd output) plus a
+// table of their typical real-world widths, work out how wide the photographed
+// wall is in centimetres — replacing the manual wall-width slider with an
+// automatic guess. Kept browser-free so it can be unit-tested in isolation; the
+// actual TensorFlow.js detection lives in ./detect-objects.ts.
+
+/** A single object detection in coco-ssd's shape. bbox = [x, y, width, height] in px. */
+export interface Detection {
+  class: string;
+  score: number;
+  bbox: [number, number, number, number];
+}
+
+export interface WallEstimate {
+  /** Estimated real width of the wall shown in the photo, in centimetres. */
+  wallWidthCm: number;
+  /** Human-readable label of what drove the estimate (e.g. "couch"). */
+  reference: string;
+  /** 0..1 rough confidence, for deciding whether to trust/show the estimate. */
+  confidence: number;
+}
+
+/**
+ * Typical real-world WIDTH (cm) of common coco-ssd classes, paired with a
+ * reliability weight (0..1) reflecting how consistent that width is across the
+ * real world. A couch is almost always ~2m wide (high weight); a TV or potted
+ * plant varies wildly (low weight). Only classes plausibly seen in a room/wall
+ * photo are listed — detections of anything else are ignored.
+ */
+export const REFERENCE_WIDTHS_CM: Record<string, { widthCm: number; weight: number }> = {
+  couch: { widthCm: 200, weight: 0.9 },
+  bed: { widthCm: 160, weight: 0.75 },
+  "dining table": { widthCm: 150, weight: 0.7 },
+  chair: { widthCm: 50, weight: 0.6 },
+  refrigerator: { widthCm: 70, weight: 0.6 },
+  person: { widthCm: 45, weight: 0.45 },
+  "potted plant": { widthCm: 35, weight: 0.4 },
+  tv: { widthCm: 110, weight: 0.4 },
+};
+
+/** Plausible wall widths — clamps wild estimates to the same range as the manual slider. */
+export const MIN_WALL_CM = 100;
+export const MAX_WALL_CM = 600;
+
+/** Minimum detection score we trust as a scale reference. */
+export const MIN_REFERENCE_SCORE = 0.4;
+
+/** Weighted median: robust against a single mis-sized outlier detection. */
+function weightedMedian(samples: { value: number; weight: number }[]): number {
+  const sorted = [...samples].sort((a, b) => a.value - b.value);
+  const total = sorted.reduce((s, x) => s + x.weight, 0);
+  let acc = 0;
+  for (const s of sorted) {
+    acc += s.weight;
+    if (acc >= total / 2) return s.value;
+  }
+  return sorted[sorted.length - 1].value;
+}
+
+/**
+ * Estimate how wide the photographed wall is, in cm, from detected objects.
+ *
+ * For each usable detection: impliedWall = photoWidthPx × (realWidthCm /
+ * bboxWidthPx). Because it's a ratio, the absolute photo resolution cancels
+ * out. We combine implied widths with a weighted median (weight = detection
+ * score × class reliability) so one oddly-cropped object can't dominate.
+ *
+ * Returns null when nothing usable was detected — the caller should then fall
+ * back to the manual slider default.
+ */
+export function estimateWallWidthCm(
+  detections: Detection[],
+  photoWidthPx: number,
+): WallEstimate | null {
+  if (photoWidthPx <= 0) return null;
+
+  const samples: { value: number; weight: number; class: string }[] = [];
+  for (const d of detections) {
+    const ref = REFERENCE_WIDTHS_CM[d.class];
+    if (!ref) continue;
+    if (d.score < MIN_REFERENCE_SCORE) continue;
+    const bboxWidthPx = d.bbox[2];
+    if (bboxWidthPx <= 0) continue;
+
+    const impliedWall = photoWidthPx * (ref.widthCm / bboxWidthPx);
+    samples.push({ value: impliedWall, weight: d.score * ref.weight, class: d.class });
+  }
+
+  if (samples.length === 0) return null;
+
+  const median = weightedMedian(samples);
+  const wallWidthCm = Math.round(Math.min(MAX_WALL_CM, Math.max(MIN_WALL_CM, median)));
+
+  // Reference label: the highest-weighted contributing class.
+  const best = samples.reduce((a, b) => (b.weight > a.weight ? b : a));
+  // Confidence: scale total evidence toward 1, capped. More/heavier detections → higher.
+  const totalWeight = samples.reduce((s, x) => s + x.weight, 0);
+  const confidence = Math.min(1, totalWeight / 1.2);
+
+  return { wallWidthCm, reference: best.class, confidence };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.100.14",
+        "@tensorflow-models/coco-ssd": "^2.2.3",
+        "@tensorflow/tfjs": "^4.22.0",
         "@types/bcryptjs": "^3.0.0",
         "@types/memoizee": "^0.4.12",
         "@types/three": "^0.184.1",
@@ -4418,6 +4420,167 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tensorflow-models/coco-ssd": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@tensorflow-models/coco-ssd/-/coco-ssd-2.2.3.tgz",
+      "integrity": "sha512-iCLGktG/XhHbP6h2FWxqCKMp/Px0lCp6MZU1fjNhjDHeaWEC9G7S7cZrnPXsfH+NewCM53YShlrHnknxU3SQig==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@tensorflow/tfjs-converter": "^4.10.0",
+        "@tensorflow/tfjs-core": "^4.10.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-4.22.0.tgz",
+      "integrity": "sha512-0TrIrXs6/b7FLhLVNmfh8Sah6JgjBPH4mZ8JGb7NU6WW+cx00qK5BcAZxw7NCzxj6N8MRAIfHq+oNbPUNG5VAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tensorflow/tfjs-backend-cpu": "4.22.0",
+        "@tensorflow/tfjs-backend-webgl": "4.22.0",
+        "@tensorflow/tfjs-converter": "4.22.0",
+        "@tensorflow/tfjs-core": "4.22.0",
+        "@tensorflow/tfjs-data": "4.22.0",
+        "@tensorflow/tfjs-layers": "4.22.0",
+        "argparse": "^1.0.10",
+        "chalk": "^4.1.0",
+        "core-js": "3.29.1",
+        "regenerator-runtime": "^0.13.5",
+        "yargs": "^16.0.3"
+      },
+      "bin": {
+        "tfjs-custom-module": "dist/tools/custom_module/cli.js"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-backend-cpu": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-4.22.0.tgz",
+      "integrity": "sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/seedrandom": "^2.4.28",
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "yarn": ">= 1.3.2"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "4.22.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-backend-webgl": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-4.22.0.tgz",
+      "integrity": "sha512-H535XtZWnWgNwSzv538czjVlbJebDl5QTMOth4RXr2p/kJ1qSIXE0vZvEtO+5EC9b00SvhplECny2yDewQb/Yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tensorflow/tfjs-backend-cpu": "4.22.0",
+        "@types/offscreencanvas": "~2019.3.0",
+        "@types/seedrandom": "^2.4.28",
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "yarn": ">= 1.3.2"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "4.22.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-converter": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.22.0.tgz",
+      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "4.22.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-core": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-4.22.0.tgz",
+      "integrity": "sha512-LEkOyzbknKFoWUwfkr59vSB68DMJ4cjwwHgicXN0DUi3a0Vh1Er3JQqCI1Hl86GGZQvY8ezVrtDIvqR1ZFW55A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "@types/offscreencanvas": "~2019.7.0",
+        "@types/seedrandom": "^2.4.28",
+        "@webgpu/types": "0.1.38",
+        "long": "4.0.0",
+        "node-fetch": "~2.6.1",
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "yarn": ">= 1.3.2"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-core/node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@tensorflow/tfjs-data": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-4.22.0.tgz",
+      "integrity": "sha512-dYmF3LihQIGvtgJrt382hSRH4S0QuAp2w1hXJI2+kOaEqo5HnUPG0k5KA6va+S1yUhx7UBToUKCBHeLHFQRV4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node-fetch": "^2.1.2",
+        "node-fetch": "~2.6.1",
+        "string_decoder": "^1.3.0"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "4.22.0",
+        "seedrandom": "^3.0.5"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-layers": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.22.0.tgz",
+      "integrity": "sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA==",
+      "license": "Apache-2.0 AND MIT",
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "4.22.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tensorflow/tfjs/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -4655,6 +4818,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4697,11 +4866,26 @@
       "version": "24.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.3.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.3.0.tgz",
+      "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==",
+      "license": "MIT"
     },
     "node_modules/@types/passport": {
       "version": "1.0.17",
@@ -4792,6 +4976,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/seedrandom": {
+      "version": "2.4.34",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.34.tgz",
+      "integrity": "sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A==",
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -5261,6 +5451,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.38.tgz",
+      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5334,7 +5530,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5344,7 +5539,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5361,6 +5555,15 @@
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
@@ -5395,7 +5598,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -5562,6 +5764,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -5658,7 +5876,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5671,7 +5888,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -5685,7 +5901,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5794,6 +6009,17 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
+      "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -6057,7 +6283,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6791,7 +7016,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -6868,7 +7092,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6987,7 +7210,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7568,7 +7790,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7585,7 +7806,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7595,7 +7815,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7762,6 +7981,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -7778,7 +8006,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8084,7 +8311,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8524,6 +8750,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -9459,6 +9691,26 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "license": "ISC"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
@@ -10450,6 +10702,12 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
     "node_modules/regexparam": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
@@ -10496,7 +10754,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10774,6 +11031,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -11026,6 +11289,12 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -11080,7 +11349,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -11109,7 +11377,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11170,6 +11437,18 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svix": {
@@ -11301,6 +11580,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -11461,7 +11746,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -12144,6 +12428,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -12204,7 +12504,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -12258,7 +12557,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.100.14",
+    "@tensorflow-models/coco-ssd": "^2.2.3",
+    "@tensorflow/tfjs": "^4.22.0",
     "@types/bcryptjs": "^3.0.0",
     "@types/memoizee": "^0.4.12",
     "@types/three": "^0.184.1",

--- a/specs/features/ar-view-in-room/SPEC.md
+++ b/specs/features/ar-view-in-room/SPEC.md
@@ -33,7 +33,10 @@ and pinch/scroll to zoom. Headline feature of the next major version (v4.0.0).
   textured plane over the room photo, drag to position, pinch/scroll/buttons to
   zoom, save the composite as PNG. Scale derives from the artwork's real cm size
   vs. an estimated wall width (manual slider for now).
-- **Phase 1b — NEXT**: CV auto-detect of wall scale to remove the manual slider.
+- **Phase 1b — THIS PR**: CV auto-detect of wall scale. When the buyer picks a
+  room photo, a TensorFlow.js (coco-ssd) model detects common objects; their
+  known typical real-world widths back out an estimated wall width, which seeds
+  the slider automatically. The slider remains as a manual override.
 - **Phase 2**: native AR via `<model-viewer ar>` (auto-generated USDZ + glTF).
 
 ## Architecture (Phase 1a)
@@ -58,6 +61,32 @@ client/src/components/ar/
   only downloads when a buyer opens the AR view — the main bundle is unaffected.
 - **Save**: the r3f canvas uses `preserveDrawingBuffer` so `toDataURL` can export
   the composite as a PNG download.
+
+## Architecture (Phase 1b — CV auto-detect)
+
+```
+client/src/components/ar/
+  wall-estimator.ts      Pure: detections + known object widths → wall width (cm). Unit-tested.
+  detect-objects.ts      Browser-only adapter: lazy-loads tfjs + coco-ssd, runs detection.
+```
+
+- **Estimation model**: for each recognised object, `impliedWallCm =
+  photoWidthPx × (typicalObjectWidthCm / objectBboxWidthPx)`. Because it's a
+  ratio, photo resolution cancels out. Multiple detections are combined with a
+  **weighted median** (weight = detection score × per-class reliability) so one
+  oddly-cropped object can't skew the estimate. Result is clamped to the slider's
+  `100–600 cm` range.
+- **Reference table** (`REFERENCE_WIDTHS_CM`): only classes plausibly seen in a
+  room photo, each with a reliability weight — a couch (~2 m, consistent) is
+  trusted far more than a TV or potted plant (highly variable).
+- **Bundle**: `detect-objects.ts` (tfjs + coco-ssd, several MB) is `import()`-ed
+  dynamically only when a photo is picked, so it splits into its own lazy chunk
+  and never touches the main bundle or even the dialog chunk.
+- **Best-effort**: detection never blocks or throws to the UI — on model-load
+  failure or no recognisable object, it silently falls back to the manual slider.
+- **UX**: a "Measuring your wall…" spinner during detection; on success, a "Scale
+  auto-detected from the &lt;object&gt;" hint. Touching the slider clears the hint
+  (manual override wins).
 
 ## Out of scope (v1)
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,10 +5,14 @@ export default defineConfig({
   resolve: {
     alias: {
       "@shared": path.resolve(__dirname, "shared"),
+      "@": path.resolve(__dirname, "client/src"),
     },
   },
   test: {
     globals: true,
-    include: ["server/__tests__/**/*.test.ts"],
+    include: [
+      "server/__tests__/**/*.test.ts",
+      "client/src/**/__tests__/**/*.test.ts",
+    ],
   },
 });


### PR DESCRIPTION
## Phase 1b — CV auto-detect of wall scale

Part of the AR "View in My Room" feature ([#634](https://github.com/ilv78/Art-World-Hub/issues/634)), v4 line. Builds on Phase 1a (#638). Replaces the **manual-only** wall-width slider with an automatic estimate derived from a reference object detected in the room photo.

### How it works
- **`wall-estimator.ts`** (pure, unit-tested): for each recognised object, `impliedWallCm = photoWidthPx × (typicalWidthCm / bboxWidthPx)`. Because it's a ratio, photo resolution cancels out. Detections are combined with a **weighted median** (weight = detection score × per-class reliability) so one oddly-cropped object can't skew the result, then clamped to the slider's 100–600 cm range. `REFERENCE_WIDTHS_CM` lists only room-plausible coco-ssd classes, each weighted by how consistent its real-world width is (couch ≫ TV/potted plant).
- **`detect-objects.ts`** (browser-only adapter): lazy-loads `@tensorflow/tfjs` + `@tensorflow-models/coco-ssd` (`lite_mobilenet_v2`) and runs detection. **Dynamically `import()`-ed only when a photo is picked**, so the multi-MB model splits into its own chunk — the dialog chunk stays ~15.6 KB and the main bundle is untouched.
- **`view-in-room-dialog.tsx`**: on photo pick → detect → seed wall width. Shows a "Measuring your wall…" spinner, then a "Scale auto-detected from the &lt;object&gt;" hint. Touching the slider clears the hint (manual override wins). Detection is **best-effort** — on model-load failure or no recognisable object it silently falls back to the manual slider; it never blocks or throws.

### Also in this PR
- `vitest.config.ts` now includes `client/src/**/__tests__` (the Phase 1a `ar-scale` tests were **never actually running**) and adds the `@` alias. Fixed a stale `ar-scale` assertion that surfaced once those tests started executing.

### Testing
- New `wall-estimator.test.ts` — 9 cases (ratio math, score/zero-bbox filtering, outlier-resistant weighted median, clamping, labelling, reference-table sanity).
- Full suite: **218 passing**. Typecheck clean. Production build verified — TF.js confirmed in a lazy chunk, dialog chunk ~15.6 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)