### PR TITLE
fix: remove duplicate agent commands from deny array (completes #697)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,15 +32,6 @@
       "Bash(git branch -D:*)",
       "Bash(rclone delete:*)",
       "Bash(rclone purge:*)",
-      "Bash(npm run check)",
-      "Bash(npm run check:*)",
-      "Bash(npm test)",
-      "Bash(npm test:*)",
-      "Bash(npx tsc:*)",
-      "Bash(npx vitest:*)",
-      "Bash(node --version)",
-      "Bash(tail:*)",
-      "Bash(head:*)",
       "Bash(rclone deletefile:*)"
     ]
   },


### PR DESCRIPTION
## Summary
Completes the fix from #697. That PR added nine agent test/typecheck commands to `permissions.allow` in `.claude/settings.json` but left the duplicates in `permissions.deny`. Because **deny beats allow**, the commands (`npm test`, `npm run check`, `npx tsc`, `npx vitest`, `node --version`, `tail`, `head`) were still blocked for headless/agent runs.

This removes those 9 duplicate entries from the deny array. The deny floor (`rm -rf`, `git branch -D`, `rclone delete/purge/deletefile`, etc.) is unchanged.

## Verification
- `.claude/settings.json` remains valid JSON.
- The nine commands now appear only in `allow`, no longer in `deny`.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)