### PR TITLE
fix: agent allowlist was appended to deny array

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
+    "allow": [
+      "Bash(npm run check)",
+      "Bash(npm run check:*)",
+      "Bash(npm test)",
+      "Bash(npm test:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest:*)",
+      "Bash(node --version)",
+      "Bash(tail:*)",
+      "Bash(head:*)",
+      "Bash(grep:*)",
+      "Bash(git diff:*)"
+    ],
     "deny": [
       "Read(./.env)",
       "Bash(rm -rf:*)",
@@ -19,15 +32,6 @@
       "Bash(git branch -D:*)",
       "Bash(rclone delete:*)",
       "Bash(rclone purge:*)",
-      "Bash(npm run check)",
-      "Bash(npm run check:*)",
-      "Bash(npm test)",
-      "Bash(npm test:*)",
-      "Bash(npx tsc:*)",
-      "Bash(npx vitest:*)",
-      "Bash(node --version)",
-      "Bash(tail:*)",
-      "Bash(head:*)",
       "Bash(rclone deletefile:*)"
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,15 @@
       "Bash(git branch -D:*)",
       "Bash(rclone delete:*)",
       "Bash(rclone purge:*)",
+      "Bash(npm run check)",
+      "Bash(npm run check:*)",
+      "Bash(npm test)",
+      "Bash(npm test:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest:*)",
+      "Bash(node --version)",
+      "Bash(tail:*)",
+      "Bash(head:*)",
       "Bash(rclone deletefile:*)"
     ]
   },


### PR DESCRIPTION
The nine agent entries landed in permissions.deny, hard-blocking the exact commands headless runs need. Moved to a new allow array; grep and git diff added. Deny floor unchanged.