### PR TITLE
fix(ui): Enquire button for POR works on artist portfolio (closes #674)

### DIFF
--- a/client/src/pages/artist-profile.tsx
+++ b/client/src/pages/artist-profile.tsx
@@ -16,6 +16,7 @@ import {
   Calendar,
   ArrowLeft,
   ShoppingCart,
+  Mail,
   Box,
   Globe,
   ExternalLink,
@@ -381,9 +382,20 @@ export default function ArtistProfile() {
                         {artwork.dimensions && (
                           <p className="text-sm text-muted-foreground">{artwork.dimensions}{!/cm/i.test(artwork.dimensions) ? ' cm' : ''}</p>
                         )}
-                        {artwork.isForSale && (
-                          <Button 
-                            className="w-full mt-4" 
+                        {artwork.isForSale && artwork.priceOnRequest && (
+                          <Button
+                            className="w-full mt-4"
+                            size="sm"
+                            onClick={(e) => { e.stopPropagation(); setSelectedArtwork(artwork); }}
+                            data-testid={`button-enquire-${artwork.id}`}
+                          >
+                            <Mail className="h-4 w-4 mr-2" />
+                            Enquire
+                          </Button>
+                        )}
+                        {artwork.isForSale && !artwork.priceOnRequest && (
+                          <Button
+                            className="w-full mt-4"
                             size="sm"
                             onClick={(e) => { e.stopPropagation(); addItem(artwork); }}
                             data-testid={`button-add-to-cart-${artwork.id}`}


### PR DESCRIPTION
Closes #674. Follow-up to #668.

## Bug
On an artist's portfolio page, price-on-request (POR) artworks showed **Add to Cart** instead of **Enquire** — unlike the gallery/store.

## Cause
`artist-profile.tsx` renders its artwork grid with a bespoke inline block (not the shared `ArtworkCard`); its button only checked `isForSale`. POR works are `isForSale: true`, so they hit the Add-to-Cart branch. This render path was missed in #668.

## Fix
Add the `priceOnRequest` branch to the grid button: POR → **Enquire** (opens the detail dialog that hosts the enquiry modal, matching the gallery card behavior); non-POR → **Add to Cart** (unchanged). Single-file, client-only change.

Verified locally on the New Artist portfolio (POR works show Enquire; priced works still Add to Cart). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)