### PR TITLE
fix(ui): stack curator-gallery header on mobile (closes #646)

### DIFF
--- a/client/src/pages/curator-gallery.tsx
+++ b/client/src/pages/curator-gallery.tsx
@@ -87,7 +87,7 @@ export default function CuratorGalleryPage() {
         </Button>
       )}
       {!isImmersive && (
-        <div className="p-4 border-b bg-background flex flex-wrap items-start justify-between gap-4">
+        <div className="p-4 border-b bg-background flex flex-col sm:flex-row sm:flex-wrap sm:items-start sm:justify-between gap-4">
           <div className="min-w-0 flex-1">
             <h1 className="font-serif text-2xl font-bold">{gallery.name}</h1>
             <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
Closes #646.

## Problem
On mobile, entering a curator exhibition rendered the gallery name + description in a narrow left column with empty space beside it, wrapping into a tall stack and pushing artwork thumbnails below the fold.

## Fix
The non-immersive header placed the title/description (`flex-1`) and the share/view-toggle block (`shrink-0`) on the same row. On narrow viewports the fixed-width buttons squeezed the description. Now the header stacks vertically on mobile and restores the side-by-side row at `sm` and up:

```diff
- flex flex-wrap items-start justify-between gap-4
+ flex flex-col sm:flex-row sm:flex-wrap sm:items-start sm:justify-between gap-4
```

- **Mobile (<640px):** description spans full width, compacts in height, thumbnails rise into view.
- **sm+:** unchanged.

Single-line responsive-CSS change, no logic touched. `npm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)