### PR TITLE
fix(ui): pin gallery 2D nav arrows to fixed position (closes #654)

### DIFF
--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -242,7 +242,7 @@ export default function Gallery() {
             <Button
               variant="secondary"
               size="icon"
-              className="shrink-0 z-20 h-12 w-12 rounded-full shadow-lg"
+              className="absolute left-4 top-1/2 -translate-y-1/2 z-20 h-12 w-12 rounded-full shadow-lg"
               onClick={handlePrevious}
               data-testid="button-prev-artwork"
             >
@@ -279,7 +279,7 @@ export default function Gallery() {
             <Button
               variant="secondary"
               size="icon"
-              className="shrink-0 z-20 h-12 w-12 rounded-full shadow-lg"
+              className="absolute right-4 top-1/2 -translate-y-1/2 z-20 h-12 w-12 rounded-full shadow-lg"
               onClick={handleNext}
               data-testid="button-next-artwork"
             >


### PR DESCRIPTION
Closes #654.

## Problem
In the museum gallery's 2D ("classic") view, navigating between artworks moved the left/right nav arrows — jarring on every click.

## Cause
The prev arrow, image, and next arrow shared one center-justified flex row. The image is `object-contain` with max-width caps, so its rendered width changes with each artwork's aspect ratio (portrait narrow, landscape wide), pushing the flanking arrows in/out.

## Fix
Absolutely position both arrows at fixed left/right edges, vertically centered in the existing `relative` viewing area (standard lightbox pattern):

```diff
- className="shrink-0 z-20 h-12 w-12 rounded-full shadow-lg"   // prev
+ className="absolute left-4 top-1/2 -translate-y-1/2 z-20 h-12 w-12 rounded-full shadow-lg"
- className="shrink-0 z-20 h-12 w-12 rounded-full shadow-lg"   // next
+ className="absolute right-4 top-1/2 -translate-y-1/2 z-20 h-12 w-12 rounded-full shadow-lg"
```

The image stays centered via the flex `justify-center`; arrows no longer move when the artwork changes. CSS-only, classic-view block only. `npm run check` passes.

**Trade-off:** on narrow phones the fixed arrows overlay the image edges slightly — the conventional lightbox look, avoids the image being squeezed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)