### PR TITLE
chore: allow test/typecheck commands for headless agent runs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,15 @@
       "Bash(git branch -D:*)",
       "Bash(rclone delete:*)",
       "Bash(rclone purge:*)",
+      "Bash(npm run check)",
+      "Bash(npm run check:*)",
+      "Bash(npm test)",
+      "Bash(npm test:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest:*)",
+      "Bash(node --version)",
+      "Bash(tail:*)",
+      "Bash(head:*)",
       "Bash(rclone deletefile:*)"
     ]
   },


### PR DESCRIPTION
Adds allow entries to .claude/settings.json so fresh-clone headless agent runs can execute npm run check / npm test / npx tsc / npx vitest non-interactively. Fixes the max-turns exhaustion seen on agent runs for #691.